### PR TITLE
Graphics enhancements wave 1: persistent config, display-rate interpolation, widescreen, resolution scaling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/register_overlays.cpp
         src/stub_renderer.cpp
         src/lambo_audio.cpp    # SDL2 push-audio sink for the AI buffer (audio epic #53, PR 1 of 3)
+        src/lambo_config.cpp   # persistent graphics.json -> ultramodern GraphicsConfig (enhancements #1/#2)
         src/aspMain.cpp        # RSPRecomp'd audio microcode (M_AUDTASK PCM synthesis, #53).
                                # GENERATED: RSPRecomp aspMain.us.toml (see BUILDING.md step 3)
         src/libultra_stubs.c   # no-op symbols for ignored libultra CP0 helpers (e.g. __osSetSR)

--- a/README.md
+++ b/README.md
@@ -17,15 +17,16 @@ This is an in-progress port. It boots, presents the attract/title sequence and m
 ## Graphics options
 
 Graphics settings persist in `graphics.json` (in `%LOCALAPPDATA%\LamborghiniRecomp` on
-Windows, `~/.config/LamborghiniRecomp` elsewhere; create a `portable.txt` next to the
-executable to keep it in the working directory instead). The file is created with
+Windows, `~/.config/LamborghiniRecomp` elsewhere; create a `portable.txt` in the
+directory you launch from to keep everything there instead). Game saves live in the
+same directory. The file is created with
 defaults on first run — edit it and relaunch. The schema and vocabulary match the other
 N64Recomp ports (Zelda 64: Recompiled et al.):
 
 | Key | Values | Default | Meaning |
 | --- | --- | --- | --- |
-| `res_option` | `Original`, `Original2x`, `Auto` | `Auto` | Internal render resolution. `Auto` scales with the window size; `Original`/`Original2x` use `ds_option` as a fixed multiplier of 240p. |
-| `ar_option` | `Original`, `Expand` | `Expand` | Aspect ratio. `Expand` widens the 3D view to the window's aspect (true widescreen, not stretch). |
+| `res_option` | `Original`, `Original2x`, `Auto` | `Auto` | Internal render resolution. `Auto` scales with the window size; `Original`/`Original2x` render at 1×/2× of 240p, each supersampled by the `ds_option` factor. |
+| `ar_option` | `Original`, `Expand`, `Manual` | `Expand` | Aspect ratio. `Expand` widens the 3D view to the window's aspect (true widescreen, not stretch). |
 | `hr_option` | `Original`, `Clamp16x9`, `Full` | `Clamp16x9` | Where edge-pinned HUD elements sit in widescreen (takes effect as HUD elements gain extended-GBI alignment). |
 | `rr_option` | `Original`, `Display`, `Manual` | `Display` | Presented framerate. `Display` renders RT64-interpolated frames at the monitor refresh rate — game logic stays at its native 30Hz. `Manual` uses `rr_manual_value`. |
 | `msaa_option` | `None`, `MSAA2X`, `MSAA4X`, `MSAA8X` | `MSAA2X` | Anti-aliasing. |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@ Only the **North American (USA) release** is currently supported. The build read
 
 This is an in-progress port. It boots, presents the attract/title sequence and menus, and goes in-race. Input, audio, and rendering are wired through RT64. Expect rough edges — see the issue tracker.
 
