### PR TITLE
Fix wheel ghost/jump under RT64 frame interpolation (#30)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -74,7 +74,9 @@ jobs:
           rm -rf rom-assets
 
       - name: Apply runtime patch
-        run: git -C lib/N64ModernRuntime apply "$(pwd)/patches/0001-lamborghini-runtime-scheduler-audio-vi.patch"
+        run: |
+          git -C lib/N64ModernRuntime apply "$(pwd)/patches/0001-lamborghini-runtime-scheduler-audio-vi.patch"
+          git -C lib/rt64 apply "$(pwd)/patches/0006-rt64-interp-angular-velocity-matching.patch"
 
       - name: Configure + build recompiler CLIs
         run: |
@@ -164,6 +166,7 @@ jobs:
         run: |
           $root = (Get-Location).Path
           git -C lib/N64ModernRuntime apply "$root/patches/0001-lamborghini-runtime-scheduler-audio-vi.patch"
+          git -C lib/rt64 apply "$root/patches/0006-rt64-interp-angular-velocity-matching.patch"
           git -C lib/rt64 apply "$root/patches/0005-rt64-mingw-gcc-compat.patch"
           git -C lib/rt64/src/contrib/plume apply "$root/patches/0004-plume-d3d12-mingw-com-abi-struct-return.patch"
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -42,6 +42,9 @@ pacing, and — on Windows — the MinGW/D3D12 COM ABI fixes for RT64/plume).
 # ultramodern / librecomp runtime (all platforms):
 git -C lib/N64ModernRuntime apply ../../patches/0001-lamborghini-runtime-scheduler-audio-vi.patch
 
+# RT64 renderer — all platforms (frame-interpolation transform matching, issue #30):
+git -C lib/rt64 apply "$(pwd)/patches/0006-rt64-interp-angular-velocity-matching.patch"
+
 # RT64 renderer — Windows / MinGW only (absolute paths avoid depth confusion):
 git -C lib/rt64 apply "$(pwd)/patches/0005-rt64-mingw-gcc-compat.patch"
 git -C lib/rt64/src/contrib/plume apply "$(pwd)/patches/0004-plume-d3d12-mingw-com-abi-struct-return.patch"

--- a/patches/0006-rt64-interp-angular-velocity-matching.patch
+++ b/patches/0006-rt64-interp-angular-velocity-matching.patch
@@ -1,5 +1,5 @@
 diff --git a/src/hle/rt64_game_frame.cpp b/src/hle/rt64_game_frame.cpp
-index 87392d0..9b59713 100644
+index 87392d0..936f488 100644
 --- a/src/hle/rt64_game_frame.cpp
 +++ b/src/hle/rt64_game_frame.cpp
 @@ -2,6 +2,12 @@
@@ -15,7 +15,7 @@ index 87392d0..9b59713 100644
  #include "common/rt64_math.h"
  
  #include "rt64_game_frame.h"
