### PR TITLE
Texture extraction & replacement foundation (part of #9)

### DIFF
--- a/docs/TEXTURES.md
+++ b/docs/TEXTURES.md
@@ -1,0 +1,139 @@
+# Texture extraction & replacement (issue #9 foundation, 2026-07-06)
+
+Reference for anyone (human or LLM) adding replacement/HD textures — the first target
+being the game's hard-to-read text. Everything here was verified end-to-end on this port:
+a headless dump of the demo race, an offline decode, and a replacement texture visibly
+applied in-game (the speedometer's MPH digits and the title "COPYRIGHT 1997 TITUS" line
+turned solid magenta once their font-atlas texture was replaced).
+
+## What RT64 already gives us (and what the port adds)
+
+RT64 (`lib/rt64`) ships the **entire** texture-replacement system — hashing, a dump mode,
+a pack database, DDS/PNG loading, `.rtz` packaging tools. The port previously wired **none**
+of it (`src/rt64_renderer.cpp` was "adapted from Zelda64Recomp minus the texture-pack
+plumbing"). Issue #9's foundation is just to *expose* it:
+
+| Capability | Provided by | Where |
+|---|---|---|
+| Texture identity = XXH3-64 of the used TMEM bytes + TLUT + tile params (**version 5**) | RT64 | `common/rt64_tmem_hasher.h` |
+| Dump every uploaded texture (raw TMEM/RDRAM + tile JSON) | RT64 | `hle/rt64_rdp_tmem.cpp` `dumpTexture()`, gated on `state->dumpingTexturesDirectory` |
+| Pack manifest `rt64.json` (hash → file, per-texture stream/preload + shift) | RT64 | `common/rt64_replacement_database.*` |
+| Load a pack (loose directory **or** `.rtz`) | RT64 | `TextureCache::loadReplacementDirectory(ReplacementDirectory)` |
+| **Config-driven dump + startup pack auto-load** | **port** | `src/rt64_renderer.cpp` (after `app->setup()`), `src/lambo_config.cpp` |
+| Dump → viewable PNG decode | **port** | `tools/decode_dump.py` |
+| Generate `rt64.json` from replacement files | **port** | `tools/make_pack.py` |
+| Build `.rtz` (+ low-mip cache) | RT64 | `build/rt64/src/tools/texture_packer/texture_packer.exe` |
+
+Texture identity is the **TMEM content hash**, not an RDRAM address — so a replacement keyed
+by hash survives the asset moving in memory, but the *same on-screen text drawn at a
+different scale/palette is a different hash* (see the coverage gotcha below).
+
+## Config keys (graphics.json)
+
+Two string keys, both empty (off) by default, each overridable by an env var so a headless
+capture never has to touch the user's `graphics.json`:
+
+| Key | Env override | Effect |
+|---|---|---|
+| `texture_pack` | `LAMBO_TEXTURE_PACK` | Directory or `.rtz` auto-loaded at startup. |
+| `texture_dump` | `LAMBO_TEXTURE_DUMP` | Directory RT64 writes every used texture to. |
+
+Both are independent of `developer_mode`, so an end-user pack loads **without** the F1
+developer overlay. On success the log prints `[rt64] texture pack loaded: …` /
+`[rt64] texture dump enabled -> …`.
+
+## End-to-end workflow
+
+### 1. Dump
+
+```bash
+# headless: no dev overlay needed
+LAMBO_TEXTURE_DUMP=/path/to/dump  ./build/lamborghini_modern
+```
+
+Coverage is **runtime-driven**: a texture is only dumped once the game uploads it to TMEM.
+Exercise every screen whose text you care about — attract intro, PRESS START title,
+menus (RACE / NAME / records), and the in-race HUD. The dev warp menu (`LAMBO_WARP`,
+F1–F6) reaches race screens quickly. Missed screen ⇒ missing texture in the pack.
+
+Each unique texture writes `<hash>.v5.tmem`, `<hash>.v5.tile.json` (fmt/siz/dims/tlut),
+plus `.rice.rdram` / `.rice.palette.rdram` for CI textures. These are **raw data, not
+images**.
+
+> The in-repo `tools/drive_input.py` drives the window headlessly (PostMessage + PrintWindow)
+> and is how the captures for this doc were produced. It matches SDL's `SDL_app` window
+> class, so an editor/browser with the repo open in a tab won't be captured by mistake.
+
+### 2. Decode to viewable PNGs
+
+```bash
+python tools/decode_dump.py /path/to/dump          # writes <dump>/png/*.png + index.html
+```
+
+Open `index.html` (a contact sheet) to eyeball the whole dump. **Decode fidelity:**
+- **RGBA16 / RGBA32 / IA / I** — accurate. The "automobili Lamborghini" wordmark tiles
+  decoded pixel-clean.
+- **CI4 / CI8** (palettized — *the format most fonts use*) — good enough to **identify** a
+  texture, but 4-bit textures loaded via `LOAD_BLOCK` are sheared/off-colour because the
+  block DXT interleave isn't emulated yet (`--no-swizzle` / `--pal-byteswap` are calibration
+  knobs; neither fully fixes it). Follow-up work. For a **pixel-perfect** view of one
+  texture, use RT64's live F1 inspector (below), which shows it GPU-decoded.
+
+### 3. Identify the text
+
+The HUD/menu font atlases are **CI4/CI8 banner-shaped** textures (e.g. the small HUD font is
+`aec01187…`, a 512×8 CI4 strip of glyphs). Filter the dump for `fmt2` (CI) textures that are
+wide-and-short. There are **several** font atlases — replacing the small-HUD one changed the
+speedo digits and the title copyright line but **not** "LAP/TIME/RANK/GET READY", which use a
+different atlas. Expect to find and replace each.
+
+### 4. Author replacements
+
+- Name each file by the RT64 hash: `<16-hex-hash>.png` (or `.dds`). That hash is exactly the
+  dump filename prefix.
+- **PNG** loads directly and is fine for iteration. **DDS** (BC7 + mipmaps, e.g. via Texconv
+  / Compressonator's *CPU* encoder) is what you ship — never ship PNG.
+- Keep `shift: half` for modern-tool exports.
+- Coverage gotcha restated: a CI font re-hashes when its palette changes (highlighted vs.
+  normal menu item), so the same glyphs can need replacing under several hashes.
+
+### 5. Build the manifest + pack
+
+```bash
+python tools/make_pack.py /path/to/pack            # writes rt64.json from the <hash>.png/.dds files
+```
+
+`rt64.json` is **required** — RT64 does not auto-scan for hash-named files, and its own
+`texture_hasher` only *upgrades* an existing manifest, it won't create one. `make_pack.py`
+fills that gap.
+
+Point the port at the directory to test:
+
+```bash
+LAMBO_TEXTURE_PACK=/path/to/pack  ./build/lamborghini_modern
+```
+
+To ship, zip to a `.rtz` (loads identically):
+
+```bash
+build/rt64/src/tools/texture_packer/texture_packer.exe /path/to/pack --create-low-mip-cache
+build/rt64/src/tools/texture_packer/texture_packer.exe /path/to/pack --create-pack
+```
+
+(The low-mip cache is only meaningful for DDS mipmaps; with PNG it is empty, which is fine.)
+
+## The F1 developer overlay (optional)
+
+With `developer_mode: true`, RT64's overlay opens on **F1** (Inspector) / **F4** (Replacements),
+giving a live per-draw-call texture view, "Start dumping textures", and interactive replace.
+⚠️ **Key clash:** the dev warp menu also uses F1–F6 (`src/main.cpp` polls those scancodes
+directly), so both fire at once. The config-driven dump/pack above avoids the overlay
+entirely, which is why it is the recommended path here; if you need the live inspector,
+expect the warp keys to also trigger.
+
+## Files
+
+- `src/rt64_renderer.cpp` — startup wiring (dump dir + `loadReplacementDirectory`).
+- `src/lambo_config.{h,cpp}` — `texture_pack` / `texture_dump` keys + env overrides.
+- `tools/decode_dump.py` — dump → PNG (+ contact sheet).
+- `tools/make_pack.py` — replacement files → `rt64.json`.

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -24,6 +24,11 @@ constexpr int kDefaultWindowHeight = 900;
 
 lambo::config::WindowSize g_window_size{kDefaultWindowWidth, kDefaultWindowHeight};
 
+// RT64 texture-replacement paths (issue #9), persisted as extra graphics.json string
+// keys alongside the GraphicsConfig fields (like the window size). Empty = feature off.
+std::string g_texture_pack;
+std::string g_texture_dump;
+
 // Read a key into `out`, keeping the existing (default) value when the key is
 // missing or invalid. NLOHMANN_JSON_SERIALIZE_ENUM does NOT throw on an
 // unrecognised string -- it silently maps it to the FIRST enumerator, which for
@@ -62,6 +67,8 @@ nlohmann::json to_json(const ultramodern::renderer::GraphicsConfig& c) {
         {"developer_mode", c.developer_mode},
         {"window_width", g_window_size.width},
         {"window_height", g_window_size.height},
+        {"texture_pack", g_texture_pack},
+        {"texture_dump", g_texture_dump},
     };
 }
 
@@ -79,6 +86,8 @@ void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c
     from_or_default(j, "developer_mode", c.developer_mode);
     from_or_default(j, "window_width", g_window_size.width);
     from_or_default(j, "window_height", g_window_size.height);
+    from_or_default(j, "texture_pack", g_texture_pack);
+    from_or_default(j, "texture_dump", g_texture_dump);
     // Sanity-bound the window size: below the N64 framebuffer is useless, above 8K
     // is a typo -- either way SDL_CreateWindow would fail and the port would run
     // permanently headless, so reset to defaults instead.
@@ -229,6 +238,23 @@ void save_graphics(const ultramodern::renderer::GraphicsConfig& cfg) {
 
 WindowSize window_size() {
     return g_window_size;
+}
+
+// Env var wins over the JSON key so a headless capture run can point at a scratch
+// directory without editing (and re-saving) the user's graphics.json.
+static std::string path_from_env_or(const char* env, const std::string& fallback) {
+    if (const char* v = std::getenv(env)) {
+        return v;
+    }
+    return fallback;
+}
+
+std::string texture_pack_path() {
+    return path_from_env_or("LAMBO_TEXTURE_PACK", g_texture_pack);
+}
+
+std::string texture_dump_dir() {
+    return path_from_env_or("LAMBO_TEXTURE_DUMP", g_texture_dump);
 }
 
 } // namespace config

--- a/src/lambo_config.h
+++ b/src/lambo_config.h
@@ -9,6 +9,7 @@
 #define LAMBO_CONFIG_H
 
 #include <filesystem>
+#include <string>
 
 #include "ultramodern/config.hpp"
 
@@ -41,6 +42,16 @@ void update_saved_window_mode(ultramodern::renderer::WindowMode wm);
 // chosen 16:9 so AspectRatio::Expand actually widens on first launch).
 struct WindowSize { int width; int height; };
 WindowSize window_size();
+
+// RT64 texture-replacement paths (issue #9). Both are extra graphics.json string keys
+// (empty = feature off), overridable by env var for headless capture/testing:
+//   texture_pack  / LAMBO_TEXTURE_PACK  -- directory or .rtz to auto-load at startup.
+//   texture_dump  / LAMBO_TEXTURE_DUMP  -- directory RT64 writes every used texture to
+//                                          (raw TMEM/RDRAM dumps; decode with
+//                                          tools/decode_dump.py). Enables headless dump
+//                                          without the F1 developer overlay.
+std::string texture_pack_path();
+std::string texture_dump_dir();
 
 } // namespace config
 } // namespace lambo