+## Graphics options
+
+Graphics settings persist in `graphics.json` (in `%LOCALAPPDATA%\LamborghiniRecomp` on
+Windows, `~/.config/LamborghiniRecomp` elsewhere; create a `portable.txt` next to the
+executable to keep it in the working directory instead). The file is created with
+defaults on first run — edit it and relaunch. The schema and vocabulary match the other
+N64Recomp ports (Zelda 64: Recompiled et al.):
+
+| Key | Values | Default | Meaning |
+| --- | --- | --- | --- |
+| `res_option` | `Original`, `Original2x`, `Auto` | `Auto` | Internal render resolution. `Auto` scales with the window size; `Original`/`Original2x` use `ds_option` as a fixed multiplier of 240p. |
+| `ar_option` | `Original`, `Expand` | `Expand` | Aspect ratio. `Expand` widens the 3D view to the window's aspect (true widescreen, not stretch). |
+| `hr_option` | `Original`, `Clamp16x9`, `Full` | `Clamp16x9` | Where edge-pinned HUD elements sit in widescreen (takes effect as HUD elements gain extended-GBI alignment). |
+| `rr_option` | `Original`, `Display`, `Manual` | `Display` | Presented framerate. `Display` renders RT64-interpolated frames at the monitor refresh rate — game logic stays at its native 30Hz. `Manual` uses `rr_manual_value`. |
+| `msaa_option` | `None`, `MSAA2X`, `MSAA4X`, `MSAA8X` | `MSAA2X` | Anti-aliasing. |
+| `hpfb_option` | `Auto`, `On`, `Off` | `Auto` | High-precision framebuffer. |
+| `wm_option` | `Windowed`, `Fullscreen` | `Windowed` | Window mode. **F11** or **Alt+Enter** toggles at runtime (and is remembered). |
+| `window_width` / `window_height` | pixels | `1600`/`900` | Windowed-mode size. |
+| `api_option` | `Auto`, `D3D12`, `Vulkan`, `Metal` | `Auto` | Graphics API. |
+
 ## Building
 
 See **[BUILDING.md](./BUILDING.md)**. In brief: clone with submodules, supply your ROM, run the recompile step, then configure and build with CMake.

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -1,0 +1,176 @@
+// Persistent graphics configuration (see lambo_config.h).
+//
+// Schema and behaviour mirror Zelda64Recomp's src/game/config.cpp graphics.json
+// (same key names, same per-key fall-back-to-default on missing/corrupt values,
+// same "portable.txt beside the exe -> use the working directory" escape hatch),
+// minus the RmlUi menu: this port's UI is the JSON file itself plus hotkeys.
+#include "lambo_config.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+
+#include "json/json.hpp"
+
+namespace {
+
+constexpr const char* kAppFolderName = "LamborghiniRecomp";
+constexpr const char* kGraphicsFile = "graphics.json";
+
+// Window-size keys live in the same graphics.json (extra keys alongside the
+// GraphicsConfig fields); 16:9 default so AspectRatio::Expand widens on first run.
+constexpr int kDefaultWindowWidth = 1600;
+constexpr int kDefaultWindowHeight = 900;
+
+lambo::config::WindowSize g_window_size{kDefaultWindowWidth, kDefaultWindowHeight};
+
+// Read a key into `out`, keeping the existing (default) value when the key is
+// missing or has the wrong type. NLOHMANN_JSON_SERIALIZE_ENUM maps an unknown
+// string to the FIRST enumerator of the mapping, which for every GraphicsConfig
+// enum is a valid conservative option, so no extra validation is needed.
+template <typename T>
+void from_or_default(const nlohmann::json& j, const char* key, T& out) {
+    auto it = j.find(key);
+    if (it == j.end()) return;
+    try {
+        out = it->get<T>();
+    } catch (const nlohmann::json::exception&) {
+        // keep default
+    }
+}
+
+nlohmann::json to_json(const ultramodern::renderer::GraphicsConfig& c) {
+    return nlohmann::json{
+        {"res_option", c.res_option},
+        {"wm_option", c.wm_option},
+        {"hr_option", c.hr_option},
+        {"api_option", c.api_option},
+        {"ar_option", c.ar_option},
+        {"msaa_option", c.msaa_option},
+        {"rr_option", c.rr_option},
+        {"hpfb_option", c.hpfb_option},
+        {"rr_manual_value", c.rr_manual_value},
+        {"ds_option", c.ds_option},
+        {"developer_mode", c.developer_mode},
+        {"window_width", g_window_size.width},
+        {"window_height", g_window_size.height},
+    };
+}
+
+void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c) {
+    from_or_default(j, "res_option", c.res_option);
+    from_or_default(j, "wm_option", c.wm_option);
+    from_or_default(j, "hr_option", c.hr_option);
+    from_or_default(j, "api_option", c.api_option);
+    from_or_default(j, "ar_option", c.ar_option);
+    from_or_default(j, "msaa_option", c.msaa_option);
+    from_or_default(j, "rr_option", c.rr_option);
+    from_or_default(j, "hpfb_option", c.hpfb_option);
+    from_or_default(j, "rr_manual_value", c.rr_manual_value);
+    from_or_default(j, "ds_option", c.ds_option);
+    from_or_default(j, "developer_mode", c.developer_mode);
+    from_or_default(j, "window_width", g_window_size.width);
+    from_or_default(j, "window_height", g_window_size.height);
+    if (g_window_size.width < 320 || g_window_size.height < 240) {
+        g_window_size = {kDefaultWindowWidth, kDefaultWindowHeight};
+    }
+}
+
+std::filesystem::path graphics_json_path() {
+    // Test/harness override: point at (or isolate to) an explicit file.
+    if (const char* p = std::getenv("LAMBO_GRAPHICS_CONFIG")) {
+        return std::filesystem::path{p};
+    }
+    return lambo::config::app_config_dir() / kGraphicsFile;
+}
+
+} // anonymous namespace
+
+namespace lambo {
+namespace config {
+
+std::filesystem::path app_config_dir() {
+    // Portable mode: a portable.txt in the working directory keeps everything local.
+    std::error_code ec;
+    if (std::filesystem::exists("portable.txt", ec)) {
+        return std::filesystem::current_path();
+    }
+#if defined(_WIN32)
+    if (const char* localappdata = std::getenv("LOCALAPPDATA")) {
+        return std::filesystem::path{localappdata} / kAppFolderName;
+    }
+#else
+    if (const char* xdg = std::getenv("XDG_CONFIG_HOME")) {
+        return std::filesystem::path{xdg} / kAppFolderName;
+    }
+    if (const char* home = std::getenv("HOME")) {
+        return std::filesystem::path{home} / ".config" / kAppFolderName;
+    }
+#endif
+    return std::filesystem::current_path();
+}
+
+ultramodern::renderer::GraphicsConfig default_graphics_config() {
+    // Zelda64Recomp's shipped defaults (config.cpp:26-35), which are the
+    // enhancement goals of issue wave 1: window-scaled internal resolution,
+    // widescreen Expand with the HUD clamped to 16:9, and RT64 frame
+    // interpolation up to the display refresh rate (game logic stays at its
+    // native 30Hz tick either way -- ultramodern's VI clock is fixed).
+    ultramodern::renderer::GraphicsConfig cfg{};
+    cfg.res_option = ultramodern::renderer::Resolution::Auto;
+    cfg.wm_option = ultramodern::renderer::WindowMode::Windowed;
+    cfg.hr_option = ultramodern::renderer::HUDRatioMode::Clamp16x9;
+    cfg.api_option = ultramodern::renderer::GraphicsApi::Auto;
+    cfg.ar_option = ultramodern::renderer::AspectRatio::Expand;
+    cfg.msaa_option = ultramodern::renderer::Antialiasing::MSAA2X;
+    cfg.rr_option = ultramodern::renderer::RefreshRate::Display;
+    cfg.hpfb_option = ultramodern::renderer::HighPrecisionFramebuffer::Auto;
+    cfg.rr_manual_value = 60;
+    cfg.ds_option = 1;
+    cfg.developer_mode = false;
+    return cfg;
+}
+
+ultramodern::renderer::GraphicsConfig load_and_apply_graphics() {
+    ultramodern::renderer::GraphicsConfig cfg = default_graphics_config();
+    const std::filesystem::path path = graphics_json_path();
+
+    std::ifstream in{path};
+    if (in.good()) {
+        try {
+            nlohmann::json j;
+            in >> j;
+            from_json(j, cfg);
+        } catch (const nlohmann::json::exception& e) {
+            std::fprintf(stderr, "[config] %s unparseable (%s); using defaults\n",
+                         path.string().c_str(), e.what());
+        }
+    }
+    in.close();
+
+    ultramodern::renderer::set_graphics_config(cfg);
+    // Write the merged config back so the on-disk file is always complete and
+    // editable (new keys appear with their defaults after an upgrade).
+    save_graphics(cfg);
+    std::fprintf(stderr, "[config] graphics config: %s\n", path.string().c_str());
+    return cfg;
+}
+
+void save_graphics(const ultramodern::renderer::GraphicsConfig& cfg) {
+    const std::filesystem::path path = graphics_json_path();
+    std::error_code ec;
+    std::filesystem::create_directories(path.parent_path(), ec);
+    std::ofstream out{path};
+    if (!out.good()) {
+        std::fprintf(stderr, "[config] cannot write %s\n", path.string().c_str());
+        return;
+    }
+    out << to_json(cfg).dump(4) << "\n";
+}
+
+WindowSize window_size() {
+    return g_window_size;
+}
+
+} // namespace config
+} // namespace lambo

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -2,7 +2,7 @@
 //
 // Schema and behaviour mirror Zelda64Recomp's src/game/config.cpp graphics.json
 // (same key names, same per-key fall-back-to-default on missing/corrupt values,
