### PR TITLE
Widescreen skybox: rebuild background frustum aspect per frame (#3)

### DIFF
--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -400,6 +400,24 @@ func = "func_8004384C"
 before_vram = 0x80043C88
 text = "extern unsigned int lambo_ws_minimap_outline_x(unsigned int); ctx->r5 = S32(lambo_ws_minimap_outline_x((uint32_t)ctx->r5));"
 
+# Issue #3 — per-frame Mtx rebuild for the widescreen skybox. func_8004384C (the
+# per-frame 3D DL builder) opens the frame by calling func_80075500 (a hand-rolled
+# guPerspective-equivalent: fovy/aspect/near/far -> frustum -> Mtx) to build the
+# BACKGROUND/skybox layer's own projection, distinct from the main race camera. The
+# call site hardcodes the aspect argument ($a3) to the hex float literal 0x3FAAAAAB
+# (= 4/3, verified by decoding the IEEE-754 bits) via `lui $a3,0x3FAA` / `ori
+# $a3,$a3,0xAAAB` at 0x80042CE0/E4, so the frustum's tangent — and therefore the
+# skybox panels' screen coverage — stays sized for 4:3 no matter the RT64 output
+# width, leaving gaps at the wide edges under ar_option Expand. Hooked right after
+# the literal is fully assembled (0x80042CE8, not a branch-delay slot) and before it
+# is consumed by the jal at 0x80042CFC: overwrite $a3 with the live output aspect
+# (lambo_ws_get_output_aspect_bits, rt64_renderer.cpp) so the frustum widens with the
+# window — the fix degenerates to the original constant at 4:3 or ar_option Original.
+[[patches.hook]]
+func = "func_8004384C"
+before_vram = 0x80042CE8
+text = "extern unsigned int lambo_ws_get_output_aspect_bits(void); ctx->r7 = (int32_t)lambo_ws_get_output_aspect_bits();"
+
 # Issue #12 — developer warp menu. Per-frame warp tick at the entry of the TOP-LEVEL
 # state dispatcher func_800028D0 (runtime 0x80001CD0, argument-free, jump-table over
 # states 1..0x10, runs every frame in every state; func_800030F8 was tried first but

--- a/scripts/gen_syms_toml.py
+++ b/scripts/gen_syms_toml.py
@@ -732,6 +732,24 @@ func = "func_8004384C"
 before_vram = 0x80043C88
 text = "extern unsigned int lambo_ws_minimap_outline_x(unsigned int); ctx->r5 = S32(lambo_ws_minimap_outline_x((uint32_t)ctx->r5));"
 
+# Issue #3 — per-frame Mtx rebuild for the widescreen skybox. func_8004384C (the
+# per-frame 3D DL builder) opens the frame by calling func_80075500 (a hand-rolled
+# guPerspective-equivalent: fovy/aspect/near/far -> frustum -> Mtx) to build the
+# BACKGROUND/skybox layer's own projection, distinct from the main race camera. The
+# call site hardcodes the aspect argument ($a3) to the hex float literal 0x3FAAAAAB
+# (= 4/3, verified by decoding the IEEE-754 bits) via `lui $a3,0x3FAA` / `ori
+# $a3,$a3,0xAAAB` at 0x80042CE0/E4, so the frustum's tangent — and therefore the
+# skybox panels' screen coverage — stays sized for 4:3 no matter the RT64 output
+# width, leaving gaps at the wide edges under ar_option Expand. Hooked right after
+# the literal is fully assembled (0x80042CE8, not a branch-delay slot) and before it
+# is consumed by the jal at 0x80042CFC: overwrite $a3 with the live output aspect
+# (lambo_ws_get_output_aspect_bits, rt64_renderer.cpp) so the frustum widens with the
+# window — the fix degenerates to the original constant at 4:3 or ar_option Original.
+[[patches.hook]]
+func = "func_8004384C"
+before_vram = 0x80042CE8
+text = "extern unsigned int lambo_ws_get_output_aspect_bits(void); ctx->r7 = (int32_t)lambo_ws_get_output_aspect_bits();"
+
 # Issue #12 — developer warp menu. Per-frame warp tick at the entry of the TOP-LEVEL
 # state dispatcher func_800028D0 (runtime 0x80001CD0, argument-free, jump-table over
 # states 1..0x10, runs every frame in every state; func_800030F8 was tried first but

--- a/src/rt64_renderer.cpp
+++ b/src/rt64_renderer.cpp
@@ -9,6 +9,7 @@
 
 #define HLSL_CPU
 #include <algorithm>
+#include <atomic>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -41,6 +42,24 @@ uint32_t DPC_PIPEBUSY_REG = 0;
 uint32_t DPC_TMEM_REG = 0;
 
 void dummy_check_interrupts() {}
+
+// Live swapchain handle for the background/skybox aspect-ratio fix (issue #3): the
+// course frame-builder (func_8004384C) issues its own frustum matrix for the
+// background layer with a HARDCODED 4/3 literal (0x3FAAAAAB) baked at the call site,
+// so under RT64 Expand the skybox panels stay sized for 4:3 and don't reach the wide
+// edges. lambo_ws_get_output_aspect_bits() below lets a patches.hook override that
+// literal with the live output aspect each frame, mirroring the HUD widescreen gate
+// (lambo_ws_hud_widescreen_active in lambo_config.cpp) but reading the actual ratio
+// instead of a bool, since a symmetric frustum only needs a wider tangent, not a
+// separate translate (unlike the 2D HUD's rect-align + matrix-nudge scheme).
+//
+// Written on the gfx thread (RT64Context ctor/dtor), read every frame on the CPU/
+// game-logic thread inside lambo_ws_get_output_aspect_bits() below -- unlike
+// get_resolution_scale() elsewhere in this file, which is only ever called from the
+// gfx thread itself. atomic (not a plain pointer) so the CPU thread can't observe a
+// torn or stale value; the dtor nulls it before `app` is torn down so a load racing
+// shutdown sees either the fully-live pointer or nullptr, never a dangling one.
+std::atomic<RT64::Application*> g_lambo_active_app{nullptr};
 
 RT64::UserConfiguration::AspectRatio to_rt64(ultramodern::renderer::AspectRatio option) {
     switch (option) {
@@ -232,9 +251,14 @@ public:
         }
 
         std::fprintf(stderr, "[rt64] RT64 renderer initialised (api=%d)\n", (int)chosen_api);
+        g_lambo_active_app = app.get();
     }
 
-    ~RT64Context() override = default;
+    ~RT64Context() override {
+        if (g_lambo_active_app == app.get()) {
+            g_lambo_active_app = nullptr;
+        }
+    }
 
     bool valid() override { return static_cast<bool>(app); }
 
@@ -343,6 +367,35 @@ private:
 };
 
 } // anonymous namespace
