### PR TITLE
Add on-demand CI workflow to build & release Windows/Linux binaries

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,200 @@
+name: Build & Release
+
+# Manual, on-demand build of Windows + Linux binaries, published to GitHub Releases.
+#
+# The recompilation step (BUILDING.md step 3) needs the actual game ROM to translate
+# into C, and the port also reads the ROM at runtime for assets. The ROM is
+# copyrighted and is never committed to this repo (see .gitignore) — it is supplied
+# to this workflow as a base64-encoded repository secret (LAMBORGHINI_ROM_B64) and
+# decoded onto the runner just long enough to build. It is never uploaded as part of
+# any artifact or release asset: downstream users must supply their own legally
+# dumped copy of "Automobili Lamborghini (USA).z64" to run the released binary.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to create (e.g. v0.3.0)"
+        required: true
+      prerelease:
+        description: "Mark the release as a pre-release"
+        type: boolean
+        default: true
+      draft:
+        description: "Create the release as a draft (review before publishing)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+env:
+  ROM_FILENAME: "Automobili Lamborghini (USA).z64"
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake ninja-build python3 pkg-config \
+            libsdl2-dev libvulkan-dev \
+            libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+            libdbus-1-dev
+
+      - name: Decode ROM
+        env:
+          ROM_B64: ${{ secrets.LAMBORGHINI_ROM_B64 }}
+        run: |
+          if [ -z "$ROM_B64" ]; then
+            echo "::error::LAMBORGHINI_ROM_B64 secret is not set — cannot recompile without a ROM."
+            exit 1
+          fi
+          echo "$ROM_B64" | base64 -d > "$ROM_FILENAME"
+
+      - name: Apply runtime patch
+        run: git -C lib/N64ModernRuntime apply "$(pwd)/patches/0001-lamborghini-runtime-scheduler-audio-vi.patch"
+
+      - name: Configure + build recompiler CLIs
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          cmake --build build --target N64RecompCLI RSPRecomp -j"$(nproc)"
+
+      - name: Recompile game code + audio microcode from ROM
+        run: |
+          ./build/lib/N64ModernRuntime/librecomp/N64Recomp/N64Recomp lamborghini.us.toml
+          ./build/lib/N64ModernRuntime/librecomp/N64Recomp/RSPRecomp aspMain.us.toml
+
+      - name: Build port
+        run: cmake --build build --target lamborghini_modern -j"$(nproc)"
+
+      - name: Remove ROM before packaging
+        if: always()
+        run: rm -f "$ROM_FILENAME"
+
+      - name: Package
+        run: |
+          mkdir -p dist
+          cp build/lamborghini_modern dist/
+          cd dist && zip -r ../lamborghini-recomp-linux-x64.zip .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lamborghini-recomp-linux-x64
+          path: lamborghini-recomp-linux-x64.zip
+          retention-days: 14
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Enable long paths
+        run: git config --global core.longpaths true
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install MinGW-w64 GCC, CMake, Ninja
+        shell: pwsh
+        run: |
+          choco install mingw -y --no-progress
+          choco install ninja -y --no-progress
+          python -m pip install --upgrade pip
+          python -m pip install cmake
+          # Put a MinGW-w64 GCC ahead of any MSYS2 toolchain that might also be on PATH.
+          echo "C:\ProgramData\mingw64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Verify toolchain
+        shell: pwsh
+        run: |
+          gcc --version
+          cmake --version
+          ninja --version
+
+      - name: Decode ROM
+        shell: pwsh
+        env:
+          ROM_B64: ${{ secrets.LAMBORGHINI_ROM_B64 }}
+        run: |
+          if (-not $env:ROM_B64) {
+            Write-Error "LAMBORGHINI_ROM_B64 secret is not set -- cannot recompile without a ROM."
+            exit 1
+          }
+          [IO.File]::WriteAllBytes("$env:ROM_FILENAME", [Convert]::FromBase64String($env:ROM_B64))
+
+      - name: Apply patches
+        shell: pwsh
+        run: |
+          $root = (Get-Location).Path
+          git -C lib/N64ModernRuntime apply "$root/patches/0001-lamborghini-runtime-scheduler-audio-vi.patch"
+          git -C lib/rt64 apply "$root/patches/0005-rt64-mingw-gcc-compat.patch"
+          git -C lib/rt64/src/contrib/plume apply "$root/patches/0004-plume-d3d12-mingw-com-abi-struct-return.patch"
+
+      - name: Configure + build recompiler CLIs
+        shell: pwsh
+        run: |
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_C_COMPILER=gcc.exe -DCMAKE_CXX_COMPILER=g++.exe
+          cmake --build build --target N64RecompCLI RSPRecomp -j
+
+      - name: Recompile game code + audio microcode from ROM
+        shell: pwsh
+        run: |
+          & ".\build\lib\N64ModernRuntime\librecomp\N64Recomp\N64Recomp.exe" lamborghini.us.toml
+          & ".\build\lib\N64ModernRuntime\librecomp\N64Recomp\RSPRecomp.exe" aspMain.us.toml
+
+      - name: Build port
+        shell: pwsh
+        run: cmake --build build --target lamborghini_modern -j
+
+      - name: Remove ROM before packaging
+        if: always()
+        shell: pwsh
+        run: Remove-Item -Force -ErrorAction SilentlyContinue "$env:ROM_FILENAME"
+
+      - name: Package
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force dist | Out-Null
+          Copy-Item build\lamborghini_modern.exe dist\
+          Copy-Item build\SDL2.dll, build\dxcompiler.dll, build\dxil.dll dist\ -ErrorAction SilentlyContinue
+          Compress-Archive -Path dist\* -DestinationPath lamborghini-recomp-windows-x64.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lamborghini-recomp-windows-x64
+          path: lamborghini-recomp-windows-x64.zip
+          retention-days: 14
+
+  release:
+    needs: [build-linux, build-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ inputs.tag }}" \
+            artifacts/lamborghini-recomp-linux-x64/lamborghini-recomp-linux-x64.zip \
+            artifacts/lamborghini-recomp-windows-x64/lamborghini-recomp-windows-x64.zip \
+            --repo "${{ github.repository }}" \
+            --title "${{ inputs.tag }}" \
+            $( [ "${{ inputs.prerelease }}" = "true" ] && echo --prerelease ) \
+            $( [ "${{ inputs.draft }}" = "true" ] && echo --draft ) \
+            --notes "Automated build from commit ${{ github.sha }}. **You must supply your own legally-dumped copy of \`Automobili Lamborghini (USA).z64\` next to the executable — this project ships no game data.** See BUILDING.md."

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,11 +4,13 @@ name: Build & Release
 #
 # The recompilation step (BUILDING.md step 3) needs the actual game ROM to translate
 # into C, and the port also reads the ROM at runtime for assets. The ROM is
-# copyrighted and is never committed to this repo (see .gitignore) — it is supplied
-# to this workflow as a base64-encoded repository secret (LAMBORGHINI_ROM_B64) and
-# decoded onto the runner just long enough to build. It is never uploaded as part of
-# any artifact or release asset: downstream users must supply their own legally
-# dumped copy of "Automobili Lamborghini (USA).z64" to run the released binary.
+# copyrighted and is never committed to this repo (see .gitignore) — GitHub Actions
+# secrets are capped at 48 KB, far too small for a multi-MB ROM, so it can't be stored
+# as a secret directly. Instead it lives in a separate *private* companion repo
+# (ROM_ASSETS_REPO) and is checked out during the build using a fine-grained PAT
+# (ROM_ASSETS_PAT) scoped to read-only access on that one repo. It is never uploaded
+# as part of any artifact or release asset: downstream users must supply their own
+# legally dumped copy of "Automobili Lamborghini (USA).z64" to run the released binary.
 
 on:
   workflow_dispatch:
@@ -49,15 +51,27 @@ jobs:
             libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
             libdbus-1-dev
 
-      - name: Decode ROM
+      - name: Check ROM asset config
         env:
-          ROM_B64: ${{ secrets.LAMBORGHINI_ROM_B64 }}
+          ROM_ASSETS_REPO: ${{ vars.ROM_ASSETS_REPO }}
+          ROM_ASSETS_PAT: ${{ secrets.ROM_ASSETS_PAT }}
         run: |
-          if [ -z "$ROM_B64" ]; then
-            echo "::error::LAMBORGHINI_ROM_B64 secret is not set — cannot recompile without a ROM."
+          if [ -z "$ROM_ASSETS_REPO" ] || [ -z "$ROM_ASSETS_PAT" ]; then
+            echo "::error::vars.ROM_ASSETS_REPO and/or secrets.ROM_ASSETS_PAT are not set — cannot recompile without a ROM."
             exit 1
           fi
-          echo "$ROM_B64" | base64 -d > "$ROM_FILENAME"
+
+      - name: Fetch ROM from private assets repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ vars.ROM_ASSETS_REPO }}
+          token: ${{ secrets.ROM_ASSETS_PAT }}
+          path: rom-assets
+
+      - name: Place ROM
+        run: |
+          cp "rom-assets/$ROM_FILENAME" "./$ROM_FILENAME"
+          rm -rf rom-assets
 
       - name: Apply runtime patch
         run: git -C lib/N64ModernRuntime apply "$(pwd)/patches/0001-lamborghini-runtime-scheduler-audio-vi.patch"
@@ -121,16 +135,29 @@ jobs:
           cmake --version
           ninja --version
 
-      - name: Decode ROM
+      - name: Check ROM asset config
         shell: pwsh
         env:
-          ROM_B64: ${{ secrets.LAMBORGHINI_ROM_B64 }}
+          ROM_ASSETS_REPO: ${{ vars.ROM_ASSETS_REPO }}
+          ROM_ASSETS_PAT: ${{ secrets.ROM_ASSETS_PAT }}
         run: |
-          if (-not $env:ROM_B64) {
-            Write-Error "LAMBORGHINI_ROM_B64 secret is not set -- cannot recompile without a ROM."
+          if (-not $env:ROM_ASSETS_REPO -or -not $env:ROM_ASSETS_PAT) {
+            Write-Error "vars.ROM_ASSETS_REPO and/or secrets.ROM_ASSETS_PAT are not set -- cannot recompile without a ROM."
             exit 1
           }
-          [IO.File]::WriteAllBytes("$env:ROM_FILENAME", [Convert]::FromBase64String($env:ROM_B64))
+
+      - name: Fetch ROM from private assets repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ vars.ROM_ASSETS_REPO }}
+          token: ${{ secrets.ROM_ASSETS_PAT }}
+          path: rom-assets
+
+      - name: Place ROM
+        shell: pwsh
+        run: |
+          Copy-Item "rom-assets\$env:ROM_FILENAME" ".\$env:ROM_FILENAME"
+          Remove-Item -Recurse -Force rom-assets
 
       - name: Apply patches
         shell: pwsh


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build-release.yml`, a `workflow_dispatch`-only workflow that recompiles the game from a ROM and builds `lamborghini_modern` for both Windows (MinGW-w64 GCC) and Linux, then publishes both binaries to a GitHub Release.
- The ROM lives in a separate private companion repo (`alondero/automobililamborghini-recomp-assets`), checked out during the build via a fine-grained PAT (`ROM_ASSETS_PAT` secret + `ROM_ASSETS_REPO` variable), copied in just for the build, and deleted before packaging — it is never included in any artifact or release asset. Users must supply their own legally-dumped `Automobili Lamborghini (USA).z64` to run the released binary, same as building locally.
- Windows job uses MinGW-w64 GCC (via choco) + a pip-installed CMake, matching this project's documented toolchain gotchas (MSYS2's bundled cmake/bash misbehave here) and applies the MinGW/D3D12 COM-ABI patches (0004/0005); Linux job builds against SDL2/Vulkan and only needs the runtime patch (0001).

## Test plan
- [x] Create private ROM assets repo + PAT secret + repo variable
- [ ] Manually trigger the workflow (Actions tab → Build & Release → Run workflow) with a test tag
- [ ] Confirm both `build-linux` and `build-windows` jobs succeed and produce zips
- [ ] Confirm the release is created with both zips attached and no ROM data present
- [ ] Sanity-run each downloaded binary locally with a real ROM alongside it