-// same "portable.txt beside the exe -> use the working directory" escape hatch),
+// and a "portable.txt in the LAUNCH directory -> keep config there" escape hatch),
 // minus the RmlUi menu: this port's UI is the JSON file itself plus hotkeys.
 #include "lambo_config.h"
 
@@ -25,17 +25,25 @@ constexpr int kDefaultWindowHeight = 900;
 lambo::config::WindowSize g_window_size{kDefaultWindowWidth, kDefaultWindowHeight};
 
 // Read a key into `out`, keeping the existing (default) value when the key is
-// missing or has the wrong type. NLOHMANN_JSON_SERIALIZE_ENUM maps an unknown
-// string to the FIRST enumerator of the mapping, which for every GraphicsConfig
-// enum is a valid conservative option, so no extra validation is needed.
+// missing or invalid. NLOHMANN_JSON_SERIALIZE_ENUM does NOT throw on an
+// unrecognised string -- it silently maps it to the FIRST enumerator, which for
+// several options (res/ar/rr/msaa) is not this port's default. Round-tripping the
+// parsed value back to JSON detects that: a value that doesn't re-serialise to
+// what we read was invalid, so the default is kept (and the user warned).
 template <typename T>
 void from_or_default(const nlohmann::json& j, const char* key, T& out) {
     auto it = j.find(key);
     if (it == j.end()) return;
     try {
-        out = it->get<T>();
+        T parsed = it->get<T>();
+        if (nlohmann::json(parsed) != *it) {
+            std::fprintf(stderr, "[config] %s: invalid value %s -- keeping default\n",
+                         key, it->dump().c_str());
+            return;
+        }
+        out = parsed;
     } catch (const nlohmann::json::exception&) {
-        // keep default
+        std::fprintf(stderr, "[config] %s: wrong type -- keeping default\n", key);
     }
 }
 