+
+// Native for the issue #3 patches.hook (lamborghini.us.toml, func_8004384C): returns
+// the live output aspect ratio as raw float bits, clamped to never go BELOW 4/3 so a
+// narrower-than-4:3 window (or ar_option != Expand) degenerates to the original
+// constant rather than squeezing the skybox. Called from recompiled game code on the
+// game-logic thread, which races the gfx/render thread's swapchain resize handling;
+// take the same configurationMutex RT64::SharedQueueResources::setSwapChainSize()
+// locks when writing width+height together, so this never observes a torn pair.
+extern "C" uint32_t lambo_ws_get_output_aspect_bits(void) {
+    float aspect = 4.0f / 3.0f;
+    const auto& cfg = ultramodern::renderer::get_graphics_config();
+    RT64::Application* active_app = g_lambo_active_app.load(std::memory_order_acquire);
+    if (cfg.ar_option == ultramodern::renderer::AspectRatio::Expand &&
+        active_app != nullptr && active_app->sharedQueueResources) {
+        auto& shared = *active_app->sharedQueueResources;
+        std::scoped_lock<std::mutex> configuration_lock(shared.configurationMutex);
+        uint32_t w = shared.swapChainWidth;
+        uint32_t h = shared.swapChainHeight;
+        if (w > 0 && h > 0) {
+            float live = float(w) / float(h);
+            if (live > aspect) {
+                aspect = live;
+            }
+        }
+    }
+    uint32_t bits;
+    std::memcpy(&bits, &aspect, sizeof(bits));
+    return bits;
+}
 
 namespace lambo_rt64 {
 


### PR DESCRIPTION
## Summary
- `func_8004384C` (the per-frame 3D scene builder) calls `func_80075500`, a hand-rolled guPerspective-equivalent that builds the background/skybox layer's own frustum matrix. The call site hardcodes the aspect argument to the IEEE-754 literal `0x3FAAAAAB` (exactly 4/3), so the skybox stays 4:3-sized regardless of RT64's output width under `ar_option Expand`, leaving gaps at the wide edges.
- A `[[patches.hook]]` at `before_vram=0x80042CE8` overrides that argument with a live output aspect ratio from a new native, `lambo_ws_get_output_aspect_bits()` (`src/rt64_renderer.cpp`), which degenerates to the original 4/3 constant at 4:3 output or when `ar_option != Expand`.
- Mirrored the new hook into `scripts/gen_syms_toml.py`'s `PATCH_BLOCKS` so a future regen of `lamborghini.us.toml` doesn't silently drop it — the generator's own comment already flags this exact trap for the sibling widescreen-HUD/minimap patches.
- Hardened the new native against two cross-thread races caught in review: swap-chain width/height are now read under RT64's own `configurationMutex` (matching its resize writer) instead of racing it, and the cross-thread `Application*` handle is now `std::atomic` instead of a plain pointer racing renderer teardown.

## Test plan
- [x] Clean `lamborghini_modern` build succeeds (Ninja, full link).
- [x] Regenerating `lamborghini.us.toml` via `scripts/gen_syms_toml.py` reproduces the landed patch byte-for-byte (confirms `PATCH_BLOCKS` is in sync).
- [x] Boot smoke test via `LAMBO_WARP` into a race — no crash, race renders normally.
- [x] Visual verification: skybox now fills the 16:9 frame edge-to-edge under the shipped `Expand` defaults; confirmed a pre-existing, unrelated gouraud-shading seam in the sky gradient mesh reproduces identically at native 4:3 (`ar_option: Original`), so it's not a regression from this change.

Closes #3