### PR TITLE
Fix Controller Pak TOC checksum (#31)

### DIFF
--- a/src/libultra_stubs.c
+++ b/src/libultra_stubs.c
@@ -129,11 +129,18 @@ static void lambo_pak_format(void) {
         img[base + 0x1C] = (uint8_t)(checksum >> 8); img[base + 0x1D] = (uint8_t)checksum;
         img[base + 0x1E] = (uint8_t)(inverted >> 8); img[base + 0x1F] = (uint8_t)inverted;
     }
+    /* TOC checksum (#31 follow-up): an 8-bit sum of ONLY the low byte of each inode word for
+     * slots 5..127 (BLOCK_EMPTY markers), NOT a sum over the whole 256-byte sector -- verified
+     * against libdragon's __get_toc_checksum (src/joybus/mempak.c), the reference SDK-compatible
+     * Controller Pak filesystem implementation. Getting this wrong makes the game's own
+     * osPfsInitPak-equivalent (func_8007A8A0) classify a freshly-formatted pak as
+     * PFS_ERR_INVALID (return code 4) -- ID area valid, TOC "corrupted" -- which is exactly the
+     * unrepairable "repair controller pak?" loop this was causing. */
     for (page = 1; page <= 2; page++) {
-        uint8_t ck = 0;
-        for (slot = 5; slot < 128; slot++) img[0x100 * page + slot * 2 + 0x01] = 0x03;
-        for (i = 2; i < 0x100; i++) ck = (uint8_t)(ck + img[0x100 * 1 + i]);
-        img[0x100 * page + 0x01] = ck;
+        uint32_t sum = 0;
+        for (slot = 0; slot < 128; slot++) img[0x100 * page + slot * 2 + 0x01] = 0x03;
+        for (i = 5; i < 128; i++) sum += img[0x100 * page + i * 2 + 0x01];
+        img[0x100 * page + 0x01] = (uint8_t)(sum & 0xFFu);
     }
 }
 


### PR DESCRIPTION
## Summary
- `lambo_pak_format()`'s inode/TOC checksum summed the whole 256-byte sector instead of just the low byte of each inode word for slots 5..127, per libdragon's reference `__get_toc_checksum`. That mismatch made the game's own `osPfsInitPak`-equivalent (`func_8007A8A0`) classify a freshly-formatted pak as `PFS_ERR_INVALID` on every boot, producing an unrepairable "Repair Controller Pak?" loop even though the ID area and everything else was already correctly formatted.
- Fixes #31.

## Test plan
- [x] Full clean build (submodules + recompile from ROM + `lamborghini_modern`) on this fix.
- [x] Booted repeatedly from a fresh (no `.mpk`) state: no "corrupted"/"repair" prompt appears; the game's own pak-scan (`func_8007A8A0`) now returns 0 (fully valid) instead of 4 (`PFS_ERR_INVALID`), verified via temporary call/return-value tracing.
- [x] State machine progresses cleanly through 0→3→4→5→6→7→8 with the fix in place; confirmed no regression vs. pre-fix boot behaviour otherwise.
- Follow-on: found that the in-game "save records" flow never actually issues a pak write (separate bug, tracked as #35) — not addressed by this PR.