@@ -71,8 +79,35 @@ void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c
     from_or_default(j, "developer_mode", c.developer_mode);
     from_or_default(j, "window_width", g_window_size.width);
     from_or_default(j, "window_height", g_window_size.height);
-    if (g_window_size.width < 320 || g_window_size.height < 240) {
+    // Sanity-bound the window size: below the N64 framebuffer is useless, above 8K
+    // is a typo -- either way SDL_CreateWindow would fail and the port would run
+    // permanently headless, so reset to defaults instead.
+    if (g_window_size.width < 320 || g_window_size.width > 7680 ||
+        g_window_size.height < 240 || g_window_size.height > 4320) {
+        std::fprintf(stderr, "[config] window %dx%d out of range -- using %dx%d\n",
+                     g_window_size.width, g_window_size.height,
+                     kDefaultWindowWidth, kDefaultWindowHeight);
         g_window_size = {kDefaultWindowWidth, kDefaultWindowHeight};
+    }
+}
+
+// Read graphics.json into cfg (merging over whatever cfg already holds).
+enum class ReadResult { Missing, Ok, Unparseable };
+
+ReadResult read_graphics_file(const std::filesystem::path& path,
+                              ultramodern::renderer::GraphicsConfig& cfg) {
+    std::ifstream in{path};
+    if (!in.good()) return ReadResult::Missing;
+    try {
+        nlohmann::json j;
+        in >> j;
+        from_json(j, cfg);
+        return ReadResult::Ok;
+    } catch (const nlohmann::json::exception& e) {
+        std::fprintf(stderr, "[config] %s unparseable (%s); using defaults IN MEMORY"
+                     " -- file left untouched, fix or delete it\n",
+                     path.string().c_str(), e.what());
+        return ReadResult::Unparseable;
     }
 }
 
