### PR TITLE
Per-element widescreen HUD pinning (issue #2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/aspMain.cpp        # RSPRecomp'd audio microcode (M_AUDTASK PCM synthesis, #53).
                                # GENERATED: RSPRecomp aspMain.us.toml (see BUILDING.md step 3)
         src/libultra_stubs.c   # no-op symbols for ignored libultra CP0 helpers (e.g. __osSetSR)
+        src/lambo_hud_widescreen.c  # issue #2: gEXSetRectAlign brackets around the race-HUD dials
     )
     target_compile_options(lamborghini_modern PRIVATE
         -fno-strict-aliasing
@@ -167,6 +168,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
     # mirror Zelda64Recomp's include list for the game target.
     set(RT64_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/rt64)
     target_include_directories(lamborghini_modern PRIVATE
+        ${RT64_DIR}/include
         ${RT64_DIR}/src
         ${RT64_DIR}/src/rhi
         ${RT64_DIR}/src/render

--- a/docs/HUD.md
+++ b/docs/HUD.md
@@ -1,0 +1,96 @@
+# HUD architecture & widescreen pinning (issue #2 findings, 2026-07-05)
+
+Reference for anyone (human or LLM) touching HUD/2D rendering. Everything here was
+verified live against a driven 1P race (probe printfs in the recompiled C + decoded
+frame captures of the display list). Names are splat-style (`lamborghini.syms.toml`
+name space); runtime vram = splat − 0xC00.
+
+## The 2D pipeline
+
+- **DL write cursor: `0x800A39CC`** (runtime address). Every 2D helper allocates 8
+  bytes per command: load cursor, store cursor+8 back, write two words through the old
+  value. Native code can inject F3DEX (v1) commands at this cursor — this is the seam
+  the widescreen brackets use (`src/lambo_hud_widescreen.c`).
+- **Per-frame 2D dispatcher: `func_80050860`** (runtime 0x8004FC60), called each frame
+  by the game-logic state machine `func_800030F8`. It is a mode-keyed wall of inline
+  draw sections: 1P race, 2P split (two variants), pause, results, etc.
+- The dispatcher's helpers (all take `(a0=data, a1=x, a2=y, ...)` with x,y in 320×240
+  coords): `func_8004CCB4` text/string, `func_8004D468` glyph/number,
+  `func_8004DB08` digit sequence, `func_8004C070` scaled text, `func_8005464C`
+  table-driven (x,y,idx) draw.
+
+## 1P race HUD element map (all verified live)
+
+| Element | Drawn by | Call site (jal, runtime) | Anchor |
+|---|---|---|---|
+| Speedo dial face + digital speed + gear | `func_80056318` (runtime 0x80055718) | `0x8004FF60`, args (0, x=0xDC, y=0x98, speed float) | right |
+| RANK label+value block | `func_800583B8` (0x800577B8) | `0x8004FF88`, (val, x=0x118, y=0x13) | right |
+| LAP label+values block | `func_80058464` (0x80057864) | `0x8004FFA0`, (vals, x=0x28, y=0x13); draws label at x+2, values at x−0x10/x/x+0x10 | left |
+| TIME label+value | `func_8004CCB4` pair at `0x800503E8`/`0x80050414` (x=0xA0) | centered — needs no pinning |
+| Speedo NEEDLE | geometry built INSIDE `func_80056318`: one `G_MTX LOAD\|MODELVIEW` (word0 `0x01020040`) + rotation MULs + static DL; pivot trans ≈ (1000, −690) model units | right (via matrix nudge, see below) |
+| Minimap track outline | polyline geometry, drawn elsewhere in the frame (2D ortho section starting ~`DL 0x8011EFD8`), untagged | centered (unpinned) |
+| Minimap car dots + P1 label + player arrow | `func_80054FFC` (0x800543FC), jal `0x80050588`; a2/a3 = cos/sin of CAR HEADING (arrow rotation); dots are 2×2 texrects, arrow is 2 quads via matrices | centered (unpinned, must stay with map) |
+| Top translucent bar | static DL `0x80167170` (one 296×6 texrect, teal prim color) via projection MTX at `0x800A2C40` | centered |
+| Lens flare | alpha-0x0F/0x1E texrects drawn LAST in the frame | centered — game clips to 4:3, see follow-up |
+
+Traps discovered the hard way:
+- `func_800717E0` (0x80070BE0) is a DIAL ORCHESTRATOR for an **alternate dial style /
+  other modes** — it does NOT run in a normal 1P race (the 1P path branches around it
+  right after the needle/minimap call at `0x80050588`).
+- `func_80054FFC` looks speed-driven (cos/sin floats) but is the MINIMAP overlay, not
+  the needle. Pinning it detaches dots/arrow from the track outline.
+- `func_80058C48(a0=1..5, 160, 112)` correlates with gear but is a centered element
+  (draws in menus/other screens too) — not the needle.
+- 2P split is TOP/BOTTOM: sections at `0x80050CE8`/`0x80050D00` (y=0x10) and
+  `0x80050F2C`/`0x80050F44` (y=0x80) etc. RANK x=0x10E, LAP x=0x28 per half —
+  same left/right anchors as 1P, so the same pinning pattern applies (unhooked so far).
+
+## Injection mechanism (no MIPS patch pipeline needed)
+
+`[[patches.hook]]` in `lamborghini.us.toml` (`func`, `before_vram`, `text`) injects raw
+C text before the instruction at `before_vram` when N64Recomp emits the function
+(vendored N64Recomp `recompilation.cpp:129`). The text runs in the recompiled function
+scope (`rdram`, `ctx` available; implicit declaration links against natives).
+Rules:
+- `before_vram` must not be a branch delay slot.
+- Place hooks BEFORE the game's cursor-allocation block for the following command
+  (the alloc pattern is ~5 instructions: `lw` cursor / `addiu +8` / `sw` / `sw` to
+  stack), or your injected commands land after the game's next command.
+- Regenerating RecompiledFuncs: `N64Recomp.exe lamborghini.us.toml` from repo root,
+  then delete `build/**/libRecompiledFuncs.a` before rebuilding.
+
+## RT64 extended-GBI facts (verified against lib/rt64 source + live)
+
+- Enable hook: `G_SPNOOP`(0x00 on F3DEX v1) with magic `0x525464`, w1 =
+  `(1<<28)|0x64`. Must be emitted before any `0x64` extended command; idempotent.
+- `gEXSetRectAlign` affects ONLY rects (texrects/fillrects). LEFT pin =
+  `(LEFT, LEFT, 0,0,0,0)`; RIGHT pin = `(RIGHT, RIGHT, -1280, 0, -1280, 0)`
+  (offsets are quarter-pixels; −1280 re-bases the 320-wide coordinate space);
+  reset = ORIGIN_NONE (0x800). At 4:3 output the math degenerates — no gating needed.
+- The game's own scissor is untagged, so RT64 centers it on 4:3 and CROPS moved rects.
+  Each bracket must push + set a full-width extended scissor
+  (`gEXSetScissor(0, LEFT, RIGHT, 0,0, 0,240)`) and pop on reset.
+- **Never wrap a GEOMETRY draw in a wide scissor**: the draw merges the wide scissor
+  into the fbPair scissor, flipping RT64's `coversWholeWidth` heuristic
+  (`rt64_framebuffer_renderer.cpp:1493`) for every untagged full-width-viewport
+  geometry in that frame — the minimap visibly squeezes toward center.
+- `gEXSetViewportAlign` with a non-NONE origin puts geometry on a squeezed
+  screen-scale path (not a pure translation) — unusable for matching a rect-pinned
+  element. Untagged full-width-viewport geometry renders on the STRETCHED path:
+  screen_x = game_x × wideWidth/320.
+- Geometry elements that must track a rect-pinned element are therefore moved in
+  GAME space (edit their modelview translation in RDRAM after the game builds it,
+  before the task is submitted). See the needle nudge in `lambo_hud_widescreen.c`:
+  walk the emitted DL between bracket cursors for `w0 == 0x01020040`, patch matrix
+  element [3][0] (int at byte 24, fraction at 0x44). Calibration (16:9, Clamp16x9):
+  needle units ≈ 0.065 game-px through the stretched path; +530 units lands the pivot
+  on the RIGHT-pinned dial hub. Gated by `lambo_ws_hud_widescreen_active()`.
+
+## Debug technique that finally worked
+
+Printf probes in the (git-ignored) generated `RecompiledFuncs/funcs_*.c` — insert at
+`RECOMP_FUNC void <fn>(` printing `ctx->r4..r7`, rebuild incrementally, drive a race,
+group stderr by line. To see actual DL bytes, dump RDRAM around the cursor from a
+native hook to a file and decode offline (F3DEX v1 decoder in session scratch;
+`tools/` has no committed copy — rederive from this table if needed). The stale
+region PAST the cursor is the previous frame's tail — same layout, already-complete.

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -329,3 +329,51 @@ ignored = [
 vram = 0x8005FA3C
 func = "func_80060464"
 value = 0x00000000
+
+# Issue #2 — per-element widescreen HUD (gEXSetRectAlign). The 1P race screen of the 2D
+# dispatcher func_80050860 draws three edge-anchored HUD elements back-to-back (verified
+# live 2026-07-05 by probing every 2D helper's (x,y) args during a driven race):
+#   jal 0x8004FF60 -> func_80056318 (runtime 0x80055718): speedometer dial at x=0xDC,
+#                     which internally also draws the digital speed + gear texrects
+#   jal 0x8004FF88 -> func_800583B8 (runtime 0x800577B8): RANK label+value block, x=0x118
+#   jal 0x8004FFA0 -> func_80058464 (runtime 0x80057864): LAP label+values block, x=0x28
+# Each jal is bracketed with a text hook that writes gEXEnable + gEXSetRectAlign
+# (RIGHT/LEFT pin, then ORIGIN_NONE reset) into the game DL through its cursor global
+# 0x800A39CC; natives in src/lambo_hud_widescreen.c. TIME stays centered (no tag needed
+# under RT64 Expand); the minimap is polyline/viewport-drawn, not texrects — pinning it
+# is a separate follow-up (rect-align cannot move it).
+[[patches.hook]]
+func = "func_80050860"
+before_vram = 0x8004FF60
+text = "lambo_ws_pin_right(rdram);"
+
+[[patches.hook]]
+func = "func_80050860"
+before_vram = 0x8004FF68
+text = "lambo_ws_pin_reset(rdram);"
+
+[[patches.hook]]
+func = "func_80050860"
+before_vram = 0x8004FF88
+text = "lambo_ws_pin_right(rdram);"
+
+[[patches.hook]]
+func = "func_80050860"
+before_vram = 0x8004FF90
+text = "lambo_ws_pin_reset(rdram);"
+
+[[patches.hook]]
+func = "func_80050860"
+before_vram = 0x8004FFA0
+text = "lambo_ws_pin_left(rdram);"
+
+[[patches.hook]]
+func = "func_80050860"
+before_vram = 0x8004FFA8
+text = "lambo_ws_pin_reset(rdram);"
+
+# The speedo NEEDLE (triangle geometry via a G_MTX chain built inside the dial drawer
+# func_80056318) is handled natively inside the existing dial bracket: pin records the
+# DL cursor and reset patches the needle's LOAD matrix translation (see
+# src/lambo_hud_widescreen.c). No extra hooks needed. func_80054FFC (minimap arrow +
+# car dots) is deliberately NOT bracketed — it must stay with the centered minimap.

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -166,10 +166,24 @@ ultramodern::renderer::GraphicsConfig default_graphics_config() {
     return cfg;
 }
 
+// Widescreen-HUD gate for src/lambo_hud_widescreen.c (issue #2): the rect pins use
+// RT64 origins and degenerate to a no-op at 4:3 on their own, but the needle's
+// game-space matrix nudge does not — it is calibrated for the shipped defaults
+// (Expand + Clamp16x9 on a >=16:9 output) and must be disabled for other configs.
+static int s_ws_hud_active = 0;
+
+extern "C" int lambo_ws_hud_widescreen_active(void) {
+    return s_ws_hud_active;
+}
+
 ultramodern::renderer::GraphicsConfig load_and_apply_graphics() {
     ultramodern::renderer::GraphicsConfig cfg = default_graphics_config();
     const std::filesystem::path path = graphics_json_path();
     const ReadResult r = read_graphics_file(path, cfg);
+
+    s_ws_hud_active =
+        cfg.ar_option == ultramodern::renderer::AspectRatio::Expand &&
+        cfg.hr_option == ultramodern::renderer::HUDRatioMode::Clamp16x9;
 
     ultramodern::renderer::set_graphics_config(cfg);
     // Write the merged config back so the on-disk file is always complete and

--- a/src/lambo_hud_widescreen.c
+++ b/src/lambo_hud_widescreen.c
@@ -1,0 +1,120 @@
+// Per-element widescreen HUD pinning (issue #2, RT64 extended GBI).
+//
+// Under `ar_option: Expand` RT64 renders untagged 2D centered in the 4:3 region, so the
+// race HUD's edge-anchored elements (LAP block left; RANK block + speedometer right)
+// float inboard of the widescreen edges. Peer ports (MM64 ui_patches.c, SK2
+// race_hud_widescreen.c) bracket each element's draw with gEXSetRectAlign; this repo has
+// no MIPS patch pipeline, so the brackets are injected as N64Recomp [[patches.hook]]
+// text (lamborghini.us.toml) around the three 1P-race draw calls in the 2D dispatcher
+// func_80050860, calling the natives below.
+//
+// The game's DL write cursor: 0x800A39CC (every 2D helper stores a command and advances
+// it by 8; verified in the recompiled emitters). Origins pin against RT64's widened
+// color image and travel is clamped by hr_option (default Clamp16x9); with a 4:3 output
+// the math degenerates to the original coordinates, so no config gating is needed.
+
+#include "recomp.h"
+#include "rt64_extended_gbi.h"
+
+#define LAMBO_DL_CURSOR 0x800A39CCu
+#define SCREEN_WIDTH_QP (320 * 4) /* gEXSetRectAlign offsets are quarter-pixels */
+
+// From src/lambo_config.cpp: true when the shipped widescreen defaults are active
+// (ar Expand + hr Clamp16x9). Gates only the needle matrix nudge; the rect-origin
+// pins degenerate to no-ops at 4:3 by construction.
+int lambo_ws_hud_widescreen_active(void);
+
+static gpr lambo_ws_bracket_start;
+
+static void emit_cmd(uint8_t* rdram, uint32_t w0, uint32_t w1) {
+    gpr curp = (gpr)(int32_t)LAMBO_DL_CURSOR;
+    gpr cur = MEM_W(0, curp);
+    MEM_W(0, cur) = (int32_t)w0;
+    MEM_W(4, cur) = (int32_t)w1;
+    MEM_W(0, curp) = (int32_t)(cur + 8);
+}
+
+static void emit_rect_align(uint8_t* rdram, uint32_t origin, int32_t xoff) {
+    // RT64 only honours extended opcodes after the enable hook; emit it every bracket
+    // (idempotent) since nothing else in this port enables the extended GBI.
+    emit_cmd(rdram,
+             PARAM(RT64_HOOK_OPCODE, 8, 24) | PARAM(RT64_HOOK_MAGIC_NUMBER, 24, 0),
+             PARAM(RT64_HOOK_OP_ENABLE, 4, 28) | PARAM(RT64_EXTENDED_OPCODE, 8, 0));
+    emit_cmd(rdram,
+             PARAM(RT64_EXTENDED_OPCODE, 8, 24) | PARAM(G_EX_SETRECTALIGN_V1, 24, 0),
+             PARAM(origin, 12, 0) | PARAM(origin, 12, 12));
+    emit_cmd(rdram,
+             PARAM(xoff, 16, 16) | PARAM(0, 16, 0),
+             PARAM(xoff, 16, 16) | PARAM(0, 16, 0));
+}
+
+static void pin(uint8_t* rdram, uint32_t origin, int32_t xoff) {
+    emit_rect_align(rdram, origin, xoff);
+    // The game's own scissor is untagged, so RT64 centers it on the 4:3 region and
+    // clips the moved element at the 4:3 edge. Bracket with a full-width scissor
+    // (ulx pinned LEFT at 0, lrx pinned RIGHT at 0 == the widened image's right edge),
+    // restored on reset (verified live: without this, LAP/RANK/dial render cropped).
+    emit_cmd(rdram,
+             PARAM(RT64_EXTENDED_OPCODE, 8, 24) | PARAM(G_EX_PUSHSCISSOR_V1, 24, 0),
+             0);
+    emit_cmd(rdram,
+             PARAM(RT64_EXTENDED_OPCODE, 8, 24) | PARAM(G_EX_SETSCISSOR_V1, 24, 0),
+             PARAM(0, 2, 0) | PARAM(G_EX_ORIGIN_LEFT, 12, 2) | PARAM(G_EX_ORIGIN_RIGHT, 12, 14));
+    emit_cmd(rdram,
+             PARAM(0, 16, 16) | PARAM(0, 16, 0),
+             PARAM(0, 16, 16) | PARAM(240 * 4, 16, 0));
+    lambo_ws_bracket_start = MEM_W(0, (gpr)(int32_t)LAMBO_DL_CURSOR);
+}
+
+void lambo_ws_pin_left(uint8_t* rdram) {
+    pin(rdram, G_EX_ORIGIN_LEFT, 0);
+}
+
+void lambo_ws_pin_right(uint8_t* rdram) {
+    // Rebase x to the right edge: movedFromOrigin adds the full image width, so the
+    // original 320-wide coordinate space is subtracted back out (peer-standard offset).
+    pin(rdram, G_EX_ORIGIN_RIGHT, -SCREEN_WIDTH_QP);
+}
+
+// The speedo NEEDLE is triangle geometry: func_80056318 (the dial drawer, inside the
+// RIGHT rect bracket) builds one G_MTX LOAD|MODELVIEW + rotation-MUL chain for the
+// needle quads. Rect-align moves only texrects, and RT64 renders this geometry on the
+// stretched-wide path (screen x = game x * wideWidth/320), so the needle is moved in
+// GAME space instead: each bracket records the DL cursor and the reset walks the
+// commands emitted in between, adding a translation to any LOAD matrix found (only the
+// dial bracket contains one). The minimap overlay func_80054FFC also builds matrices
+// but is deliberately not bracketed — its arrow/dots must stay with the centered map.
+//
+// Shift in the needle's model units, calibrated live against the RIGHT-pinned dial at
+// 16:9 (paused-race measurement 2026-07-05: pivot trans.x=1000 units; +300 units moved
+// the needle +98px at 1600-wide output; 530 centers it on the dial hub). Only valid
+// for the shipped Expand + Clamp16x9 defaults — gated above for anything else.
+#define LAMBO_WS_NEEDLE_DX 530.0f
+
+static void lambo_ws_patch_needle_mtx(uint8_t* rdram, gpr start, gpr end) {
+    if (!lambo_ws_hud_widescreen_active()) {
+        return;
+    }
+    for (gpr p = start; p + 8 <= end; p += 8) {
+        uint32_t w0 = (uint32_t)MEM_W(0, p);
+        if (w0 == 0x01020040u) { /* G_MTX LOAD|MODELVIEW, len 0x40 */
+            uint32_t seg = (uint32_t)MEM_W(4, p);
+            gpr mtx = (gpr)(int32_t)(0x80000000u | seg);
+            int32_t ip = (int16_t)MEM_H(24, mtx); /* translate.x = element 12 */
+            uint32_t fp = (uint16_t)MEM_HU(24 + 0x20, mtx);
+            int32_t fixed = (int32_t)(((uint32_t)ip << 16) | fp);
+            fixed += (int32_t)(LAMBO_WS_NEEDLE_DX * 65536.0f);
+            MEM_H(24, mtx) = (int16_t)(fixed >> 16);
+            MEM_HU(24 + 0x20, mtx) = (uint16_t)(fixed & 0xFFFF);
+        }
+    }
+}
+
+void lambo_ws_pin_reset(uint8_t* rdram) {
+    lambo_ws_patch_needle_mtx(rdram, lambo_ws_bracket_start,
+                              MEM_W(0, (gpr)(int32_t)LAMBO_DL_CURSOR));
+    emit_cmd(rdram,
+             PARAM(RT64_EXTENDED_OPCODE, 8, 24) | PARAM(G_EX_POPSCISSOR_V1, 24, 0),
+             0);
+    emit_rect_align(rdram, G_EX_ORIGIN_NONE, 0);
+}


### PR DESCRIPTION
Closes #2.

Pins the 1P race HUD to the 16:9 edges under RT64's Expand aspect mode, per the peer-port pattern (MM64 `ui_patches.c`, SK2 `race_hud_widescreen.c`):

- **LAP block** → left edge; **RANK block** and **speedometer** (dial face, digital speed, gear) → right edge.
- **TIME** and the **minimap** stay centered (correct as-is under Expand).
- The **needle** (triangle geometry built inside the dial drawer — rect-align can't move it) is translated in game space via a calibrated matrix nudge, gated to the shipped `Expand`+`Clamp16x9` config; the rect pins themselves degenerate to no-ops at 4:3 by construction.

**Mechanism** — this repo has no MIPS patch pipeline, so instead of patch C the brackets are injected with N64Recomp `[[patches.hook]]` text hooks around the three dispatcher draw calls, calling natives (`src/lambo_hud_widescreen.c`) that write `gEXEnable` + `gEXSetRectAlign` + a pushed full-width extended scissor (the game's untagged scissor otherwise crops moved elements) into the game's DL through its cursor global `0x800A39CC`.

All element→drawer attributions were verified live (probe printfs in the recompiled C + decoded DL captures during driven races, before/after screenshots at 16:9). The full HUD draw-path map and the RT64 extended-GBI pitfalls hit along the way (fbPair scissor poisoning, viewport-origin squeeze path) are documented in `docs/HUD.md`.

Follow-ups tracked separately: lens-flare 4:3 clipping, minimap edge-pinning, other modes' HUDs (time trial, 2P split).