### PR TITLE
Fix release build #28756976030 — gate ROM-derived artifacts; defensive submodule reset

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -73,12 +73,22 @@ jobs:
           cp "rom-assets/$ROM_FILENAME" "./$ROM_FILENAME"
           rm -rf rom-assets
 
+      - name: Reset submodules before patching
+        # Defensive: a previous run that patched partially would otherwise
+        # leave 0005 failing with "patch failed: ... rt64_optimus.cpp:8".
+        run: |
+          git -C lib/N64ModernRuntime checkout -- .
+          git -C lib/rt64 checkout -- .
+          git -C lib/rt64/src/contrib/plume checkout -- .
+
       - name: Apply runtime patch
         run: |
           git -C lib/N64ModernRuntime apply "$(pwd)/patches/0001-lamborghini-runtime-scheduler-audio-vi.patch"
           git -C lib/rt64 apply "$(pwd)/patches/0006-rt64-interp-angular-velocity-matching.patch"
 
       - name: Configure + build recompiler CLIs
+        # First configure runs before N64Recomp/RSPRecomp generate sources;
+        # the second configure below (after recompile) wires those in.
         run: |
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
@@ -88,6 +98,11 @@ jobs:
         run: |
           ./build/lib/N64ModernRuntime/librecomp/N64Recomp/N64Recomp lamborghini.us.toml
           ./build/lib/N64ModernRuntime/librecomp/N64Recomp/RSPRecomp aspMain.us.toml
+
+      - name: Re-configure CMake to pick up generated sources
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
 
       - name: Build port
         run: cmake --build build --target lamborghini_modern -j"$(nproc)"
@@ -161,6 +176,18 @@ jobs:
           Copy-Item "rom-assets\$env:ROM_FILENAME" ".\$env:ROM_FILENAME"
           Remove-Item -Recurse -Force rom-assets
 
+      - name: Reset submodules before patching
+        shell: pwsh
+        # Defensive: a previous run that patched partially would otherwise
+        # leave 0005 failing with "patch failed: ... rt64_optimus.cpp:8".
+        # autocrlf=false also neutralises CRLF the Windows runner's git
+        # might inject.
+        run: |
+          git config --global core.autocrlf false
+          git -C lib/N64ModernRuntime checkout -- .
+          git -C lib/rt64 checkout -- .
+          git -C lib/rt64/src/contrib/plume checkout -- .
+
       - name: Apply patches
         shell: pwsh
         run: |
@@ -172,6 +199,8 @@ jobs:
 
       - name: Configure + build recompiler CLIs
         shell: pwsh
+        # First configure runs before N64Recomp/RSPRecomp generate sources;
+        # the second configure below (after recompile) wires those in.
         run: |
           cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release `
             -DCMAKE_C_COMPILER=gcc.exe -DCMAKE_CXX_COMPILER=g++.exe
@@ -182,6 +211,12 @@ jobs:
         run: |
           & ".\build\lib\N64ModernRuntime\librecomp\N64Recomp\N64Recomp.exe" lamborghini.us.toml
           & ".\build\lib\N64ModernRuntime\librecomp\N64Recomp\RSPRecomp.exe" aspMain.us.toml
+
+      - name: Re-configure CMake to pick up generated sources
+        shell: pwsh
+        run: |
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_C_COMPILER=gcc.exe -DCMAKE_CXX_COMPILER=g++.exe
 
       - name: Build port
         shell: pwsh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,29 +105,36 @@ add_subdirectory(${N64MR})
 # (resolved relative to each TU in RecompiledFuncs/), and lookup.cpp is picked
 # up by the *.cpp glob. recomp_overlays.inl is an include (NOT a TU) and is
 # intentionally excluded by the *.c/*.cpp globs.
-add_library(RecompiledFuncs STATIC)
-
+#
+# Skipped when empty so the first configure (which builds the recompiler
+# tools) succeeds before N64Recomp populates this directory.
 file(GLOB FUNC_C_SOURCES   CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/RecompiledFuncs/*.c)
 file(GLOB FUNC_CXX_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/RecompiledFuncs/*.cpp)
-target_sources(RecompiledFuncs PRIVATE ${FUNC_C_SOURCES} ${FUNC_CXX_SOURCES})
+if(FUNC_C_SOURCES OR FUNC_CXX_SOURCES)
+    add_library(RecompiledFuncs STATIC)
+    target_sources(RecompiledFuncs PRIVATE ${FUNC_C_SOURCES} ${FUNC_CXX_SOURCES})
 
-target_compile_options(RecompiledFuncs PRIVATE
-    -fno-strict-aliasing
-    -ggdb
-    -Wno-unused-variable
-    # implicit-function-declaration is a C-only diagnostic; lookup.cpp is C++.
-    $<$<COMPILE_LANGUAGE:C>:-Wno-implicit-function-declaration>
-)
+    target_compile_options(RecompiledFuncs PRIVATE
+        -fno-strict-aliasing
+        -ggdb
+        -Wno-unused-variable
+        # implicit-function-declaration is a C-only diagnostic; lookup.cpp is C++.
+        $<$<COMPILE_LANGUAGE:C>:-Wno-implicit-function-declaration>
+    )
 
-target_include_directories(RecompiledFuncs PRIVATE
-    ${N64MR}/ultramodern/include
-    ${N64MR}/librecomp/include
-    ${N64MR}/N64Recomp/include
-)
+    target_include_directories(RecompiledFuncs PRIVATE
+        ${N64MR}/ultramodern/include
+        ${N64MR}/librecomp/include
+        ${N64MR}/N64Recomp/include
+    )
+endif()
 
 # --- Headless harness (#57): added once src/ exists ---------------------------
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
-    add_executable(lamborghini_modern
+    # src/aspMain.cpp is RSPRecomp output (see BUILDING.md step 3); appended
+    # only when present so the first configure (which builds the recompilers)
+    # can succeed before RSPRecomp runs.
+    set(LAMBO_SOURCES
         src/main.cpp
         src/register_overlays.cpp
         src/stub_renderer.cpp
@@ -137,11 +144,14 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
                                # POSIX sigaction handler printing KSEG0/RDRAM offset + a 32-entry
                                # function-lookup trace ring. No deps beyond libc + DbgHelp (Win) /
                                # libc backtrace(3) (POSIX).
-        src/aspMain.cpp        # RSPRecomp'd audio microcode (M_AUDTASK PCM synthesis, #53).
-                               # GENERATED: RSPRecomp aspMain.us.toml (see BUILDING.md step 3)
         src/libultra_stubs.c   # no-op symbols for ignored libultra CP0 helpers (e.g. __osSetSR)
         src/lambo_hud_widescreen.c  # issue #2: gEXSetRectAlign brackets around the race-HUD dials
     )
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/aspMain.cpp)
+        list(APPEND LAMBO_SOURCES src/aspMain.cpp)
+    endif()
+
+    add_executable(lamborghini_modern ${LAMBO_SOURCES})
     target_compile_options(lamborghini_modern PRIVATE
         -fno-strict-aliasing
         -fms-extensions
@@ -157,10 +167,12 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         ${CMAKE_CURRENT_SOURCE_DIR}/RecompiledFuncs
     )
     target_link_libraries(lamborghini_modern PRIVATE
-        RecompiledFuncs
         librecomp
         ultramodern
     )
+    if(TARGET RecompiledFuncs)
+        target_link_libraries(lamborghini_modern PRIVATE RecompiledFuncs)
+    endif()
 
     # RT64 renderer (#58: default presenter; see the RT64 block above).
     target_sources(lamborghini_modern PRIVATE src/rt64_renderer.cpp)


### PR DESCRIPTION
## What this fixes

CI run #28756976030 (the first-ever `Build & Release` workflow_dispatch) failed
on **both** `build-linux` and `build-windows` at the very first
`cmake -S . -B build` step:

```
CMake Error at CMakeLists.txt:130 (add_executable):
  Cannot find source file: src/aspMain.cpp