@@ -134,26 +169,31 @@ ultramodern::renderer::GraphicsConfig default_graphics_config() {
 ultramodern::renderer::GraphicsConfig load_and_apply_graphics() {
     ultramodern::renderer::GraphicsConfig cfg = default_graphics_config();
     const std::filesystem::path path = graphics_json_path();
-
-    std::ifstream in{path};
-    if (in.good()) {
-        try {
-            nlohmann::json j;
-            in >> j;
-            from_json(j, cfg);
-        } catch (const nlohmann::json::exception& e) {
-            std::fprintf(stderr, "[config] %s unparseable (%s); using defaults\n",
-                         path.string().c_str(), e.what());
-        }
-    }
-    in.close();
+    const ReadResult r = read_graphics_file(path, cfg);
 
     ultramodern::renderer::set_graphics_config(cfg);
     // Write the merged config back so the on-disk file is always complete and
-    // editable (new keys appear with their defaults after an upgrade).
-    save_graphics(cfg);
+    // editable (new keys appear with their defaults after an upgrade) -- but NEVER
+    // overwrite a file that failed to parse: a hand-edit typo must stay recoverable,
+    // not be replaced by defaults.
+    if (r != ReadResult::Unparseable) {
+        save_graphics(cfg);
+    }
     std::fprintf(stderr, "[config] graphics config: %s\n", path.string().c_str());
     return cfg;
+}
+
+void update_saved_window_mode(ultramodern::renderer::WindowMode wm) {
+    // Persist a runtime window-mode change by re-reading the on-disk file and
+    // updating ONLY wm_option -- a user hand-editing other keys while the game runs
+    // must not have those edits clobbered by an F11 press.
+    ultramodern::renderer::GraphicsConfig cfg = default_graphics_config();
+    const std::filesystem::path path = graphics_json_path();
+    if (read_graphics_file(path, cfg) == ReadResult::Unparseable) {
+        return; // don't destroy a recoverable (broken) file just to save a toggle
+    }
+    cfg.wm_option = wm;
+    save_graphics(cfg);
 }
 
 void save_graphics(const ultramodern::renderer::GraphicsConfig& cfg) {
@@ -166,6 +206,11 @@ void save_graphics(const ultramodern::renderer::GraphicsConfig& cfg) {
         return;
     }
     out << to_json(cfg).dump(4) << "\n";
+    out.flush();
+    if (!out.good()) {
+        std::fprintf(stderr, "[config] write to %s FAILED (disk full / permissions?)"
+                     " -- settings may not persist\n", path.string().c_str());
+    }
 }
 
 WindowSize window_size() {

--- a/src/lambo_config.h
+++ b/src/lambo_config.h
@@ -29,8 +29,13 @@ ultramodern::renderer::GraphicsConfig default_graphics_config();
 // users always have a complete, editable file on disk. Returns the applied config.
 ultramodern::renderer::GraphicsConfig load_and_apply_graphics();
 
-// Persist the given config (used when a runtime toggle, e.g. fullscreen, changes it).
+// Persist the given config (full overwrite of graphics.json).
 void save_graphics(const ultramodern::renderer::GraphicsConfig& cfg);
+
+// Persist a runtime window-mode change (F11) by re-reading the on-disk file and
+// updating only wm_option, so concurrent hand-edits to other keys survive. A file
+// that fails to parse is left untouched.
+void update_saved_window_mode(ultramodern::renderer::WindowMode wm);
 
 // Requested window size for windowed mode (from graphics.json; defaults 1600x900,
 // chosen 16:9 so AspectRatio::Expand actually widens on first launch).

--- a/src/lambo_config.h
+++ b/src/lambo_config.h
@@ -1,0 +1,43 @@
+// Persistent user-facing graphics configuration (#1/#2 enhancement wave).
+//
+// Same model as Zelda64Recomp: ultramodern owns the GraphicsConfig struct and the
+// renderer reacts to set_graphics_config(); the PORT owns persistence. We persist a
+// graphics.json in a per-user config directory using the NLOHMANN_JSON_SERIALIZE_ENUM
+// mappings ultramodern ships in ultramodern/config.hpp, so the on-disk vocabulary
+// ("Expand", "Display", "MSAA4X", ...) matches the peer ports.
+#ifndef LAMBO_CONFIG_H
+#define LAMBO_CONFIG_H
+
+#include <filesystem>
+
+#include "ultramodern/config.hpp"
+
+namespace lambo {
+namespace config {
+
+// Per-user persistent config directory (created on demand):
+//   Windows: %LOCALAPPDATA%\LamborghiniRecomp
+//   else:    $XDG_CONFIG_HOME/LamborghiniRecomp (or ~/.config/LamborghiniRecomp)
+std::filesystem::path app_config_dir();
+
+// The enhancement-oriented defaults this port ships with (widescreen Expand,
+// display-rate interpolated rendering, window-scaled internal resolution).
+ultramodern::renderer::GraphicsConfig default_graphics_config();
+
+// Load graphics.json (falling back to defaults for missing/invalid keys), apply it
+// via ultramodern::renderer::set_graphics_config, and write the merged file back so
+// users always have a complete, editable file on disk. Returns the applied config.
+ultramodern::renderer::GraphicsConfig load_and_apply_graphics();
+
+// Persist the given config (used when a runtime toggle, e.g. fullscreen, changes it).
+void save_graphics(const ultramodern::renderer::GraphicsConfig& cfg);
+
+// Requested window size for windowed mode (from graphics.json; defaults 1600x900,
+// chosen 16:9 so AspectRatio::Expand actually widens on first launch).
+struct WindowSize { int width; int height; };
+WindowSize window_size();
+
+} // namespace config
+} // namespace lambo
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,6 +37,7 @@
 #endif
 #include "lambo_rt64.h"
 #include "lambo_audio.h"   // SDL2 push-audio sink for the AI buffer (audio epic #53)
+#include "lambo_config.h"  // persistent graphics.json -> ultramodern GraphicsConfig (#1/#2)
 // ultramodern's native VI API (events.cpp), used by the promote_vi_context RT64 bridge.
 extern "C" void osViSwapBuffer(uint8_t* rdram, int32_t frameBufPtr);
 extern "C" void osViSetMode(uint8_t* rdram, int32_t mode_);
@@ -306,6 +307,26 @@ static void input_open_controller(int joystick_index);
 static void input_close_controller(SDL_JoystickID which);
 static void rumble_apply();  // rumble-pak sink (#69); defined in the input section below
 
+// The SDL window, kept for main-thread window ops (fullscreen toggle). SDL window
+// state is owned by THIS thread; the renderer only ever sees the raw handle.
+static SDL_Window* g_sdl_window = nullptr;
+
+// F11 / Alt+Enter fullscreen toggle (main thread, called from the SDL event loop).
+// SDL owns the window state; the new mode is also persisted to graphics.json so the
+// next launch starts in the same mode. (The renderer-side setFullScreen path in
+// rt64_renderer.cpp's update_config is intentionally NOT used -- one owner.)
+static void toggle_fullscreen() {
+    if (g_sdl_window == nullptr) return;
+    bool now_fullscreen = (SDL_GetWindowFlags(g_sdl_window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0;
+    SDL_SetWindowFullscreen(g_sdl_window, now_fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
+    ultramodern::renderer::GraphicsConfig cfg = ultramodern::renderer::get_graphics_config();
+    cfg.wm_option = now_fullscreen ? ultramodern::renderer::WindowMode::Fullscreen
+                                   : ultramodern::renderer::WindowMode::Windowed;
+    ultramodern::renderer::set_graphics_config(cfg);
+    lambo::config::save_graphics(cfg);
+    std::fprintf(stderr, "[config] fullscreen %s (F11 / Alt+Enter)\n", now_fullscreen ? "ON" : "OFF");
+}
+
 static ultramodern::renderer::WindowHandle create_window_stub(void* /*gfx_data*/) {
     // RT64 default presenter (#58): RT64 needs a real window with a Vulkan surface
     // (Linux). Created on the main thread; the SDL event pump runs in update_gfx_stub
@@ -332,16 +353,26 @@ static ultramodern::renderer::WindowHandle create_window_stub(void* /*gfx_data*/
 #if defined(__linux__)
         flags |= SDL_WINDOW_VULKAN;
 #endif
+        // Window size + startup fullscreen come from graphics.json (loaded in main()
+        // before recomp::start). Fullscreen is owned by SDL on this (main) thread --
+        // see the F11 handler in update_gfx_stub.
+        const lambo::config::WindowSize win_size = lambo::config::window_size();
+        if (ultramodern::renderer::get_graphics_config().wm_option ==
+            ultramodern::renderer::WindowMode::Fullscreen) {
+            flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+        }
         SDL_Window* window = SDL_CreateWindow("Automobili Lamborghini",
                                               SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-                                              1280, 960, flags);
+                                              win_size.width, win_size.height, flags);
         if (window == nullptr) {
             std::fprintf(stderr, "[rt64] SDL_CreateWindow failed: %s -- staying headless\n",
                          SDL_GetError());
             return ultramodern::renderer::WindowHandle{};
         }
+        g_sdl_window = window;
 #if defined(__linux__)
-        std::fprintf(stderr, "[rt64] SDL window created (1280x960, Vulkan surface)\n");
+        std::fprintf(stderr, "[rt64] SDL window created (%dx%d, Vulkan surface)\n",
+                     win_size.width, win_size.height);
         return ultramodern::renderer::WindowHandle{window};
 #elif defined(_WIN32)
         // Native Windows (#68): ultramodern's WindowHandle is {HWND, thread_id} and RT64
@@ -355,7 +386,8 @@ static ultramodern::renderer::WindowHandle create_window_stub(void* /*gfx_data*/
             SDL_DestroyWindow(window);
             return ultramodern::renderer::WindowHandle{};
         }
-        std::fprintf(stderr, "[rt64] SDL window created (1280x960, Win32 HWND -> D3D12)\n");
+        std::fprintf(stderr, "[rt64] SDL window created (%dx%d, Win32 HWND -> D3D12)\n",
+                     win_size.width, win_size.height);
         return ultramodern::renderer::WindowHandle{wmInfo.info.win.window, GetCurrentThreadId()};
 #else
         std::fprintf(stderr, "[rt64] window handle wiring not implemented on this platform\n");
@@ -378,6 +410,11 @@ static void update_gfx_stub(void* /*gfx_data*/) {
                 (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE)) {
                 std::fprintf(stderr, "[probe] window closed; quitting\n");
                 boot_summary_and_exit();
+            }
+            else if (event.type == SDL_KEYDOWN && !event.key.repeat &&
+                     (event.key.keysym.sym == SDLK_F11 ||
+                      (event.key.keysym.sym == SDLK_RETURN && (event.key.keysym.mod & KMOD_ALT)))) {
+                toggle_fullscreen();
             }
             else if (event.type == SDL_CONTROLLERDEVICEADDED) {
                 input_open_controller(event.cdevice.which);   // which = joystick index (ADDED)
@@ -600,6 +637,11 @@ int main(int argc, char** argv) {
     std::fprintf(stderr, "[probe] ROM: %s\n", rom_path);
 
     register_overlays();
+
+    // Load + apply graphics.json BEFORE recomp::start: ultramodern latches the config
+    // and the RT64 context constructor reads it via get_graphics_config(). This is the
+    // whole user-facing options mechanism (edit the file; F11 toggles fullscreen live).
+    lambo::config::load_and_apply_graphics();
 
     std::filesystem::path config_dir = std::filesystem::temp_directory_path() / "lambo_modern_probe";
     std::filesystem::create_directories(config_dir);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -312,19 +312,26 @@ static void rumble_apply();  // rumble-pak sink (#69); defined in the input sect
 static SDL_Window* g_sdl_window = nullptr;
 
 // F11 / Alt+Enter fullscreen toggle (main thread, called from the SDL event loop).
-// SDL owns the window state; the new mode is also persisted to graphics.json so the
-// next launch starts in the same mode. (The renderer-side setFullScreen path in
-// rt64_renderer.cpp's update_config is intentionally NOT used -- one owner.)
+// SDL owns the window state; the new mode is persisted to graphics.json so the next
+// launch starts in the same mode. Two deliberate omissions:
+//  - rt64_renderer.cpp's update_config setFullScreen path is not used (one owner);
+//  - ultramodern::renderer::set_graphics_config is NOT called here: it would be the
+//    only mid-game config writer, racing the gfx thread's UNLOCKED config copy
+//    (get_graphics_config returns a reference whose guard is released on return --
+//    an upstream ultramodern flaw). Nothing renderer-side consumes wm_option, so the
+//    live config staying at its startup value is harmless.
 static void toggle_fullscreen() {
     if (g_sdl_window == nullptr) return;
-    bool now_fullscreen = (SDL_GetWindowFlags(g_sdl_window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0;
-    SDL_SetWindowFullscreen(g_sdl_window, now_fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
-    ultramodern::renderer::GraphicsConfig cfg = ultramodern::renderer::get_graphics_config();
-    cfg.wm_option = now_fullscreen ? ultramodern::renderer::WindowMode::Fullscreen
-                                   : ultramodern::renderer::WindowMode::Windowed;
-    ultramodern::renderer::set_graphics_config(cfg);
-    lambo::config::save_graphics(cfg);
-    std::fprintf(stderr, "[config] fullscreen %s (F11 / Alt+Enter)\n", now_fullscreen ? "ON" : "OFF");
+    bool to_fullscreen = (SDL_GetWindowFlags(g_sdl_window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0;
+    if (SDL_SetWindowFullscreen(g_sdl_window,
+                                to_fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0) != 0) {
+        std::fprintf(stderr, "[config] fullscreen toggle FAILED: %s\n", SDL_GetError());
+        return; // window unchanged -> persist nothing, config and reality stay agreed
+    }
+    lambo::config::update_saved_window_mode(
+        to_fullscreen ? ultramodern::renderer::WindowMode::Fullscreen
+                      : ultramodern::renderer::WindowMode::Windowed);
+    std::fprintf(stderr, "[config] fullscreen %s (F11 / Alt+Enter)\n", to_fullscreen ? "ON" : "OFF");
 }
 
 static ultramodern::renderer::WindowHandle create_window_stub(void* /*gfx_data*/) {
@@ -643,7 +650,11 @@ int main(int argc, char** argv) {
     // whole user-facing options mechanism (edit the file; F11 toggles fullscreen live).
     lambo::config::load_and_apply_graphics();
 
-    std::filesystem::path config_dir = std::filesystem::temp_directory_path() / "lambo_modern_probe";
+    // librecomp's config path is where game SAVES (EEPROM/SRAM/pak) and mod config
+    // live -- point it at the same persistent per-user directory as graphics.json.
+    // (It was a throwaway temp dir during the headless-probe era, which silently
+    // discarded saves on temp cleanup.)
+    std::filesystem::path config_dir = lambo::config::app_config_dir();
     std::filesystem::create_directories(config_dir);
     recomp::register_config_path(config_dir);
 

--- a/src/rt64_renderer.cpp
+++ b/src/rt64_renderer.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <mutex>
 
 #include "hle/rt64_application.h"
 
@@ -280,15 +281,30 @@ public:
             // for (display Hz when RefreshRate::Display), and interp count/presented the
             // per-workload synthesized-frame counters -- count ~= targetRate/viOriginalRate
             // when interpolation is live; 0 means RT64 is presenting game frames raw.
-            const RT64::SharedQueueResources* sq = app->sharedQueueResources.get();
-            const RT64::InterpolatedFrameCounters& fc =
-                sq->interpolatedFrames[sq->interpolatedFramesIndex];
+            //
+            // DIAGNOSTICS-GRADE SAMPLING: interpolatedMutex synchronises with the present
+            // queue's counter updates, but RT64's workload thread writes the index/rate
+            // fields WITHOUT any lock (rt64_workload_queue.cpp:1020-1044, :237), so a
+            // fully synchronised read is impossible without patching the submodule. These
+            // are aligned word loads sampled once per second for a log line -- treat a
+            // single odd line as sampling noise, only a sustained pattern as signal.
+            RT64::SharedQueueResources* sq = app->sharedQueueResources.get();
+            uint32_t vi_rate, target_rate, swap_hz, interp_count, interp_presented;
+            {
+                std::lock_guard<std::mutex> lock(sq->interpolatedMutex);
+                const RT64::InterpolatedFrameCounters& fc =
+                    sq->interpolatedFrames[sq->interpolatedFramesIndex];
+                vi_rate = sq->viOriginalRate;
+                target_rate = sq->targetRate;
+                swap_hz = sq->swapChainRate;
+                interp_count = fc.count;
+                interp_presented = fc.presented;
+            }
             std::fprintf(stderr,
                          "[rt64] send_dl count=%d VI_ORIGIN=0x%08x VI_STATUS=0x%04x VI_WIDTH=%u"
                          " | viRate=%u targetRate=%u swapHz=%u interp count=%u presented=%u\n",
                          count, vr->VI_ORIGIN_REG, vr->VI_STATUS_REG, vr->VI_WIDTH_REG,
-                         sq->viOriginalRate, sq->targetRate, sq->swapChainRate,
-                         fc.count, fc.presented);
+                         vi_rate, target_rate, swap_hz, interp_count, interp_presented);
         }
     }
 

--- a/src/rt64_renderer.cpp
+++ b/src/rt64_renderer.cpp
@@ -242,9 +242,9 @@ public:
         if (old_config == new_config) {
             return false;
         }
-        if (new_config.wm_option != old_config.wm_option) {
-            app->setFullScreen(new_config.wm_option == ultramodern::renderer::WindowMode::Fullscreen);
-        }
+        // wm_option (fullscreen) is deliberately NOT handled here: the SDL window is
+        // owned by the main thread (toggle_fullscreen in main.cpp), and RT64's
+        // setFullScreen would fight SDL over the same HWND.
         set_application_user_config(app.get(), new_config);
         app->updateUserConfig(true);
         if (new_config.msaa_option != old_config.msaa_option) {
@@ -275,9 +275,20 @@ public:
         // not the pre-game dummy at 0x80700000 / a blanked STATUS of 0.
         if (count % 30 == 0) {
             const ultramodern::renderer::ViRegs* vr = ultramodern::renderer::get_vi_regs();
+            // Interpolation health (#1 display-rate rendering): viOriginalRate is the game's
+            // detected update rate (30 for this title), targetRate the present pace RT64 aims
+            // for (display Hz when RefreshRate::Display), and interp count/presented the
+            // per-workload synthesized-frame counters -- count ~= targetRate/viOriginalRate
+            // when interpolation is live; 0 means RT64 is presenting game frames raw.
+            const RT64::SharedQueueResources* sq = app->sharedQueueResources.get();
+            const RT64::InterpolatedFrameCounters& fc =
+                sq->interpolatedFrames[sq->interpolatedFramesIndex];
             std::fprintf(stderr,
-                         "[rt64] send_dl count=%d (pipeline sustained) VI_ORIGIN=0x%08x VI_STATUS=0x%04x VI_WIDTH=%u\n",
-                         count, vr->VI_ORIGIN_REG, vr->VI_STATUS_REG, vr->VI_WIDTH_REG);
+                         "[rt64] send_dl count=%d VI_ORIGIN=0x%08x VI_STATUS=0x%04x VI_WIDTH=%u"
+                         " | viRate=%u targetRate=%u swapHz=%u interp count=%u presented=%u\n",
+                         count, vr->VI_ORIGIN_REG, vr->VI_STATUS_REG, vr->VI_WIDTH_REG,
+                         sq->viOriginalRate, sq->targetRate, sq->swapChainRate,
+                         fc.count, fc.presented);
         }
     }
 


### PR DESCRIPTION
## What

User-facing graphics options for the port, modelled on Zelda64Recomp / Snowboard Kids 2:

- **Persistent `graphics.json`** (`%LOCALAPPDATA%\LamborghiniRecomp`, or the launch directory with `portable.txt`) using the peer ports' schema/vocabulary; documented in a README table. Loaded and applied via `ultramodern::renderer::set_graphics_config` before `recomp::start`.
- **Display-refresh-rate rendering** (`rr_option: Display`, default): RT64 frame interpolation presents at the monitor rate while game logic stays at its native 30Hz tick. Verified: identical swap pace (870/1800 VIs) with interpolation on and off; `interp count=2 presented=2` per game frame on a 60Hz display (scales automatically on faster monitors). No game-side tick patch needed.
- **Widescreen** (`ar_option: Expand`, default): RT64 widens the 3D view to the window aspect — verified true FOV expansion (no stretch) in the attract races; untagged 2D correctly centered.
- **Resolution scaling** (`res_option: Auto`, default) + MSAA2X; internal resolution follows the window.
- **F11 / Alt+Enter fullscreen toggle**, persisted; default window 1600×900.
- Game saves + mod config now live in the same persistent per-user directory (previously a throwaway temp dir).
- Permanent interpolation-health diagnostic in the periodic `send_dl` log (`viRate/targetRate/swapHz/interp count/presented`).

Second commit hardens the config layer against all 10 verified findings from a high-effort code review (unparseable-file preservation, enum-typo round-trip validation, SDL fullscreen failure handling, mid-game config-write race avoidance, write-failure reporting, window-size bounds, README accuracy).

## Testing

- Headless boot smoke green (`max_state` progression intact, exit 0).
- Presenting runs to 3600 VIs green, state 8 (demo race) reached, ~30fps game pace.
- Config edge cases exercised: broken JSON left byte-identical, `"display"`/`"expand"` typos warn + keep defaults, 1920000-wide window clamps to 1600×900.
- A/B verified interpolation on/off and each enhanced setting individually.

Closes #1