-@@ -236,11 +242,25 @@ namespace RT64 {
+@@ -236,11 +242,22 @@ namespace RT64 {
          matchResult.positionDifference = hlslpp::length(curPos - prevPos);
  
          // Compute the dot product difference between the normalized XYZ vectors of the 3x3 matrices.
@@ -25,13 +25,10 @@ index 87392d0..9b59713 100644
              (1.0f - hlslpp::dot(hlslpp::normalize(curTransform[1].xyz), hlslpp::normalize(prevTransform[1].xyz))) +
              (1.0f - hlslpp::dot(hlslpp::normalize(curTransform[2].xyz), hlslpp::normalize(prevTransform[2].xyz)));
  
-+        // Discount the rotation predicted by the tracked angular velocity, mirroring the linear velocity
-+        // prediction applied to the position above. A rotation of angle a measures exactly 2*(1-cos(a))
-+        // on the basis-vector metric regardless of its axis, so a transform that keeps rotating at its
-+        // tracked rate scores near zero. Without this, fast-spinning meshes (car wheels) score their own
-+        // previous transform worse than a phase-aliased sibling (the other axle), and the greedy matcher
-+        // locks into a front/rear wheel swap that renders wheels detached from the car under
-+        // frame interpolation.
++        // Discount the rotation predicted by the tracked angular velocity (a rotation of angle a measures
++        // 2*(1-cos(a)) on this metric for any axis), mirroring the linear velocity prediction above.
++        // Raw comparison makes fast-spinning meshes (car wheels) prefer a phase-aliased sibling over
++        // their own previous transform, locking interpolation into a front/rear wheel swap.
 +        float expectedOrientationDifference = 0.0f;
 +        if (prevRigidBody != nullptr) {
 +            expectedOrientationDifference = 2.0f * (1.0f - std::cos(prevRigidBody->angularVelocity));
@@ -42,7 +39,7 @@ index 87392d0..9b59713 100644
          // Compute the difference between the screen-space position of both transforms on their respective projections.
          hlslpp::float4 prevScreenPos = hlslpp::mul(prevTransform[3], prevViewProj);
          hlslpp::float4 curScreenPos = hlslpp::mul(curTransform[3], curViewProj);
-@@ -606,6 +626,93 @@ namespace RT64 {
+@@ -606,6 +623,93 @@ namespace RT64 {
              matchTransform(firstCurWorkload, firstPrevWorkload, firstCurWorkloadMap, firstPrevWorkloadMap, candidate.curIndex, candidate.prevIndex, modifiedBuffers);
          }
  

--- a/patches/0006-rt64-interp-angular-velocity-matching.patch
+++ b/patches/0006-rt64-interp-angular-velocity-matching.patch
@@ -1,0 +1,138 @@
+diff --git a/src/hle/rt64_game_frame.cpp b/src/hle/rt64_game_frame.cpp
+index 87392d0..9b59713 100644
+--- a/src/hle/rt64_game_frame.cpp
++++ b/src/hle/rt64_game_frame.cpp
+@@ -2,6 +2,12 @@
+ // RT64
+ //
+ 
++#include <chrono>
++#include <cmath>
++#include <cstdio>
++#include <cstdlib>
++#include <unordered_map>
++
+ #include "common/rt64_math.h"
+ 
+ #include "rt64_game_frame.h"
+@@ -236,11 +242,25 @@ namespace RT64 {
+         matchResult.positionDifference = hlslpp::length(curPos - prevPos);
+ 
+         // Compute the dot product difference between the normalized XYZ vectors of the 3x3 matrices.
+-        matchResult.orientationDifference =
++        const float rawOrientationDifference =
+             (1.0f - hlslpp::dot(hlslpp::normalize(curTransform[0].xyz), hlslpp::normalize(prevTransform[0].xyz))) +
+             (1.0f - hlslpp::dot(hlslpp::normalize(curTransform[1].xyz), hlslpp::normalize(prevTransform[1].xyz))) +
+             (1.0f - hlslpp::dot(hlslpp::normalize(curTransform[2].xyz), hlslpp::normalize(prevTransform[2].xyz)));
+ 
++        // Discount the rotation predicted by the tracked angular velocity, mirroring the linear velocity
++        // prediction applied to the position above. A rotation of angle a measures exactly 2*(1-cos(a))
++        // on the basis-vector metric regardless of its axis, so a transform that keeps rotating at its
++        // tracked rate scores near zero. Without this, fast-spinning meshes (car wheels) score their own
++        // previous transform worse than a phase-aliased sibling (the other axle), and the greedy matcher
++        // locks into a front/rear wheel swap that renders wheels detached from the car under
++        // frame interpolation.
++        float expectedOrientationDifference = 0.0f;
++        if (prevRigidBody != nullptr) {
++            expectedOrientationDifference = 2.0f * (1.0f - std::cos(prevRigidBody->angularVelocity));
++        }
++
++        matchResult.orientationDifference = std::abs(rawOrientationDifference - expectedOrientationDifference);
++
+         // Compute the difference between the screen-space position of both transforms on their respective projections.
+         hlslpp::float4 prevScreenPos = hlslpp::mul(prevTransform[3], prevViewProj);
+         hlslpp::float4 curScreenPos = hlslpp::mul(curTransform[3], curViewProj);
+@@ -606,6 +626,93 @@ namespace RT64 {
+             matchTransform(firstCurWorkload, firstPrevWorkload, firstCurWorkloadMap, firstPrevWorkloadMap, candidate.curIndex, candidate.prevIndex, modifiedBuffers);
+         }
+ 
++        // Diagnostic for transform match failures (RT64_MATCH_DEBUG=1 summary, =2 verbose accepted pairs).
++        static const char *matchDebugEnv = getenv("RT64_MATCH_DEBUG");
++        static const int matchDebugLevel = (matchDebugEnv != nullptr) ? atoi(matchDebugEnv) : 0;
++        if (matchDebugLevel > 0) {
++            static uint32_t matchDebugCall = 0;
++            matchDebugCall++;
++            const uint64_t debugMs = uint64_t(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
++            thread_local std::set<uint32_t> curCheckedSet;
++            curCheckedSet.clear();
++            for (const IndexPair &indices : transformCheckSet) {
++                curCheckedSet.insert(indices.first);
++            }
++
++            // Map transform index -> max triangle count of calls using it, to identify the mesh class.
++            thread_local std::unordered_map<uint32_t, uint32_t> transformTriCount;
++            transformTriCount.clear();
++            for (uint32_t p = 0; p < curScene.projections.size(); p++) {
++                const GameIndices::Projection &projIndices = curScene.projections[p];
++                const Workload &workload = workloadQueue.workloads[projIndices.workloadIndex];
++                const Projection &proj = workload.fbPairs[projIndices.fbPairIndex].projections[projIndices.projectionIndex];
++                for (uint32_t gc = 0; gc < proj.gameCallCount; gc++) {
++                    const GameCall &call = proj.gameCalls[gc];
++                    for (uint32_t m = call.callDesc.minWorldMatrix; m <= call.callDesc.maxWorldMatrix; m++) {
++                        uint32_t &count = transformTriCount[m];
++                        count = std::max(count, call.callDesc.triangleCount);
++                    }
++                }
++            }
++
++            uint32_t unmappedCount = 0;
++            for (uint32_t curIndex : curCheckedSet) {
++                if (!firstCurWorkloadMap.transforms[curIndex].mapped) {
++                    unmappedCount++;
++                    const hlslpp::float4x4 &m = firstCurWorkload.drawData.worldTransforms[curIndex];
++                    const float curDet = hlslpp::determinant(extract3x3(m));
++
++                    // Classify why every candidate pairing of this transform failed.
++                    uint32_t detRejected = 0, prevStolen = 0, totalPairs = 0;
++                    for (const IndexPair &indices : transformCheckSet) {
++                        if (indices.first != curIndex) {
++                            continue;
++                        }
++
++                        totalPairs++;
++                        const hlslpp::float4x4 &prevM = firstPrevWorkload.drawData.worldTransforms[indices.second];
++                        const float prevDet = hlslpp::determinant(extract3x3(prevM));
++                        if ((curDet * prevDet) < 0.0f) {
++                            detRejected++;
++                        }
++                        else if (firstCurWorkloadMap.prevTransformsMapped[indices.second]) {
++                            prevStolen++;
++                        }
++                    }
++
++                    fprintf(stderr, "[match] ms%llu c%u UNMAPPED t%u pos(%.1f %.1f %.1f) det=%.3f tris=%u pairs=%u detRej=%u stolen=%u\n",
++                        (unsigned long long)debugMs, matchDebugCall, curIndex, (float)m[3].x, (float)m[3].y, (float)m[3].z,
++                        curDet, transformTriCount.count(curIndex) ? transformTriCount[curIndex] : 0,
++                        totalPairs, detRejected, prevStolen);
++                }
++            }
++
++            if (unmappedCount > 0) {
++                fprintf(stderr, "[match] ms%llu c%u checked=%u unmapped=%u candidates=%u\n",
++                    (unsigned long long)debugMs, matchDebugCall, uint32_t(curCheckedSet.size()), unmappedCount, uint32_t(matchCandidates.size()));
++            }
++
++            for (uint32_t curIndex : curCheckedSet) {
++                const GameFrameMap::TransformMap &map = firstCurWorkloadMap.transforms[curIndex];
++                if (!map.mapped) {
++                    continue;
++                }
++
++                const hlslpp::float4x4 &curM = firstCurWorkload.drawData.worldTransforms[curIndex];
++                const hlslpp::float4x4 &prevM = firstPrevWorkload.drawData.worldTransforms[map.prevTransformIndex];
++                const float rawPosDelta = hlslpp::length(curM[3].xyz - prevM[3].xyz);
++                const uint32_t tris = transformTriCount.count(curIndex) ? transformTriCount[curIndex] : 0;
++                // Level 1: only anomalies on substantial meshes. Level 2: everything.
++                const bool anomaly = (rawPosDelta > 1.2f) && (tris >= 10);
++                if ((matchDebugLevel > 1) || anomaly) {
++                    fprintf(stderr, "[match] ms%llu c%u t%u<-p%u posDelta=%.2f tris=%u cur(%.1f %.1f %.1f) prev(%.1f %.1f %.1f)\n",
++                        (unsigned long long)debugMs, matchDebugCall, curIndex, map.prevTransformIndex, rawPosDelta, tris,
++                        (float)curM[3].x, (float)curM[3].y, (float)curM[3].z,
++                        (float)prevM[3].x, (float)prevM[3].y, (float)prevM[3].z);
++                }
++            }
++        }
++
+         if (!modifiedBuffers.empty()) {
+             workloadsModified[firstCurProjIndices.workloadIndex].merge(modifiedBuffers);
+         }


### PR DESCRIPTION
Fixes #30.

## Root cause (measured, not guessed)

RT64's frame interpolator pairs each object transform in frame N with one from frame N-1. Candidate pairs are ranked by position + orientation + screen-space difference and assigned greedily (`rt64_game_frame.cpp`). The matcher predicts **position** using the tracked per-transform linear velocity, but compares **orientation raw**.

A wheel spinning faster than ~120°/frame therefore scores its *own* previous transform worse than the phase-aliased wheel on the other axle (wagon-wheel aliasing: the rear wheel one frame ago looks orientation-identical to the front wheel now). Once the axle swap wins, it is **self-sustaining**: the per-transform rigid body learns a linear velocity of wheelbase+travel per frame with zero rotation — a self-consistent phantom that predicts the next swapped match exactly.

Under interpolated presentation the front wheel then lerps in from ~a wheelbase behind and the rear wheel from ahead — wheels render detached from the arches, worst face-on because the screen-space term (which would otherwise penalise the swap) collapses when the wheel axis lies along the camera ray. Captured live with `RT64_MATCH_DEBUG=1` during the attract demo race:

```
[match] c749 t8<-p10  posDelta=3.60 tris=13   # front wheel <- rear wheel's previous
[match] c749 t10<-p8  posDelta=1.28 tris=13   # rear wheel <- front wheel's previous
```

sustained for seconds at a time (334 reciprocal swap pairs in a 200 s run).

## Fix

`patches/0006-rt64-interp-angular-velocity-matching.patch` — discount the rotation predicted by the already-tracked angular velocity in the orientation term, exactly mirroring the linear-velocity prediction applied to position. For a rotation of angle *a* about any axis the basis-vector metric measures exactly 2(1−cos a) (trace invariance), so the discount is exact. Transforms with no rotation history behave as before.

Applied at build time like the other submodule patches (BUILDING.md step 2 + both CI build jobs — it is platform-independent, unlike 0005).

## Verification

The attract demo is deterministic, so before/after logs are frame-aligned. At the same call number where the swap locked in before (c746+), all four wheels now match themselves with posDelta equal to the car body's per-frame travel. Reciprocal wheel-class swaps at normal frame pacing: **continuous → zero** (residual pairs only inside artificially degraded ~2.5 fps segments caused by GPU contention on the test box). Full boot → menu → demo-race cycle smoke-tested with interpolation active (`presented=2`), no unmapped-transform regression.

Also included: env-gated matcher diagnostics (`RT64_MATCH_DEBUG=1` anomalies / `=2` verbose) that found and verified this — zero cost when unset.

Known separate issue kept out of scope: ground skid/shadow decals (2–4 tri, det=0) churn between left/right sides in the same matcher (posDelta 1.80 cross-matches + orphaned new segments); far less visible than the wheels.