--- a/src/rt64_renderer.cpp
+++ b/src/rt64_renderer.cpp
@@ -16,12 +16,15 @@
 #include <mutex>
 
 #include "hle/rt64_application.h"
+#include "hle/rt64_state.h"
+#include "render/rt64_texture_cache.h"
 
 #include "ultramodern/ultramodern.hpp"
 #include "ultramodern/config.hpp"
 #include "ultramodern/renderer_context.hpp"
 
 #include "lambo_rt64.h"
+#include "lambo_config.h"
 
 namespace {
 
@@ -232,6 +235,26 @@ public:
         }
 
         std::fprintf(stderr, "[rt64] RT64 renderer initialised (api=%d)\n", (int)chosen_api);
+
+        // Texture replacement wiring (issue #9). RT64 already owns the whole
+        // dump/hash/replace machinery; the port just points it at directories. Both
+        // are opt-in (empty path = off) and independent of developerMode, so an
+        // end-user pack loads without the F1 developer overlay.
+        const std::string dump_dir = lambo::config::texture_dump_dir();
+        if (!dump_dir.empty()) {
+            // Setting this non-empty makes TextureManager::dumpTexture write every
+            // uploaded texture (raw TMEM + RDRAM + tile JSON) to the directory.
+            app->state->dumpingTexturesDirectory = std::filesystem::path(dump_dir);
+            std::fprintf(stderr, "[rt64] texture dump enabled -> %s\n", dump_dir.c_str());
+        }
+
+        const std::string pack = lambo::config::texture_pack_path();
+        if (!pack.empty()) {
+            const bool ok = app->textureCache->loadReplacementDirectory(
+                RT64::ReplacementDirectory(std::filesystem::path(pack)));
+            std::fprintf(stderr, "[rt64] texture pack %s: %s\n",
+                         ok ? "loaded" : "FAILED to load", pack.c_str());
+        }
     }
 
     ~RT64Context() override = default;

