### PR TITLE
Issue #41 - widescreen: pin the minimap (outline + dots + arrow + P1) to the left edge

### DIFF
--- a/docs/HUD.md
+++ b/docs/HUD.md
@@ -28,8 +28,8 @@ name space); runtime vram = splat − 0xC00.
 | LAP label+values block | `func_80058464` (0x80057864) | `0x8004FFA0`, (vals, x=0x28, y=0x13); draws label at x+2, values at x−0x10/x/x+0x10 | left |
 | TIME label+value | `func_8004CCB4` pair at `0x800503E8`/`0x80050414` (x=0xA0) | centered — needs no pinning |
 | Speedo NEEDLE | geometry built INSIDE `func_80056318`: one `G_MTX LOAD\|MODELVIEW` (word0 `0x01020040`) + rotation MULs + static DL; pivot trans ≈ (1000, −690) model units | right (via matrix nudge, see below) |
-| Minimap track outline | polyline geometry, drawn elsewhere in the frame (2D ortho section starting ~`DL 0x8011EFD8`), untagged | centered (unpinned) |
-| Minimap car dots + P1 label + player arrow | `func_80054FFC` (0x800543FC), jal `0x80050588`; a2/a3 = cos/sin of CAR HEADING (arrow rotation); dots are 2×2 texrects, arrow is 2 quads via matrices | centered (unpinned, must stay with map) |
+| Minimap track outline | 3D geometry via the RACE PERSPECTIVE projection, emitted by the frame-builder tail (splat `func_8004384C` flow): camera-space `translate(-2.05, -2.4, 0)` built by the `func_80075278` jal at `0x80043C88`, then static-Mtx/tilt MULs, then polyline emitter `func_80045BDC` (runtime 0x80044FDC). The menu track maps use a different routine — `func_80044E2C` (runtime 0x8004422C, x·5−800 ortho translate), 14 call sites, all menus. | left (issue #41: hook rewrites the translate x by −1.09 camera units, verified live; env `LAMBO_WS_MINIMAP_OUTLINE_DX` overrides) |
+| Minimap car dots + P1 label + player arrow | `func_80054FFC` (0x800543FC), jal `0x80050588`; a2/a3 = cos/sin of CAR HEADING (arrow rotation); dots are 2×2 texrects, arrow is 2 quads via pool `G_MTX LOAD`s whose translate is `((x−158)·10, (119−y)·10)` — exactly 10 units per game px | left (issue #41: LEFT bracket for the rects, −533-unit matrix shift for the arrow) |
 | Top translucent bar | static DL `0x80167170` (one 296×6 texrect, teal prim color) via projection MTX at `0x800A2C40` | centered |
 | Lens flare | alpha-0x0F/0x1E texrects drawn LAST in the frame | centered — game clips to 4:3, see follow-up |
 
@@ -76,15 +76,23 @@ Rules:
   geometry in that frame — the minimap visibly squeezes toward center.
 - `gEXSetViewportAlign` with a non-NONE origin puts geometry on a squeezed
   screen-scale path (not a pure translation) — unusable for matching a rect-pinned
-  element. Untagged full-width-viewport geometry renders on the STRETCHED path:
-  screen_x = game_x × wideWidth/320.
+  element. Untagged geometry renders WIDE (stretched viewport, projection used as-is)
+  only when its scissor∩viewport covers the full fbPair width AND origin is NONE
+  (`useWideViewport`, rt64_framebuffer_renderer.cpp:1493); otherwise RT64 squeezes it
+  back to the 4:3 center (`screenScale.x = 320/wideWidth`). The 2D ortho HUD section
+  (needle, minimap arrow) is on the SQUEEZED path — same 4:3-centered placement as
+  untagged rects. The 3D world (and the in-race minimap outline drawn through the race
+  perspective projection) is on the wide path, but Expand widens perspective FOV, so
+  fixed camera-space objects stay center-anchored at the 4:3 pixel scale.
 - Geometry elements that must track a rect-pinned element are therefore moved in
   GAME space (edit their modelview translation in RDRAM after the game builds it,
-  before the task is submitted). See the needle nudge in `lambo_hud_widescreen.c`:
-  walk the emitted DL between bracket cursors for `w0 == 0x01020040`, patch matrix
-  element [3][0] (int at byte 24, fraction at 0x44). Calibration (16:9, Clamp16x9):
-  needle units ≈ 0.065 game-px through the stretched path; +530 units lands the pivot
-  on the RIGHT-pinned dial hub. Gated by `lambo_ws_hud_widescreen_active()`.
+  before the task is submitted). See `lambo_hud_widescreen.c`: walk the emitted DL
+  between bracket cursors for `w0 == 0x01020040`, patch matrix element [3][0] (int at
+  byte 24, fraction at 0x44). On the squeezed 2D path the required travel at 16:9
+  Clamp16x9 is (wideW − H·4/3)/2 screen px = 160/3 game px; the 2D matrices use 10
+  units per game px, so |Δ| ≈ 533 units (the needle's live-calibrated +530 matches
+  this analytic value — the old "≈0.065 game-px/unit" note was a misreading of a rough
+  screenshot measurement). Gated by `lambo_ws_hud_widescreen_active()`.
 
 ## Debug technique that finally worked
 

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -375,5 +375,29 @@ text = "lambo_ws_pin_reset(rdram);"
 # The speedo NEEDLE (triangle geometry via a G_MTX chain built inside the dial drawer
 # func_80056318) is handled natively inside the existing dial bracket: pin records the
 # DL cursor and reset patches the needle's LOAD matrix translation (see
-# src/lambo_hud_widescreen.c). No extra hooks needed. func_80054FFC (minimap arrow +
-# car dots) is deliberately NOT bracketed — it must stay with the centered minimap.
+# src/lambo_hud_widescreen.c). No extra hooks needed.
+
+# Issue #41 — pin the 1P minimap composite to the left edge. Three pieces:
+#   dots + P1 label: texrects from the overlay func_80054FFC (jal 0x80050588 in the 1P
+#     race section) — LEFT rect-align bracket, same mechanism as LAP/RANK above;
+#   player arrow: two quads via pool G_MTX LOADs built inside the same overlay call —
+#     the bracket reset shifts their translation in game space (same walker as the
+#     needle, different delta);
+#   track outline: 3D geometry drawn by the frame builder func_8004384C through the
+#     race perspective projection; its placement translate(-2.05, -2.4, 0) is built by
+#     the jal at 0x80043C88 — hook rewrites the x argument ($a1 float bits) in flight,
+#     gated to frames where the 1P bracket ran (see lambo_ws_minimap_outline_x).
+[[patches.hook]]
+func = "func_80050860"
+before_vram = 0x80050588
+text = "lambo_ws_minimap_pin(rdram);"
+
+[[patches.hook]]
+func = "func_80050860"
+before_vram = 0x80050590
+text = "lambo_ws_minimap_reset(rdram);"
+
+[[patches.hook]]
+func = "func_8004384C"
+before_vram = 0x80043C88
+text = "extern unsigned int lambo_ws_minimap_outline_x(unsigned int); ctx->r5 = S32(lambo_ws_minimap_outline_x((uint32_t)ctx->r5));"

--- a/src/lambo_hud_widescreen.c
+++ b/src/lambo_hud_widescreen.c
@@ -13,6 +13,8 @@
 // color image and travel is clamped by hr_option (default Clamp16x9); with a 4:3 output
 // the math degenerates to the original coordinates, so no config gating is needed.
 
+#include <stdlib.h>
+
 #include "recomp.h"
 #include "rt64_extended_gbi.h"
 
@@ -76,22 +78,25 @@ void lambo_ws_pin_right(uint8_t* rdram) {
     pin(rdram, G_EX_ORIGIN_RIGHT, -SCREEN_WIDTH_QP);
 }
 
-// The speedo NEEDLE is triangle geometry: func_80056318 (the dial drawer, inside the
-// RIGHT rect bracket) builds one G_MTX LOAD|MODELVIEW + rotation-MUL chain for the
-// needle quads. Rect-align moves only texrects, and RT64 renders this geometry on the
-// stretched-wide path (screen x = game x * wideWidth/320), so the needle is moved in
-// GAME space instead: each bracket records the DL cursor and the reset walks the
-// commands emitted in between, adding a translation to any LOAD matrix found (only the
-// dial bracket contains one). The minimap overlay func_80054FFC also builds matrices
-// but is deliberately not bracketed — its arrow/dots must stay with the centered map.
+// HUD geometry (needle, minimap arrow) renders through the game's 2D ortho section,
+// which RT64 places on the 4:3-centered path (screenScale.x = 320/wideWidth when the
+// draw's scissor∩viewport does not cover the widened framebuffer, see
+// rt64_framebuffer_renderer.cpp:1493) — rect-align moves only texrects, so geometry
+// that must track a pinned rect element is moved in GAME space instead: each bracket
+// records the DL cursor and the reset walks the commands emitted in between, adding a
+// translation to any LOAD matrix found. Both the needle and the minimap arrow build
+// their matrices at 10 units per game pixel (the ortho convention of func_80075278),
+// and a pinned rect travels (wideWidth - height*4/3)/2 screen px = 160/3 game px at
+// the shipped 16:9 Clamp16x9 defaults, so the magnitude is ~533 units either way.
 //
-// Shift in the needle's model units, calibrated live against the RIGHT-pinned dial at
-// 16:9 (paused-race measurement 2026-07-05: pivot trans.x=1000 units; +300 units moved
-// the needle +98px at 1600-wide output; 530 centers it on the dial hub). Only valid
-// for the shipped Expand + Clamp16x9 defaults — gated above for anything else.
+// Needle: calibrated live against the RIGHT-pinned dial at 16:9 (2026-07-05: 530
+// centers it on the dial hub — matching the analytic 533 to measurement precision).
+// Only valid for the shipped Expand + Clamp16x9 defaults — gated above for anything
+// else.
 #define LAMBO_WS_NEEDLE_DX 530.0f
+#define LAMBO_WS_MINIMAP_ARROW_DX (-1600.0f / 3.0f) /* -53.33 game px * 10 units/px */
 
-static void lambo_ws_patch_needle_mtx(uint8_t* rdram, gpr start, gpr end) {
+static void patch_load_mtx_dx(uint8_t* rdram, gpr start, gpr end, float dx_units) {
     if (!lambo_ws_hud_widescreen_active()) {
         return;
     }
@@ -103,7 +108,7 @@ static void lambo_ws_patch_needle_mtx(uint8_t* rdram, gpr start, gpr end) {
             int32_t ip = (int16_t)MEM_H(24, mtx); /* translate.x = element 12 */
             uint32_t fp = (uint16_t)MEM_HU(24 + 0x20, mtx);
             int32_t fixed = (int32_t)(((uint32_t)ip << 16) | fp);
-            fixed += (int32_t)(LAMBO_WS_NEEDLE_DX * 65536.0f);
+            fixed += (int32_t)(dx_units * 65536.0f);
             MEM_H(24, mtx) = (int16_t)(fixed >> 16);
             MEM_HU(24 + 0x20, mtx) = (uint16_t)(fixed & 0xFFFF);
         }
@@ -111,10 +116,59 @@ static void lambo_ws_patch_needle_mtx(uint8_t* rdram, gpr start, gpr end) {
 }
 
 void lambo_ws_pin_reset(uint8_t* rdram) {
-    lambo_ws_patch_needle_mtx(rdram, lambo_ws_bracket_start,
-                              MEM_W(0, (gpr)(int32_t)LAMBO_DL_CURSOR));
+    patch_load_mtx_dx(rdram, lambo_ws_bracket_start,
+                      MEM_W(0, (gpr)(int32_t)LAMBO_DL_CURSOR), LAMBO_WS_NEEDLE_DX);
     emit_cmd(rdram,
              PARAM(RT64_EXTENDED_OPCODE, 8, 24) | PARAM(G_EX_POPSCISSOR_V1, 24, 0),
              0);
     emit_rect_align(rdram, G_EX_ORIGIN_NONE, 0);
+}
+
+// Minimap composite (issue #41): the 1P dispatcher's jal to the overlay func_80054FFC
+// (car dots + P1 label texrects, player arrow = two quads via pool LOAD matrices) is
+// bracketed LEFT; the reset shifts the arrow matrices in game space to match. The
+// track OUTLINE is separate: 3D geometry drawn by the per-frame builder func_8004384C
+// through the race PERSPECTIVE projection (center-anchored under RT64 Expand's FOV
+// widening), placed by a camera-space translate(-2.05, -2.4, 0) built at 0x80043C88 —
+// a hook there rewrites the x argument in flight. Camera units -> screen px depends
+// on that projection; -1.09 verified live 2026-07-05 (1600x900 Expand+Clamp16x9,
+// arcade race: dots and P1 sit on the outline). Env LAMBO_WS_MINIMAP_OUTLINE_DX
+// (float, camera units, negative = further left) overrides for recalibration.
+#define LAMBO_WS_MINIMAP_OUTLINE_DX -1.09f
+
+// The frame builder also runs in modes whose dots are not pinned yet (#42: 2P split;
+// demo race has no HUD). Key the outline shift off the 1P bracket actually running:
+// the builder draws before the dispatcher each frame, so it sees the previous frame's
+// flag (one unshifted frame on race entry, decays within 3 frames after exit).
+static int lambo_ws_minimap_1p_frames;
+
+void lambo_ws_minimap_pin(uint8_t* rdram) {
+    lambo_ws_minimap_1p_frames = 3;
+    lambo_ws_pin_left(rdram);
+}
+
+void lambo_ws_minimap_reset(uint8_t* rdram) {
+    patch_load_mtx_dx(rdram, lambo_ws_bracket_start,
+                      MEM_W(0, (gpr)(int32_t)LAMBO_DL_CURSOR),
+                      LAMBO_WS_MINIMAP_ARROW_DX);
+    emit_cmd(rdram,
+             PARAM(RT64_EXTENDED_OPCODE, 8, 24) | PARAM(G_EX_POPSCISSOR_V1, 24, 0),
+             0);
+    emit_rect_align(rdram, G_EX_ORIGIN_NONE, 0);
+}
+
+uint32_t lambo_ws_minimap_outline_x(uint32_t x_bits) {
+    if (!lambo_ws_hud_widescreen_active() || lambo_ws_minimap_1p_frames <= 0) {
+        return x_bits;
+    }
+    lambo_ws_minimap_1p_frames--;
+    float dx = LAMBO_WS_MINIMAP_OUTLINE_DX;
+    const char* env = getenv("LAMBO_WS_MINIMAP_OUTLINE_DX");
+    if (env != NULL) {
+        dx = (float)atof(env);
+    }
+    union { uint32_t u; float f; } x;
+    x.u = x_bits;
+    x.f += dx;
+    return x.u;
 }

--- a/tools/drive_input.py
+++ b/tools/drive_input.py
@@ -1,0 +1,95 @@
+"""Drive the running lamborghini_modern window without a human: post key events and
+capture screenshots. Lets a headless session navigate the menus into a REAL race
+(attract/demo draws no HUD, so HUD work needs this).
+
+SendInput does NOT reach the SDL window even when focused on this box; PostMessage
+WM_KEYDOWN/WM_KEYUP straight to the HWND works (SDL2 translates them by scancode)
+and needs no focus at all. PrintWindow(PW_RENDERFULLCONTENT) captures occluded.
+
+Usage (window must already be running):
+  python tools/drive_input.py find                  -> HWND + title, exit 1 if absent
+  python tools/drive_input.py shot out.png          -> screenshot client area
+  python tools/drive_input.py press <key>[,key] <ms>-> hold key(s) for ms
+Keys: x(=A) c(=B) z(=Z) enter(=Start) up down left right (stick)
+
+Proven route to a 1P arcade race from attract (wait ~2.5s between presses, longer
+after the pak message): enter, enter, x (ONE PLAYER), x (ARCADE), x (BASIC SERIES),
+x (car SELECT), x (name DONE), x (pak message OK) -> race loads in ~10 s.
+"""
+import ctypes, ctypes.wintypes as wt, sys, time
+
+user32 = ctypes.windll.user32
+gdi32 = ctypes.windll.gdi32
+
+VK = {'x': 0x58, 'c': 0x43, 'z': 0x5A, 'enter': 0x0D,
+      'up': 0x26, 'down': 0x28, 'left': 0x25, 'right': 0x27}
+SC = {'x': 0x2D, 'c': 0x2E, 'z': 0x2C, 'enter': 0x1C,
+      'up': 0x48, 'down': 0x50, 'left': 0x4B, 'right': 0x4D}
+EXTENDED = {'up', 'down', 'left', 'right'}
+
+
+def find_window():
+    hwnds = []
+    def cb(h, l):
+        buf = ctypes.create_unicode_buffer(256)
+        user32.GetWindowTextW(h, buf, 256)
+        if 'amborghini' in buf.value and user32.IsWindowVisible(h):
+            hwnds.append((h, buf.value))
+        return True
+    user32.EnumWindows(ctypes.WINFUNCTYPE(ctypes.c_bool, wt.HWND, wt.LPARAM)(cb), 0)
+    return hwnds[0] if hwnds else (None, None)
+
+
+def press(h, keys, ms):
+    for k in keys:
+        ext = (1 << 24) if k in EXTENDED else 0
+        user32.PostMessageW(h, 0x0100, VK[k], 1 | (SC[k] << 16) | ext)
+    time.sleep(ms / 1000.0)
+    for k in keys:
+        ext = (1 << 24) if k in EXTENDED else 0
+        user32.PostMessageW(h, 0x0101, VK[k],
+                            1 | (SC[k] << 16) | ext | (1 << 30) | (1 << 31))
+    time.sleep(0.15)
+
+
+def shot(h, path):
+    rect = wt.RECT()
+    user32.GetClientRect(h, ctypes.byref(rect))
+    w, hgt = rect.right, rect.bottom
+    hdc = user32.GetDC(h)
+    mdc = gdi32.CreateCompatibleDC(hdc)
+    bmp = gdi32.CreateCompatibleBitmap(hdc, w, hgt)
+    gdi32.SelectObject(mdc, bmp)
+    user32.PrintWindow(h, mdc, 3)  # PW_RENDERFULLCONTENT | PW_CLIENTONLY
+
+    class BMIH(ctypes.Structure):
+        _fields_ = [("sz", wt.DWORD), ("w", ctypes.c_long), ("h", ctypes.c_long),
+                    ("planes", wt.WORD), ("bpp", wt.WORD), ("comp", wt.DWORD),
+                    ("szImg", wt.DWORD), ("xppm", ctypes.c_long),
+                    ("yppm", ctypes.c_long), ("clrUsed", wt.DWORD),
+                    ("clrImp", wt.DWORD)]
+
+    bi = BMIH(ctypes.sizeof(BMIH), w, -hgt, 1, 32, 0, 0, 0, 0, 0, 0)
+    buf = ctypes.create_string_buffer(w * hgt * 4)
+    gdi32.GetDIBits(mdc, bmp, 0, hgt, buf, ctypes.byref(bi), 0)
+    from PIL import Image
+    Image.frombuffer('RGBA', (w, hgt), buf, 'raw', 'BGRA', 0, 1).convert('RGB').save(path)
+    gdi32.DeleteObject(bmp)
+    gdi32.DeleteDC(mdc)
+    user32.ReleaseDC(h, hdc)
+    print(f"saved {path} {w}x{hgt}")
+
+
+if __name__ == '__main__':
+    cmd = sys.argv[1]
+    h, title = find_window()
+    if cmd == 'find':
+        print(h, title)
+        sys.exit(0 if h else 1)
+    if not h:
+        print("window not found")
+        sys.exit(1)
+    if cmd == 'shot':
+        shot(h, sys.argv[2])
+    elif cmd == 'press':
+        press(h, sys.argv[2].split(','), int(sys.argv[3]))


### PR DESCRIPTION
﻿Closes #41. Follow-up to #2 (PR #39), which deliberately left the minimap centered.

## What moves, and how

| Piece | Drawn by | Mechanism |
|---|---|---|
| Car dots + P1 label | texrects from overlay `func_80054FFC` (jal `0x80050588`, 1P section) | LEFT `gEXSetRectAlign` bracket — same pattern as LAP/RANK |
| Player arrow | two quads via pool `G_MTX LOAD`s in the same overlay | bracket reset patches translate x by **−533 units** in game space |
| Track outline | 3D geometry from frame-builder `func_8004384C` through the race perspective projection | hook at the translate build (`0x80043C88`) shifts x by **−1.09 camera units** |

The outline shift is gated to frames where the 1P bracket actually ran, so menus / 2P split / demo race are untouched (other modes are #42). Everything sits behind the existing `lambo_ws_hud_widescreen_active()` gate; at 4:3 output the rect pins degenerate and the game-space nudges are disabled.

## Why the arrow constant is analytic, not calibrated

Reading RT64''s `useWideViewport` heuristic resolved the #2-session mystery: the 2D ortho HUD geometry is on the **squeezed 4:3-centered** path, not the stretched one, and the overlay builds its matrices at exactly 10 units per game px (`func_80075278(mtx, (x-158)*10, (119-y)*10, 0)`). A pinned rect travels 160/3 game px at 16:9, so the arrow needs 533 units — and the needle''s live-calibrated +530 from PR #39 matches that analytic value, confirming the model. `docs/HUD.md` is updated accordingly (including the outline/menu-map emitter map: the 14 `func_80044E2C` call sites are all menu screens; the in-race outline comes from the frame-builder tail).

## Verification

Live 1600×900 arcade race (Expand + Clamp16x9): the composite hugs the left edge and the dots/P1 sit exactly on the outline. Reached the race **headlessly** with the new `tools/drive_input.py` (PostMessage key injection + PrintWindow capture — SendInput never reaches the SDL window on this box); the proven menu route is documented in its docstring.