### PR TITLE
Developer warp menu: F1-F6 / LAMBO_WARP race-track warp (#12)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
                                # libc backtrace(3) (POSIX).
         src/libultra_stubs.c   # no-op symbols for ignored libultra CP0 helpers (e.g. __osSetSR)
         src/lambo_hud_widescreen.c  # issue #2: gEXSetRectAlign brackets around the race-HUD dials
+        src/lambo_warp.c       # issue #12: developer warp menu (F1-F6 / LAMBO_WARP race-track warp)
     )
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/aspMain.cpp)
         list(APPEND LAMBO_SOURCES src/aspMain.cpp)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ N64Recomp ports (Zelda 64: Recompiled et al.):
 | `window_width` / `window_height` | pixels | `1600`/`900` | Windowed-mode size. |
 | `api_option` | `Auto`, `D3D12`, `Vulkan`, `Metal` | `Auto` | Graphics API. |
 
+## Developer warp (race-track warp)
+
+For development it is useful to jump straight into a race without driving the menus
+(the same pattern as the debug warp menus in other N64Recomp ports):
+
+- **F1–F6** at any time after boot warps to that circuit as a 1-player single race
+  (3 laps, first car).
+- **`LAMBO_WARP=circuit[:laps[:car[:players]]]`** (environment variable, circuit `1`–`6`)
+  performs the warp automatically at boot — handy for headless/scripted runs.
+
+The warp performs the same stores the game's own menu makes when you confirm RACE
+(selection cursors + audio quiesce + game-state 7), so the race it starts is a normal
+single race. Each warp is logged to stderr as `[warp] CIRCUIT N: ...`.
+
 ## Building
 
 See **[BUILDING.md](./BUILDING.md)**. In brief: clone with submodules, supply your ROM, run the recompile step, then configure and build with CMake.

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -399,3 +399,15 @@ text = "lambo_ws_minimap_reset(rdram);"
 func = "func_8004384C"
 before_vram = 0x80043C88
 text = "extern unsigned int lambo_ws_minimap_outline_x(unsigned int); ctx->r5 = S32(lambo_ws_minimap_outline_x((uint32_t)ctx->r5));"
+
+# Issue #12 — developer warp menu. Per-frame warp tick at the entry of the TOP-LEVEL
+# state dispatcher func_800028D0 (runtime 0x80001CD0, argument-free, jump-table over
+# states 1..0x10, runs every frame in every state; func_800030F8 was tried first but
+# only runs in states 7/8 — too late for menu/attract warps). Consumes an F1-F6 /
+# LAMBO_WARP request and performs the menu's own race-launch stores (cursor cluster +
+# audio quiesce + state 7) before the dispatcher reads the state word; native in
+# src/lambo_warp.c.
+[[patches.hook]]
+func = "func_800028D0"
+before_vram = 0x80001CD0
+text = "extern void lambo_warp_tick(uint8_t*, recomp_context*); lambo_warp_tick(rdram, ctx);"