--- a/tools/decode_dump.py
+++ b/tools/decode_dump.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Decode an RT64 texture dump into viewable PNGs (issue #9).
+
+RT64's "Start dumping textures" (or this port's `texture_dump` config / LAMBO_TEXTURE_DUMP
+env) writes, per unique texture, a set of files named by the 64-bit texture hash:
+
+    <hash>.v5.tmem              raw 4 KB TMEM snapshot (the sampled texel data)
+    <hash>.v5.tile.json         { tile:{fmt,siz,line,tmem,palette,...}, width, height, tlut }
+    <hash>.v5.rice.rdram        linear RDRAM slice the tile loaded from (alt decode source)
+    <hash>.v5.rice.json         { tile, type, texture:{address,fmt,siz,width} }
+    <hash>.v5.rice.palette.rdram  TLUT bytes (CI textures only)
+
+Neither RT64 nor its texture_hasher/texture_packer tools turn these into an image, so you
+cannot *see* a texture to decide whether it is the hard-to-read text you want to replace.
+This tool does that decode, emitting <hash>.png per texture plus an index.html contact
+sheet for eyeballing the whole dump at once.
+
+The PNG the tool emits is only for identification/upscaling reference -- the actual
+replacement texture is authored fresh at higher resolution, so a close-enough decode is
+fine. Byte-order/swizzle flags exist because the port hands RT64 its RDRAM in a
+mupen/N64Recomp convention; calibrate once against an in-game screenshot, then leave the
+working flags as the defaults.
+
+Usage:
+    python tools/decode_dump.py <dump_dir> [--out <png_dir>] [--source tmem|rdram]
+                                           [--no-swizzle] [--rdram-byteswap]
+                                           [--filter <hex-substr>]
+
+Self-contained: standard library only (zlib for PNG deflate).
+"""
+
+import argparse
+import json
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+# N64 image format (fmt) and pixel size (siz) enums.
+FMT_RGBA, FMT_YUV, FMT_CI, FMT_IA, FMT_I = 0, 1, 2, 3, 4
+SIZ_4B, SIZ_8B, SIZ_16B, SIZ_32B = 0, 1, 2, 3
+
+FMT_NAME = {FMT_RGBA: "RGBA", FMT_YUV: "YUV", FMT_CI: "CI", FMT_IA: "IA", FMT_I: "I"}
+SIZ_BITS = {SIZ_4B: 4, SIZ_8B: 8, SIZ_16B: 16, SIZ_32B: 32}
+
+
+def fmt_label(fmt, siz):
+    return f"{FMT_NAME.get(fmt, '?')}{SIZ_BITS.get(siz, '?')}"
+
+
+# --- tiny PNG writer (RGBA8, no dependencies) ---------------------------------
+
+def write_png(path, width, height, rgba_rows):
+    """rgba_rows: list of `height` bytes objects, each width*4 bytes (RGBA8)."""
+    def chunk(tag, data):
+        return (struct.pack(">I", len(data)) + tag + data +
+                struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF))
+
+    raw = bytearray()
+    for row in rgba_rows:
+        raw.append(0)  # filter type 0 (None)
+        raw.extend(row)
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)  # 8-bit RGBA
+    png = (b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) +
+           chunk(b"IDAT", zlib.compress(bytes(raw), 9)) + chunk(b"IEND", b""))
+    path.write_bytes(png)
+
+
+# --- texel conversions to RGBA8 -----------------------------------------------
+
+def rgba16_to_rgba8(px):
+    r = (px >> 11) & 0x1F
+    g = (px >> 6) & 0x1F
+    b = (px >> 1) & 0x1F
+    a = px & 0x1
+    return ((r << 3) | (r >> 2), (g << 3) | (g >> 2), (b << 3) | (b >> 2),
+            255 if a else 0)
+
+
+def ia16_to_rgba8(px):
+    i = (px >> 8) & 0xFF
+    a = px & 0xFF
+    return (i, i, i, a)
+
+
+def i_expand(v, bits):
+    # replicate high bits down so 4-bit 0xF -> 0xFF
+    v &= (1 << bits) - 1
+    return (v << (8 - bits)) | (v >> (2 * bits - 8)) if bits >= 4 else v * 255 // ((1 << bits) - 1)
+
+
+# --- TMEM addressing ----------------------------------------------------------
+
+def tmem_byte(tmem, addr, swizzle, row_odd):
+    """Read one byte from the 4KB TMEM snapshot, applying the N64 odd-row
+    32-bit-word swap (byte address ^ 4) that TMEM uses for <=16bpp textures."""
+    if swizzle and row_odd:
+        addr ^= 0x4
+    if 0 <= addr < len(tmem):
+        return tmem[addr]
+    return 0
+
+
+def read_palette(pal_bytes, count, byteswap):
+    """TLUT entries are 16-bit. Returns list of raw uint16 values."""
+    entries = []
+    for i in range(count):
+        off = i * 2
+        if byteswap:
+            off ^= 0x2
+        if off + 1 < len(pal_bytes):
+            entries.append((pal_bytes[off] << 8) | pal_bytes[off + 1])
+        else:
+            entries.append(0)
+    return entries
+
+
+def decode_from_tmem(tmem, tile, width, height, tlut_kind, palette, swizzle):
+    fmt, siz = tile["fmt"], tile["siz"]
+    base = tile["tmem"] * 8       # tmem word (64-bit) -> byte
+    line = tile["line"] * 8       # line stride in bytes
+    pal_base = (tile.get("palette", 0) << 4)  # CI4 sub-palette
+
+    def pal_rgba(idx):
+        if idx < len(palette):
+            v = palette[idx]
+            return ia16_to_rgba8(v) if tlut_kind == "IA16" else rgba16_to_rgba8(v)
+        return (255, 0, 255, 255)
+
+    rows = []
+    for t in range(height):
+        odd = bool(t & 1)
+        row = bytearray()
+        for s in range(width):
+            if siz == SIZ_16B:
+                a = base + t * line + s * 2
+                hi = tmem_byte(tmem, a, swizzle, odd)
+                lo = tmem_byte(tmem, a + 1, swizzle, odd)
+                px = (hi << 8) | lo
+                row += bytes(rgba16_to_rgba8(px) if fmt == FMT_RGBA else ia16_to_rgba8(px))
+            elif siz == SIZ_8B:
+                a = base + t * line + s
+                b = tmem_byte(tmem, a, swizzle, odd)
+                if fmt == FMT_CI:
+                    row += bytes(pal_rgba(b))
+                elif fmt == FMT_IA:
+                    i = (b >> 4) & 0xF; al = b & 0xF
+                    row += bytes((i_expand(i, 4),) * 3 + (i_expand(al, 4),))
+                else:  # I8
+                    row += bytes((b, b, b, b))
+            elif siz == SIZ_4B:
+                a = base + t * line + (s >> 1)
+                b = tmem_byte(tmem, a, swizzle, odd)
+                nib = (b >> 4) if (s & 1) == 0 else (b & 0xF)
+                if fmt == FMT_CI:
+                    row += bytes(pal_rgba(pal_base | nib))
+                elif fmt == FMT_IA:
+                    i = (nib >> 1) & 0x7; al = nib & 0x1
+                    row += bytes((i_expand(i, 3),) * 3 + (255 if al else 0,))
+                else:  # I4
+                    v = i_expand(nib, 4)
+                    row += bytes((v, v, v, v))
+            else:  # 32b RGBA: RG in low bank, BA in high bank (+0x800)
+                a = base + t * line + s * 2
+                r = tmem_byte(tmem, a, swizzle, odd)
+                g = tmem_byte(tmem, a + 1, swizzle, odd)
+                b_ = tmem_byte(tmem, a + 0x800, swizzle, odd)
+                al = tmem_byte(tmem, a + 0x801, swizzle, odd)
+                row += bytes((r, g, b_, al))
+        rows.append(bytes(row))
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Decode an RT64 texture dump to PNGs.")
+    ap.add_argument("dump_dir", type=Path)
+    ap.add_argument("--out", type=Path, default=None, help="output dir (default <dump>/png)")
+    ap.add_argument("--source", choices=["tmem"], default="tmem",
+                    help="decode source (tmem only for now)")
+    ap.add_argument("--no-swizzle", action="store_true",
+                    help="disable the odd-row TMEM word swap (calibration knob)")
+    ap.add_argument("--pal-byteswap", action="store_true",
+                    help="byteswap palette uint16 reads (calibration knob)")
+    ap.add_argument("--filter", default=None, help="only decode hashes containing this hex substring")
+    args = ap.parse_args()
+
+    out = args.out or (args.dump_dir / "png")
+    out.mkdir(parents=True, exist_ok=True)
+    swizzle = not args.no_swizzle
+
+    tiles = sorted(args.dump_dir.glob("*.tile.json"))
+    if not tiles:
+        print(f"No *.tile.json in {args.dump_dir} -- is this a dump directory?", file=sys.stderr)
+        return 1
+
+    index = []
+    for tj in tiles:
+        base = tj.name[:-len(".tile.json")]     # e.g. "0001d055....v5"
+        hexhash = base.split(".")[0]
+        if args.filter and args.filter.lower() not in hexhash.lower():
+            continue
+        meta = json.loads(tj.read_text())
+        tile = meta["tile"]
+        width, height = int(meta["width"]), int(meta["height"])
+        tlut_kind = meta.get("tlut", "None")
+
+        tmem_path = args.dump_dir / (base + ".tmem")
+        if not tmem_path.exists():
+            print(f"skip {hexhash}: no .tmem", file=sys.stderr)
+            continue
+        tmem = tmem_path.read_bytes()
+
+        palette = []
+        if tile["fmt"] == FMT_CI:
+            pal_path = args.dump_dir / (base + ".rice.palette.rdram")
+            if pal_path.exists():
+                # Read up to a full 256-entry TLUT: CI4 indexes it as
+                # (tile.palette << 4) | nib, which reaches past the low 16 when a
+                # non-zero palette bank is selected. read_palette zero-fills a
+                # short file, so over-requesting is safe.
+                pal_data = pal_path.read_bytes()
+                count = min(256, len(pal_data) // 2)
+                palette = read_palette(pal_data, count, args.pal_byteswap)
+
+        if width <= 0 or height <= 0 or width > 1024 or height > 1024:
+            print(f"skip {hexhash}: implausible {width}x{height}", file=sys.stderr)
+            continue
+
+        rows = decode_from_tmem(tmem, tile, width, height, tlut_kind, palette, swizzle)
+        png_path = out / (hexhash + ".png")
+        write_png(png_path, width, height, rows)
+        index.append((hexhash, width, height, fmt_label(tile["fmt"], tile["siz"]), tlut_kind))
+
+    # Contact sheet for eyeballing the whole dump.
+    html = ["<!doctype html><meta charset=utf8><title>texture dump</title>",
+            "<style>body{background:#222;color:#ddd;font:12px monospace}",
+            "figure{display:inline-block;margin:6px;text-align:center;vertical-align:top}",
+            "img{image-rendering:pixelated;background:#000;border:1px solid #444;max-width:256px}",
+            "figcaption{max-width:256px;word-break:break-all}</style>"]
+    for h, w, ht, fl, tl in sorted(index):
+        html.append(f'<figure><img src="{h}.png" width="{min(w*2,256)}">'
+                    f'<figcaption>{h}<br>{w}x{ht} {fl} {tl}</figcaption></figure>')
+    (out / "index.html").write_text("\n".join(html))
+
+    print(f"decoded {len(index)} textures -> {out}")
+    print(f"open {out / 'index.html'} to browse")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/drive_input.py
+++ b/tools/drive_input.py
@@ -29,11 +29,16 @@ EXTENDED = {'up', 'down', 'left', 'right'}
 
 
 def find_window():
+    # Match SDL2's window class ('SDL_app'), NOT a title substring: an editor or
+    # browser with the repo ("...lamborghini-recomp...") open in a tab would
+    # otherwise match first and steal the screenshot/key events.
     hwnds = []
     def cb(h, l):
-        buf = ctypes.create_unicode_buffer(256)
-        user32.GetWindowTextW(h, buf, 256)
-        if 'amborghini' in buf.value and user32.IsWindowVisible(h):
+        cls = ctypes.create_unicode_buffer(256)
+        user32.GetClassNameW(h, cls, 256)
+        if cls.value == 'SDL_app' and user32.IsWindowVisible(h):
+            buf = ctypes.create_unicode_buffer(256)
+            user32.GetWindowTextW(h, buf, 256)
             hwnds.append((h, buf.value))
         return True
     user32.EnumWindows(ctypes.WINFUNCTYPE(ctypes.c_bool, wt.HWND, wt.LPARAM)(cb), 0)

--- a/tools/make_pack.py
+++ b/tools/make_pack.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Generate an RT64 texture-pack manifest (rt64.json) from replacement images (issue #9).
+
+RT64 loads a texture pack by reading rt64.json from the pack directory (or .rtz) -- it
+does NOT auto-scan for hash-named files. RT64's own `texture_hasher` only *upgrades* an
+existing rt64.json; it will not create one from scratch. This tool fills that gap: point
+it at a directory of replacement images named by the RT64 texture hash
+(`<16-hex-hash>.png` or `.dds`, the same hash RT64 writes as the dump filename) and it
+writes a valid rt64.json listing each.
+
+    python tools/make_pack.py <pack_dir> [--auto-path rt64|rice]
+                                         [--shift half|none] [--operation stream|preload]
+
+Then either point the port at <pack_dir> directly (graphics.json `texture_pack` /
+LAMBO_TEXTURE_PACK), or zip it into a shippable .rtz with RT64's texture_packer.
+
+Self-contained: standard library only.
+"""
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+HASH_RE = re.compile(r"^([0-9a-fA-F]{16})$")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Write rt64.json from hash-named replacement images.")
+    ap.add_argument("pack_dir", type=Path)
+    ap.add_argument("--auto-path", choices=["rt64", "rice"], default="rt64",
+                    help="which hash names the files on disk (default rt64)")
+    ap.add_argument("--shift", choices=["half", "none", "auto"], default="half",
+                    help="default texel shift; 'half' suits modern-tool exports (default)")
+    ap.add_argument("--operation", choices=["stream", "preload", "auto"], default="stream",
+                    help="default load operation (default stream)")
+    args = ap.parse_args()
+
+    textures = []
+    for p in sorted(args.pack_dir.iterdir()):
+        if p.suffix.lower() not in (".png", ".dds"):
+            continue
+        m = HASH_RE.match(p.stem)
+        if not m:
+            print(f"skip {p.name}: stem is not a 16-hex RT64 hash")
+            continue
+        h = m.group(1).lower()
+        textures.append({
+            "path": p.name,
+            "hashes": {"rt64": h, "rice": ""},
+            "operation": "auto",
+            "shift": "auto",
+        })
+
+    if not textures:
+        print(f"No <hash>.png/.dds files in {args.pack_dir}")
+        return 1
+
+    db = {
+        "configuration": {
+            "autoPath": args.auto_path,
+            "defaultOperation": args.operation,
+            "defaultShift": args.shift,
+            "hashVersion": 5,  # TMEMHasher::CurrentHashVersion
+        },
+        "textures": textures,
+    }
+    out = args.pack_dir / "rt64.json"
+    out.write_text(json.dumps(db, indent=2))
+    print(f"wrote {out} with {len(textures)} texture(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
First part of #9: dump, decode, author and load replacement textures — the foundation for HD / readable-text packs.

## What this does
RT64 already ships the entire texture dump/hash/replace system; the port had wired **none** of it (`rt64_renderer.cpp` was "adapted from Zelda64Recomp minus the texture-pack plumbing"). This exposes it:

- **`rt64_renderer.cpp`** — after `app->setup()`, enable RT64's texture dump and auto-load a replacement pack (directory **or** `.rtz`). Both opt-in (empty = off) and independent of `developer_mode`, so an end-user pack loads without the F1 overlay.
- **`lambo_config`** — `texture_pack` / `texture_dump` graphics.json keys (+ `LAMBO_TEXTURE_PACK` / `LAMBO_TEXTURE_DUMP` env overrides for headless capture).
- **`tools/decode_dump.py`** — RT64 dumps are raw TMEM (no image); this decodes them to viewable PNGs + a contact sheet. RGBA16/IA/I are pixel-clean; CI4/CI8 are approximate (LOAD_BLOCK 4-bit shearing — see follow-up).
- **`tools/make_pack.py`** — generate the required `rt64.json` from hash-named replacement files (RT64's `texture_hasher` only *upgrades* an existing manifest).
- **`tools/drive_input.py`** — match SDL's `SDL_app` window class instead of a title substring (was capturing a browser tab with the repo open).
- **`docs/TEXTURES.md`** — the full verified workflow.

## Verification
Build green; boot smoke passed. Replacing the HUD font-atlas texture (`aec01187`, CI4) turned the speedometer MPH digits and the title "COPYRIGHT 1997 TITUS" line solid magenta in-game, loaded purely from a config path. `.rtz` packaging round-trips.

## Note on #9's scope
#9 is titled "per-actor tagging (`gCurrGfxTag`)", but in the actual MM64 source `gCurrGfxTag` feeds RT64's frame-**interpolation** engine, **not** texture replacement — text replacement needs none of it (RT64 keys purely on the TMEM hash). This PR therefore delivers the texture-replacement foundation without the tagging work; recommend splitting #9. Details in an issue comment.

Does **not** close #9.