CMake Error at CMakeLists.txt:108 (add_library):
  No SOURCES given to target: RecompiledFuncs
```

Both `src/aspMain.cpp` and `RecompiledFuncs/*.cpp` are produced by `RSPRecomp` /
`N64Recomp` — they do not exist until *after* the recompile step. The first
configure (which builds the recompiler tools themselves) must succeed without
them.

On Windows, `patches/0005-rt64-mingw-gcc-compat.patch` also failed with
`error: patch failed: src/render/rt64_optimus.cpp:8`. Reproduced locally:
re-applying 0005 against an already-patched `lib/rt64` produces the identical
error. The submodule working tree had a partially-applied patch from a prior
attempt.

## Changes

**`CMakeLists.txt`** — gate the two ROM-derived inputs on existence, mirroring
the existing `if(EXISTS src/main.cpp)` pattern above:
- `add_library(RecompiledFuncs STATIC)` is now inside
  `if(FUNC_C_SOURCES OR FUNC_CXX_SOURCES)`, so an empty `RecompiledFuncs/`
  no longer crashes `target_sources`.
- `add_executable(lamborghini_modern ...)` now uses a `set(LAMBO_SOURCES ...)`
  list that conditionally appends `src/aspMain.cpp` only when it exists.
- `target_link_libraries(... RecompiledFuncs)` is guarded by
  `if(TARGET RecompiledFuncs)`.

The `file(GLOB ... CONFIGURE_DEPENDS)` on `RecompiledFuncs/` is unchanged —
when N64Recomp populates that directory, CMake re-globs on the next build.

**`.github/workflows/build-release.yml`** (both `build-linux` and `build-windows`):
- New **"Reset submodules before patching"** step: runs
  `git -C lib/<sub> checkout -- .` for each patched submodule (and sets
  `git config --global core.autocrlf false` on Windows only). Recovers the
  dirty-submodule state that caused 0005 to fail.
- New **"Re-configure CMake to pick up generated sources"** step after the
  recompile step. Mirrors `BUILDING.md` step 4: the new `src/aspMain.cpp` has
  to be wired into `lamborghini_modern` via `add_executable`, which only
  happens at configure time. `CONFIGURE_DEPENDS` re-globs `RecompiledFuncs`
  but cannot add a brand-new file to a hand-written source list.

## Verified locally (Windows, MinGW gcc 16.1.0, cmake 4.3.1)

| check | result |
|---|---|
| First `cmake -S . -B build` on clean tree | succeeds in ~14s (was crashing) |
| `cmake --build --target N64RecompCLI RSPRecomp` | both `.exe` produced |
| Second configure with stubbed `RecompiledFuncs/` + `src/aspMain.cpp` | succeeds; `lamborghini_modern` and `RecompiledFuncs` targets both defined |
| All 4 patches apply after defensive `checkout -- .` | ✓ |
| Re-apply 0005 to patched submodule | reproduces the exact CI error from #28756976030 |
| Defensive `checkout -- .` recovers | ✓ |