--- a/scripts/gen_syms_toml.py
+++ b/scripts/gen_syms_toml.py
@@ -649,7 +649,7 @@ NATIVE_OVERRIDES = [
 # generated lamborghini.us.toml (issues #2/#4 landed them by editing the toml directly; the
 # generator must carry them or a regen silently drops the widescreen HUD + LOD patches).
 PATCH_BLOCKS = """
-# Issue #4 â€” game-side geometry-LOD distance-test, NOT covered by RT64's
+# Issue #4 — game-side geometry-LOD distance-test, NOT covered by RT64's
 # renderer-level forceBranch (which only touches RSP G_BRANCH_Z/W).
 # NOPs the bc1f +0xDC in func_80060464 that gates the per-car high-poly
 # fall-through; threshold was 100.0 IEEE-754 at 0x42C80000. Identified
@@ -660,7 +660,7 @@ vram = 0x8005FA3C
 func = "func_80060464"
 value = 0x00000000
 
-# Issue #2 â€” per-element widescreen HUD (gEXSetRectAlign). The 1P race screen of the 2D
+# Issue #2 — per-element widescreen HUD (gEXSetRectAlign). The 1P race screen of the 2D
 # dispatcher func_80050860 draws three edge-anchored HUD elements back-to-back (verified
 # live 2026-07-05 by probing every 2D helper's (x,y) args during a driven race):
 #   jal 0x8004FF60 -> func_80056318 (runtime 0x80055718): speedometer dial at x=0xDC,
@@ -670,7 +670,7 @@ value = 0x00000000
 # Each jal is bracketed with a text hook that writes gEXEnable + gEXSetRectAlign
 # (RIGHT/LEFT pin, then ORIGIN_NONE reset) into the game DL through its cursor global
 # 0x800A39CC; natives in src/lambo_hud_widescreen.c. TIME stays centered (no tag needed
-# under RT64 Expand); the minimap is polyline/viewport-drawn, not texrects â€” pinning it
+# under RT64 Expand); the minimap is polyline/viewport-drawn, not texrects — pinning it
 # is a separate follow-up (rect-align cannot move it).
 [[patches.hook]]
 func = "func_80050860"
@@ -705,8 +705,44 @@ text = "lambo_ws_pin_reset(rdram);"
 # The speedo NEEDLE (triangle geometry via a G_MTX chain built inside the dial drawer
 # func_80056318) is handled natively inside the existing dial bracket: pin records the
 # DL cursor and reset patches the needle's LOAD matrix translation (see
-# src/lambo_hud_widescreen.c). No extra hooks needed. func_80054FFC (minimap arrow +
-# car dots) is deliberately NOT bracketed â€” it must stay with the centered minimap.
+# src/lambo_hud_widescreen.c). No extra hooks needed.
+
+# Issue #41 — pin the 1P minimap composite to the left edge. Three pieces:
+#   dots + P1 label: texrects from the overlay func_80054FFC (jal 0x80050588 in the 1P
+#     race section) — LEFT rect-align bracket, same mechanism as LAP/RANK above;
+#   player arrow: two quads via pool G_MTX LOADs built inside the same overlay call —
+#     the bracket reset shifts their translation in game space (same walker as the
+#     needle, different delta);
+#   track outline: 3D geometry drawn by the frame builder func_8004384C through the
+#     race perspective projection; its placement translate(-2.05, -2.4, 0) is built by
+#     the jal at 0x80043C88 — hook rewrites the x argument ($a1 float bits) in flight,
+#     gated to frames where the 1P bracket ran (see lambo_ws_minimap_outline_x).
+[[patches.hook]]
+func = "func_80050860"
+before_vram = 0x80050588
+text = "lambo_ws_minimap_pin(rdram);"
+
+[[patches.hook]]
+func = "func_80050860"
+before_vram = 0x80050590
+text = "lambo_ws_minimap_reset(rdram);"
+
+[[patches.hook]]
+func = "func_8004384C"
+before_vram = 0x80043C88
+text = "extern unsigned int lambo_ws_minimap_outline_x(unsigned int); ctx->r5 = S32(lambo_ws_minimap_outline_x((uint32_t)ctx->r5));"
+
+# Issue #12 — developer warp menu. Per-frame warp tick at the entry of the TOP-LEVEL
+# state dispatcher func_800028D0 (runtime 0x80001CD0, argument-free, jump-table over
+# states 1..0x10, runs every frame in every state; func_800030F8 was tried first but
+# only runs in states 7/8 — too late for menu/attract warps). Consumes an F1-F6 /
+# LAMBO_WARP request and performs the menu's own race-launch stores (cursor cluster +
+# audio quiesce + state 7) before the dispatcher reads the state word; native in
+# src/lambo_warp.c.
+[[patches.hook]]
+func = "func_800028D0"
+before_vram = 0x80001CD0
+text = "extern void lambo_warp_tick(uint8_t*, recomp_context*); lambo_warp_tick(rdram, ctx);"
 """
 
 UNSTUB = [
@@ -1462,7 +1498,7 @@ rom_file_path = "Automobili Lamborghini (USA).z64"
 stubs = {toml_array(race_stubs)}
 ignored = {toml_array(race_ignored)}
 {PATCH_BLOCKS}'''
-    CONFIG.write_text(cfg)
+    CONFIG.write_text(cfg, encoding="utf-8")
 
     print(f"dump funcs:        {n_dump}")
     print(f"size overrides hit: {n_over} / {len(overrides)}")

--- a/src/lambo_warp.c
+++ b/src/lambo_warp.c
@@ -1,0 +1,146 @@
+// Developer warp menu (issue #12, survey pattern A13: Banjo warps_table, Dr Mario
+// scene_table): jump straight to a race on any circuit without driving the menus.
+//
+// The ROM funnels every race start through one path: menu screens park their
+// selections in a cursor cluster at 0x800CE6xx, the RACE menu action quiesces audio
+// (func_800676B4 stop-and-drain + func_80008ECC) and stores 7 into the game-state
+// halfword 0x800CE6AC, and the state-7 handler (splat boot_pad_apply_calibration,
+// runtime 0x80005A24) copies the cursors into the live race config keyed by mode.
+// The warp performs exactly those menu-side stores and the same state write -- the
+// ROM's own finalizer does everything else, so nothing about the race is invented.
+//
+// Trigger paths (both consumed on the game thread by lambo_warp_tick, hooked at the
+// entry of the per-frame game-logic dispatcher func_800030F8, runtime 0x800024F8):
+//   - F1..F6 (SDL keyboard, published from input_sample in main.cpp): warp to that
+//     circuit as a 1-player single race with the current defaults below.
+//   - LAMBO_WARP=circuit[:laps[:car[:players]]] (env, circuit 1-6): one-shot boot
+//     warp, fired at the first frame the game is in a warpable state.
+//
+// Cluster map (all halfwords; MEM_H handles guest byte order):
+//   0x800CE6A4 players (1-4)          0x800CE6C0 track cursor (0-5; 0-2 if 3+ players)
+//   0x800CE6A6 track-select-entered   0x800CE6E0 laps cursor (menu range 3-30)
+//   0x800CE6B4 mode (2 = SINGLE RACE) 0x800CE7A4 car cursor
+//   0x800CE6BA race counter (0)       0x800CE6AC game state (7 = load race)
+
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "recomp.h"
+
+// Audio quiesce pair the ROM runs before every state->7 write (menu RACE action,
+// pause-restart, championship next-race). Recompiled bodies; safe to call from a
+// func_800030F8 entry hook (that function is argument-free and both callees keep
+// the guest stack balanced).
+void func_800676B4(uint8_t* rdram, recomp_context* ctx);
+void func_80008ECC(uint8_t* rdram, recomp_context* ctx);
+
+#define WARP_STATE      0x800CE6ACu
+#define WARP_PLAYERS    0x800CE6A4u
+#define WARP_TRACK_FLAG 0x800CE6A6u
+#define WARP_MODE       0x800CE6B4u
+#define WARP_COUNTER    0x800CE6BAu
+#define WARP_TRACK_CUR  0x800CE6C0u
+#define WARP_LAPS_CUR   0x800CE6E0u
+#define WARP_CAR_CUR    0x800CE7A4u
+
+#define MODE_SINGLE_RACE 2
+
+// The game's circuits are unnamed (menu shows "CIRCUIT" + a numbered map preview;
+// ROM has no track-name strings), so the scene table mirrors that presentation.
+static const char* const lambo_scene_table[6] = {
+    "CIRCUIT 1", "CIRCUIT 2", "CIRCUIT 3", "CIRCUIT 4", "CIRCUIT 5", "CIRCUIT 6",
+};
+
+// Request packing: bit 31 = pending, bits 0-7 circuit (0-based), 8-15 laps,
+// 16-23 car, 24-27 players. Published by the SDL main thread / env parse,
+// exchanged to 0 by the game-thread tick.
+static _Atomic uint32_t g_warp_request;
+
+static uint32_t pack_request(int circuit0, int laps, int car, int players) {
+    return 0x80000000u | (uint32_t)(circuit0 & 0xFF) | ((uint32_t)(laps & 0xFF) << 8)
+         | ((uint32_t)(car & 0xFF) << 16) | ((uint32_t)(players & 0xF) << 24);
+}
+
+// Hotkey entry point (called from main.cpp on the SDL thread). circuit0 = 0-based.
+void lambo_warp_request(int circuit0) {
+    if (circuit0 < 0 || circuit0 > 5) return;
+    atomic_store_explicit(&g_warp_request, pack_request(circuit0, 3, 0, 1),
+                          memory_order_relaxed);
+}
+
+// LAMBO_WARP=circuit[:laps[:car[:players]]], circuit 1-based to match the game UI.
+static void parse_env_request(void) {
+    const char* env = getenv("LAMBO_WARP");
+    if (env == NULL || env[0] == '\0') return;
+    int v[4] = { 0, 3, 0, 1 };
+    char buf[64];
+    snprintf(buf, sizeof(buf), "%s", env);
+    char* p = buf;
+    for (int i = 0; i < 4 && p != NULL && *p != '\0'; i++) {
+        v[i] = (int)strtol(p, NULL, 10);
+        p = strchr(p, ':');
+        if (p != NULL) p++;
+    }
+    if (v[0] < 1 || v[0] > 6) {
+        fprintf(stderr, "[warp] LAMBO_WARP=%s invalid: circuit must be 1-6\n", env);
+        return;
+    }
+    atomic_store_explicit(&g_warp_request, pack_request(v[0] - 1, v[1], v[2], v[3]),
+                          memory_order_relaxed);
+}
+
+// States a warp is allowed to fire from, mirroring where the ROM itself issues the
+// state->7 write: 6 = menu (RACE action), 8 = in race (pause restart), and the
+// attract flow states 3-5 (title/attract screens; the attract handoff enters its
+// demo race the same way). 7 (already loading) and boot states 0-2 hold the
+// request pending.
+static int warpable(int state) {
+    return state >= 3 && state <= 8 && state != 7;
+}
+
+// Per-frame tick, injected at the entry of func_800030F8 (see the [[patches.hook]]
+// block carried by scripts/gen_syms_toml.py). Runs on the game thread.
+void lambo_warp_tick(uint8_t* rdram, recomp_context* ctx) {
+    static int env_parsed;
+    if (!env_parsed) {
+        env_parsed = 1;
+        parse_env_request();
+    }
+    uint32_t req = atomic_load_explicit(&g_warp_request, memory_order_relaxed);
+    if (!(req & 0x80000000u)) return;
+
+    int state = (int16_t)MEM_H(0, (gpr)(int32_t)WARP_STATE);
+    if (!warpable(state)) return;
+    if (!atomic_compare_exchange_strong_explicit(&g_warp_request, &req, 0,
+                                                 memory_order_relaxed,
+                                                 memory_order_relaxed)) {
+        return;
+    }
+
+    int circuit0 = (int)(req & 0xFF);
+    int laps     = (int)((req >> 8) & 0xFF);
+    int car      = (int)((req >> 16) & 0xFF);
+    int players  = (int)((req >> 24) & 0xF);
+    if (players < 1) players = 1;
+    if (players > 4) players = 4;
+    if (players >= 3 && circuit0 > 2) circuit0 = 2;  // ROM offers 3 tracks to 3-4 players
+    if (laps < 1) laps = 1;
+    if (laps > 30) laps = 30;                        // menu lap range tops out at 30
+
+    MEM_H(0, (gpr)(int32_t)WARP_PLAYERS)    = (int16_t)players;
+    MEM_H(0, (gpr)(int32_t)WARP_TRACK_FLAG) = 1;
+    MEM_H(0, (gpr)(int32_t)WARP_MODE)       = MODE_SINGLE_RACE;
+    MEM_H(0, (gpr)(int32_t)WARP_COUNTER)    = 0;
+    MEM_H(0, (gpr)(int32_t)WARP_TRACK_CUR)  = (int16_t)circuit0;
+    MEM_H(0, (gpr)(int32_t)WARP_LAPS_CUR)   = (int16_t)laps;
+    MEM_H(0, (gpr)(int32_t)WARP_CAR_CUR)    = (int16_t)car;
+
+    func_800676B4(rdram, ctx);
+    func_80008ECC(rdram, ctx);
+    MEM_H(0, (gpr)(int32_t)WARP_STATE) = 7;
+
+    fprintf(stderr, "[warp] %s: single race, %d lap(s), car %d, %d player(s) (from state %d)\n",
+            lambo_scene_table[circuit0], laps, car, players, state);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -490,6 +490,9 @@ static SDL_GameController* g_pad = nullptr;          // first opened controller 
 static std::atomic<int> g_rumble_on{0};              // game-thread write, main-thread read
 extern "C" void lambo_pak_set_rumble(int on) { g_rumble_on.store(on ? 1 : 0, std::memory_order_relaxed); }
 
+// Developer warp menu (#12, src/lambo_warp.c): main thread publishes, game thread warps.
+extern "C" void lambo_warp_request(int circuit0);
+
 // Apply the published rumble state to the physical pad. Called once per main-thread pump.
 // N64 rumble is bang-bang (motor fully on or off), so map to SDL full strength. We refresh the
 // effect every pump with a short expiry (150 ms > one 30 fps frame) so a sustained motor-on
@@ -579,6 +582,16 @@ static void input_sample() {
         if (ks[SDL_SCANCODE_DOWN]  || ks[SDL_SCANCODE_S]) ky -= N64_STICK_MAX;
         if (sx == 0 && kx != 0) sx = kx;               // pad stick wins if deflected
         if (sy == 0 && ky != 0) sy = ky;
+
+        // Developer warp menu (#12): F1..F6 warp straight to that circuit as a
+        // 1-player single race. Edge-detected here (main thread); consumed by
+        // lambo_warp_tick on the game thread (src/lambo_warp.c).
+        static Uint8 warp_prev[6] = {};
+        for (int i = 0; i < 6; i++) {
+            Uint8 down = ks[SDL_SCANCODE_F1 + i];
+            if (down && !warp_prev[i]) lambo_warp_request(i);
+            warp_prev[i] = down;
+        }
     }
 
     uint32_t snap = (uint16_t)b


### PR DESCRIPTION
Closes #12 (survey pattern A13: Banjo `warps_table`, Dr Mario `scene_table`).

## What
Jump straight into a 1-player single race on any of the 6 circuits without driving the menus:

- **F1–F6** warps to that circuit at any time after boot (works from attract, title, menu, and mid-race — re-warping between circuits works).
- **`LAMBO_WARP=circuit[:laps[:car[:players]]]`** (circuit 1–6) warps automatically at boot; a headless boot reaches the race in ~75 VIs (~2.5 s) instead of ~37 s through the attract cycle.

## How (decoded launch path, no invented mechanics)
Every race start in this ROM funnels through one path: menu screens park selections in the cursor cluster at `0x800CE6xx`, the RACE action quiesces audio (`func_800676B4` stop-and-drain + `func_80008ECC`) and stores **7** into the game-state halfword `0x800CE6AC`, and the state-7 handler (splat `boot_pad_apply_calibration`, a misnomer) copies the cursors into the live race config keyed by mode (2 = SINGLE RACE). The warp performs exactly those menu-side stores and the same state write — the ROM's own finalizer does the rest, so the launched race is a normal single race.

The tick is a `[[patches.hook]]` at the entry of the **top-level per-frame state dispatcher `func_800028D0`** (runtime `0x80001CD0`, argument-free, jump-table over states 1–0x10). `func_800030F8` was tried first but only runs in states 7/8 — too late for menu/attract warps.

The circuits are unnamed in the ROM (menu shows "CIRCUIT" + a map preview; verified by a full ROM strings scan), so the scene table uses CIRCUIT 1–6.

## Also in this PR
- `gen_syms_toml.py` PATCH_BLOCKS was stale **again**: the issue #41 minimap hooks existed only in the hand-edited toml, so a regen would have silently dropped them — synced into the generator.
- The generator now writes `lamborghini.us.toml` as UTF-8 (`write_text` defaulted to cp1252 and mangled the em-dashes in comments).

## Verified
- Headless `LAMBO_WARP=2` vs `=5`: both reach state 8 with the `[warp]` log, and the state-8 frame captures differ (different track geometry loaded).
- Windowed: F3 from the attract and F6 re-warp mid-race both land in a playable race (LAP 0/3, RANK 6/6, full HUD, AI field).
- No-env boot regression: state progression identical to before (3→4→5→6→7→8, same VI timings), no warp lines.