### PR TITLE
decode_dump.py: fix CI4/CI8 sheared/miscoloured textures (#50)

### DIFF
--- a/docs/TEXTURES.md
+++ b/docs/TEXTURES.md
@@ -73,11 +73,16 @@ python tools/decode_dump.py /path/to/dump          # writes <dump>/png/*.png + i
 Open `index.html` (a contact sheet) to eyeball the whole dump. **Decode fidelity:**
 - **RGBA16 / RGBA32 / IA / I** — accurate. The "automobili Lamborghini" wordmark tiles
   decoded pixel-clean.
-- **CI4 / CI8** (palettized — *the format most fonts use*) — good enough to **identify** a
-  texture, but 4-bit textures loaded via `LOAD_BLOCK` are sheared/off-colour because the
-  block DXT interleave isn't emulated yet (`--no-swizzle` / `--pal-byteswap` are calibration
-  knobs; neither fully fixes it). Follow-up work. For a **pixel-perfect** view of one
-  texture, use RT64's live F1 inspector (below), which shows it GPU-decoded.
+- **CI4 / CI8** (palettized — *the format most fonts use*) — accurate as of issue #50.
+  They used to come out "sheared and miscoloured", but the cause was the **TLUT byte order**,
+  not the texel decode: `.rice.palette.rdram` is raw RDRAM, which RT64 stores byte-swapped
+  within each 32-bit word (logical byte `A` at physical `A^3`). Reading the 16-bit palette
+  entries without that swap mapped every index to a garbled RGBA5551 value, and because the
+  noise still carried the image's index structure it *looked* like a diagonal shear. The tool
+  now reads the palette through the `^3` swap by default (`--pal-no-swap` is a calibration
+  knob). Texels still decode from `.tmem`, which was already correct. Verified end-to-end: the
+  `aec01187` 512×8 font atlas reads as legible characters and the sky/cloud CI4 tiles show
+  clean blue/gold. RT64's live F1 inspector still gives a GPU-decoded cross-check.
 
 ### 3. Identify the text
 

--- a/tools/decode_dump.py
+++ b/tools/decode_dump.py
@@ -4,11 +4,12 @@
 RT64's "Start dumping textures" (or this port's `texture_dump` config / LAMBO_TEXTURE_DUMP
 env) writes, per unique texture, a set of files named by the 64-bit texture hash:
 
-    <hash>.v5.tmem              raw 4 KB TMEM snapshot (the sampled texel data)
+    <hash>.v5.tmem              raw 4 KB TMEM snapshot -- this tool decodes texels from here
     <hash>.v5.tile.json         { tile:{fmt,siz,line,tmem,palette,...}, width, height, tlut }
-    <hash>.v5.rice.rdram        linear RDRAM slice the tile loaded from (alt decode source)
+    <hash>.v5.rice.rdram        linear RDRAM slice the tile loaded from (not used by this tool;
+                                a block source can't be un-interleaved without replaying DXT)
     <hash>.v5.rice.json         { tile, type, texture:{address,fmt,siz,width} }
-    <hash>.v5.rice.palette.rdram  TLUT bytes (CI textures only)
+    <hash>.v5.rice.palette.rdram  raw TLUT bytes, CI textures only -- the palette source
 
 Neither RT64 nor its texture_hasher/texture_packer tools turn these into an image, so you
 cannot *see* a texture to decide whether it is the hard-to-read text you want to replace.
@@ -113,49 +114,28 @@ def tmem_byte(tmem, addr, swizzle, row_odd):
 #
 # RT64 keeps RDRAM byte-swapped within each 32-bit word: the logical byte at N64
 # address A physically lives at RDRAM[A ^ 3] (see loadWord() in rt64_rdp.cpp,
-# `RDRAM[(textureAddress + i) ^ 3]`). The .rice* dumps are a *raw* copy of that
-# physical RDRAM, so reading a logical byte back needs the same `^ 3` -- but the
-# swap is anchored to the true RDRAM address the slice started at, not to the
-# slice's own offset 0, in case that address is not 4-aligned. This is what the
-# palette read below uses; texels come from the (logical-order) .tmem snapshot.
+# `RDRAM[(textureAddress + i) ^ 3]`). The .rice.palette.rdram dump is a *raw* copy
+# of that physical RDRAM, so reading a logical byte back needs the same `^ 3`.
+# A TLUT is DMA-loaded, so its slice always starts 8-aligned -- the swap therefore
+# reduces to a plain `logical_off ^ 3` with no per-slice address anchor. (Texels
+# come from the logical-order .tmem snapshot, which needs no such swap.)
 
-def rdram_byte(buf, rdram_start, logical_off, swap=True):
-    """Read one logical byte at `logical_off` from a raw RDRAM slice that began at
-    absolute address `rdram_start`. With swap, undoes RT64's 32-bit-word byteswap."""
-    if swap:
-        file_off = ((rdram_start + logical_off) ^ 0x3) - rdram_start
-    else:
-        file_off = logical_off
+def rdram_byte(buf, logical_off, swap=True):
+    """Read one logical byte at `logical_off` from a raw, 8-aligned RDRAM slice.
+    With swap, undoes RT64's 32-bit-word byteswap (`^ 3`)."""
+    file_off = (logical_off ^ 0x3) if swap else logical_off
     if 0 <= file_off < len(buf):
         return buf[file_off]
     return 0
 
 
-def rice_rdram_start(info_path):
-    """Absolute RDRAM address the .rice(.palette).rdram slice began at, mirroring
-    RT64's dumpTexture(). Only its low 2 bits matter (the word-swap anchor), but
-    computing it in full keeps unaligned block sources honest. Missing/short info
-    -> 0, i.e. assume a 4-aligned slice."""
-    try:
-        meta = json.loads(info_path.read_text())
-    except (OSError, ValueError):
-        return 0
-    tile, tex = meta.get("tile", {}), meta.get("texture", {})
-    siz = tex.get("siz", 0)
-    uls, ult = tile.get("uls", 0), tile.get("ult", 0)
-    common_offset = ((uls >> 2) << siz) >> 1
-    common_bpr = (tex.get("width", 0) << siz) >> 1
-    row = ult if meta.get("type") == "Block" else (ult >> 2)
-    return tex.get("address", 0) + common_offset + common_bpr * row
-
-
-def read_palette_rdram(pal_bytes, count, swap=True, rdram_start=0):
+def read_palette_rdram(pal_bytes, count, swap=True):
     """TLUT entries are big-endian uint16 in logical N64 memory. The dump is raw
     physical RDRAM, so read each byte through RT64's 32-bit-word swap."""
     entries = []
     for i in range(count):
-        hi = rdram_byte(pal_bytes, rdram_start, i * 2, swap)
-        lo = rdram_byte(pal_bytes, rdram_start, i * 2 + 1, swap)
+        hi = rdram_byte(pal_bytes, i * 2, swap)
+        lo = rdram_byte(pal_bytes, i * 2 + 1, swap)
         entries.append((hi << 8) | lo)
     return entries
 
@@ -189,7 +169,8 @@ def decode_from_tmem(tmem, tile, width, height, tlut_kind, palette, swizzle):
                 if fmt == FMT_CI:
                     row += bytes(pal_rgba(b))
                 elif fmt == FMT_IA:
-                    i = (b >> 4) & 0xF; al = b & 0xF
+                    i = (b >> 4) & 0xF
+                    al = b & 0xF
                     row += bytes((i_expand(i, 4),) * 3 + (i_expand(al, 4),))
                 else:  # I8
                     row += bytes((b, b, b, b))
@@ -200,7 +181,8 @@ def decode_from_tmem(tmem, tile, width, height, tlut_kind, palette, swizzle):
                 if fmt == FMT_CI:
                     row += bytes(pal_rgba(pal_base | nib))
                 elif fmt == FMT_IA:
-                    i = (nib >> 1) & 0x7; al = nib & 0x1
+                    i = (nib >> 1) & 0x7
+                    al = nib & 0x1
                     row += bytes((i_expand(i, 3),) * 3 + (255 if al else 0,))
                 else:  # I4
                     v = i_expand(nib, 4)
@@ -267,10 +249,8 @@ def main():
                 # byteswap (issue #50: without it every index maps to a garbled
                 # RGBA5551 value, which reads as "sheared and miscoloured").
                 pal_data = pal_path.read_bytes()
-                pal_start = rice_rdram_start(args.dump_dir / (base + ".rice.palette.json"))
                 count = min(256, len(pal_data) // 2)
-                palette = read_palette_rdram(pal_data, count,
-                                             not args.pal_no_swap, pal_start)
+                palette = read_palette_rdram(pal_data, count, not args.pal_no_swap)
 
         if width <= 0 or height <= 0 or width > 1024 or height > 1024:
             print(f"skip {hexhash}: implausible {width}x{height}", file=sys.stderr)

--- a/tools/decode_dump.py
+++ b/tools/decode_dump.py
@@ -21,9 +21,17 @@ fine. Byte-order/swizzle flags exist because the port hands RT64 its RDRAM in a
 mupen/N64Recomp convention; calibrate once against an in-game screenshot, then leave the
 working flags as the defaults.
 
+CI4/CI8 (palettized) textures used to come out "sheared and miscoloured" (issue #50).
+The root cause was the TLUT byte order, not the texel decode: the .rice.palette.rdram
+dump is a *raw* copy of RT64's RDRAM, which stores every 32-bit word byte-swapped
+(logical byte A lives at physical A^3, see loadWord() in rt64_rdp.cpp). Reading the
+16-bit TLUT entries without that swap maps each palette index to a garbled RGBA5551
+value; because the noise still carries the image's index structure it reads as a
+diagonal "shear". Applying the ^3 swap when reading the palette fixes both symptoms.
+
 Usage:
-    python tools/decode_dump.py <dump_dir> [--out <png_dir>] [--source tmem|rdram]
-                                           [--no-swizzle] [--rdram-byteswap]
+    python tools/decode_dump.py <dump_dir> [--out <png_dir>]
+                                           [--no-swizzle] [--pal-no-swap]
                                            [--filter <hex-substr>]
 
 Self-contained: standard library only (zlib for PNG deflate).
@@ -101,17 +109,54 @@ def tmem_byte(tmem, addr, swizzle, row_odd):
     return 0
 
 
-def read_palette(pal_bytes, count, byteswap):
-    """TLUT entries are 16-bit. Returns list of raw uint16 values."""
+# --- linear RDRAM addressing (for the .rice.palette.rdram TLUT slice) -----------
+#
+# RT64 keeps RDRAM byte-swapped within each 32-bit word: the logical byte at N64
+# address A physically lives at RDRAM[A ^ 3] (see loadWord() in rt64_rdp.cpp,
+# `RDRAM[(textureAddress + i) ^ 3]`). The .rice* dumps are a *raw* copy of that
+# physical RDRAM, so reading a logical byte back needs the same `^ 3` -- but the
+# swap is anchored to the true RDRAM address the slice started at, not to the
+# slice's own offset 0, in case that address is not 4-aligned. This is what the
+# palette read below uses; texels come from the (logical-order) .tmem snapshot.
+
+def rdram_byte(buf, rdram_start, logical_off, swap=True):
+    """Read one logical byte at `logical_off` from a raw RDRAM slice that began at
+    absolute address `rdram_start`. With swap, undoes RT64's 32-bit-word byteswap."""
+    if swap:
+        file_off = ((rdram_start + logical_off) ^ 0x3) - rdram_start
+    else:
+        file_off = logical_off
+    if 0 <= file_off < len(buf):
+        return buf[file_off]
+    return 0
+
+
+def rice_rdram_start(info_path):
+    """Absolute RDRAM address the .rice(.palette).rdram slice began at, mirroring
+    RT64's dumpTexture(). Only its low 2 bits matter (the word-swap anchor), but
+    computing it in full keeps unaligned block sources honest. Missing/short info
+    -> 0, i.e. assume a 4-aligned slice."""
+    try:
+        meta = json.loads(info_path.read_text())
+    except (OSError, ValueError):
+        return 0
+    tile, tex = meta.get("tile", {}), meta.get("texture", {})
+    siz = tex.get("siz", 0)
+    uls, ult = tile.get("uls", 0), tile.get("ult", 0)
+    common_offset = ((uls >> 2) << siz) >> 1
+    common_bpr = (tex.get("width", 0) << siz) >> 1
+    row = ult if meta.get("type") == "Block" else (ult >> 2)
+    return tex.get("address", 0) + common_offset + common_bpr * row
+
+
+def read_palette_rdram(pal_bytes, count, swap=True, rdram_start=0):
+    """TLUT entries are big-endian uint16 in logical N64 memory. The dump is raw
+    physical RDRAM, so read each byte through RT64's 32-bit-word swap."""
     entries = []
     for i in range(count):
-        off = i * 2
-        if byteswap:
-            off ^= 0x2
-        if off + 1 < len(pal_bytes):
-            entries.append((pal_bytes[off] << 8) | pal_bytes[off + 1])
-        else:
-            entries.append(0)
+        hi = rdram_byte(pal_bytes, rdram_start, i * 2, swap)
+        lo = rdram_byte(pal_bytes, rdram_start, i * 2 + 1, swap)
+        entries.append((hi << 8) | lo)
     return entries
 
 
@@ -175,12 +220,12 @@ def main():
     ap = argparse.ArgumentParser(description="Decode an RT64 texture dump to PNGs.")
     ap.add_argument("dump_dir", type=Path)
     ap.add_argument("--out", type=Path, default=None, help="output dir (default <dump>/png)")
-    ap.add_argument("--source", choices=["tmem"], default="tmem",
-                    help="decode source (tmem only for now)")
     ap.add_argument("--no-swizzle", action="store_true",
                     help="disable the odd-row TMEM word swap (calibration knob)")
-    ap.add_argument("--pal-byteswap", action="store_true",
-                    help="byteswap palette uint16 reads (calibration knob)")
+    ap.add_argument("--pal-no-swap", action="store_true",
+                    help="read the TLUT without RT64's 32-bit-word byteswap "
+                         "(calibration knob; the swapped read is correct for this port "
+                         "and is the default -- issue #50)")
     ap.add_argument("--filter", default=None, help="only decode hashes containing this hex substring")
     args = ap.parse_args()
 
@@ -216,11 +261,16 @@ def main():
             if pal_path.exists():
                 # Read up to a full 256-entry TLUT: CI4 indexes it as
                 # (tile.palette << 4) | nib, which reaches past the low 16 when a
-                # non-zero palette bank is selected. read_palette zero-fills a
-                # short file, so over-requesting is safe.
+                # non-zero palette bank is selected. read_palette_rdram zero-fills
+                # a short file, so over-requesting is safe. The .rice.palette.rdram
+                # is raw physical RDRAM, so the entries need RT64's 32-bit-word
+                # byteswap (issue #50: without it every index maps to a garbled
+                # RGBA5551 value, which reads as "sheared and miscoloured").
                 pal_data = pal_path.read_bytes()
+                pal_start = rice_rdram_start(args.dump_dir / (base + ".rice.palette.json"))
                 count = min(256, len(pal_data) // 2)
-                palette = read_palette(pal_data, count, args.pal_byteswap)
+                palette = read_palette_rdram(pal_data, count,
+                                             not args.pal_no_swap, pal_start)
 
         if width <= 0 or height <= 0 or width > 1024 or height > 1024:
             print(f"skip {hexhash}: implausible {width}x{height}", file=sys.stderr)

--- a/tools/test_decode_dump.py
+++ b/tools/test_decode_dump.py
@@ -42,22 +42,16 @@ class TestRdramByteAddressing(unittest.TestCase):
     def test_physical_read_undoes_word_swap(self):
         logical = bytes(range(16))
         phys = to_physical(logical)
-        got = bytes(dd.rdram_byte(phys, 0, i, swap=True) for i in range(16))
+        got = bytes(dd.rdram_byte(phys, i, swap=True) for i in range(16))
         self.assertEqual(got, logical)
 
     def test_no_swap_is_identity(self):
         phys = bytes(range(16))
-        got = bytes(dd.rdram_byte(phys, 0, i, swap=False) for i in range(16))
+        got = bytes(dd.rdram_byte(phys, i, swap=False) for i in range(16))
         self.assertEqual(got, phys)
 
-    def test_aligned_base_matches_plain_xor3(self):
-        # DMA sources are 8-aligned, so the anchored swap reduces to a plain L^3.
-        buf = bytes(range(16))
-        for base in (0, 0x1000, 0x2E800):
-            for L in range(16):
-                self.assertEqual(dd.rdram_byte(buf, base, L, swap=True),
-                                 dd.rdram_byte(buf, 0, L, swap=True),
-                                 f"base={base:#x} L={L}")
+    def test_out_of_range_is_zero(self):
+        self.assertEqual(dd.rdram_byte(b"\x01\x02\x03\x04", 100, swap=True), 0)
 
 
 class TestPaletteByteOrder(unittest.TestCase):
@@ -75,34 +69,60 @@ class TestPaletteByteOrder(unittest.TestCase):
                             entries)
 
 
-class TestRiceRdramStart(unittest.TestCase):
-    def test_block_uses_full_ult(self):
-        import json
-        import tempfile
-        from pathlib import Path
-        with tempfile.TemporaryDirectory() as d:
-            p = Path(d) / "x.json"
-            p.write_text(json.dumps({
-                "type": "Block", "tile": {"uls": 0, "ult": 2},
-                "texture": {"address": 0x1000, "siz": 0, "width": 8}}))
-            # common_bpr = 8<<0>>1 = 4; +4*2 = 8
-            self.assertEqual(dd.rice_rdram_start(p), 0x1000 + 8)
-
-    def test_missing_file_is_zero(self):
-        from pathlib import Path
-        self.assertEqual(dd.rice_rdram_start(Path("does_not_exist.json")), 0)
-
-
 class TestEndToEnd(unittest.TestCase):
     """Drive main() over a synthetic dump laid out as RT64 writes it (TMEM in
     logical order with the odd-row xor, palette in physical RDRAM order) and
-    confirm the emitted PNG pixels carry the intended palette colours."""
+    confirm the emitted PNG pixels carry the intended palette colours.
+
+    Note: the palette fixture is byte-swapped with the same ^3 the decoder inverts,
+    so these tests pin the addressing math's *self-consistency*, not the byte-order
+    hypothesis itself -- that rests on RT64's loadWord() (`RDRAM[addr ^ 3]`, the
+    authoritative source) and was confirmed by eyeballing the real aec01187 dump."""
+
+    @staticmethod
+    def _decode_png(png):
+        import struct
+        import zlib
+        idat = b""
+        i = 8
+        w = h = 0
+        while i < len(png):
+            ln = struct.unpack(">I", png[i:i + 4])[0]
+            tag = png[i + 4:i + 8]
+            data = png[i + 8:i + 8 + ln]
+            if tag == b"IHDR":
+                w, h = struct.unpack(">II", data[:8])
+            elif tag == b"IDAT":
+                idat += data
+            i += 12 + ln
+        raw = zlib.decompress(idat)
+        stride = 1 + w * 4
+        px = [[tuple(raw[t * stride + 1 + s * 4:t * stride + 1 + s * 4 + 4])
+               for s in range(w)] for t in range(h)]
+        return w, h, px
+
+    def _run_main(self, dump, out):
+        import contextlib
+        import io
+        import sys
+        argv = sys.argv
+        sys.argv = ["decode_dump.py", str(dump), "--out", str(out)]
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(dd.main(), 0)
+        finally:
+            sys.argv = argv
+
+    def _write_dump(self, dump, base, tile, width, height, entries, tmem):
+        import json
+        (dump / (base + ".tile.json")).write_text(json.dumps(
+            {"tile": tile, "width": width, "height": height, "tlut": "RGBA16"}))
+        (dump / (base + ".tmem")).write_bytes(bytes(tmem))
+        (dump / (base + ".rice.palette.rdram")).write_bytes(
+            to_physical(pack_palette_logical(entries)))
 
     def test_ci8_dump_decodes_to_correct_colours(self):
-        import json
-        import struct
         import tempfile
-        import zlib
         from pathlib import Path
 
         width, height, line = 8, 4, 1        # 8 bytes/row, tmem word stride 8
@@ -114,54 +134,61 @@ class TestEndToEnd(unittest.TestCase):
         for t in range(height):
             xor = 0x4 if (t & 1) else 0x0
             for s in range(width):
-                idx = (t * width + s) & 0xFF
-                tmem[(t * line * 8 + s) ^ xor] = idx
+                tmem[(t * line * 8 + s) ^ xor] = (t * width + s) & 0xFF
 
         with tempfile.TemporaryDirectory() as d:
             dump = Path(d)
             base = "abc0000000000001.v5"
             tile = {"fmt": dd.FMT_CI, "siz": dd.SIZ_8B, "line": line, "palette": 0,
                     "tmem": 0, "uls": 0, "ult": 0}
-            (dump / (base + ".tile.json")).write_text(json.dumps(
-                {"tile": tile, "width": width, "height": height, "tlut": "RGBA16"}))
-            (dump / (base + ".tmem")).write_bytes(bytes(tmem))
-            (dump / (base + ".rice.palette.rdram")).write_bytes(
-                to_physical(pack_palette_logical(entries)))
-            (dump / (base + ".rice.palette.json")).write_text(json.dumps(
-                {"tile": {"uls": 0, "ult": 0}, "type": "TLUT",
-                 "texture": {"address": 0x2000, "siz": 2, "width": 256}}))
-
+            self._write_dump(dump, base, tile, width, height, entries, tmem)
             out = dump / "png"
-            import sys
-            argv = sys.argv
-            sys.argv = ["decode_dump.py", str(dump), "--out", str(out)]
-            try:
-                self.assertEqual(dd.main(), 0)
-            finally:
-                sys.argv = argv
+            self._run_main(dump, out)
 
-            png = (out / (base.split(".")[0] + ".png")).read_bytes()
-            self.assertTrue(png.startswith(b"\x89PNG"))
-            idat = b""
-            i = 8
-            w = h = 0
-            while i < len(png):
-                ln = struct.unpack(">I", png[i:i + 4])[0]
-                tag = png[i + 4:i + 8]
-                data = png[i + 8:i + 8 + ln]
-                if tag == b"IHDR":
-                    w, h = struct.unpack(">II", data[:8])
-                elif tag == b"IDAT":
-                    idat += data
-                i += 12 + ln
+            w, h, px = self._decode_png((out / "abc0000000000001.png").read_bytes())
             self.assertEqual((w, h), (width, height))
-            raw = zlib.decompress(idat)
-            stride = 1 + width * 4
             for (t, s) in [(0, 0), (0, 7), (1, 3), (3, 5)]:
                 idx = (t * width + s) & 0xFF
-                exp = dd.rgba16_to_rgba8(entries[idx])
-                off = t * stride + 1 + s * 4
-                self.assertEqual(tuple(raw[off:off + 4]), exp, f"pixel ({t},{s})")
+                self.assertEqual(px[t][s], dd.rgba16_to_rgba8(entries[idx]),
+                                 f"pixel ({t},{s})")
+
+    def test_ci4_dump_decodes_to_correct_colours(self):
+        # Issue #50's motivating case: a CI4 font-shaped strip. Exercises the
+        # nibble split (high nibble = even s), a non-zero sub-palette bank, and
+        # the odd-row TMEM swizzle -- end to end through main().
+        import tempfile
+        from pathlib import Path
+
+        width, height, line, bank = 16, 4, 1, 2   # 8 bytes/row; palette bank 2
+        pal_base = bank << 4
+        entries = [(((i & 0x1F) << 11) | 0x0001) for i in range(256)]
+
+        # Logical CI4 index for texel (t,s), then pack 2 nibbles/byte and lay the
+        # bytes into TMEM in logical order with the odd-row xor 0x4.
+        def idx_of(t, s):
+            return (t * width + s) & 0xF
+
+        tmem = bytearray(4096)
+        for t in range(height):
+            xor = 0x4 if (t & 1) else 0x0
+            for sb in range(width // 2):
+                byte = (idx_of(t, sb * 2) << 4) | idx_of(t, sb * 2 + 1)
+                tmem[(t * line * 8 + sb) ^ xor] = byte
+
+        with tempfile.TemporaryDirectory() as d:
+            dump = Path(d)
+            base = "def0000000000002.v5"
+            tile = {"fmt": dd.FMT_CI, "siz": dd.SIZ_4B, "line": line,
+                    "palette": bank, "tmem": 0, "uls": 0, "ult": 0}
+            self._write_dump(dump, base, tile, width, height, entries, tmem)
+            out = dump / "png"
+            self._run_main(dump, out)
+
+            w, h, px = self._decode_png((out / "def0000000000002.png").read_bytes())
+            self.assertEqual((w, h), (width, height))
+            for (t, s) in [(0, 0), (0, 1), (0, 15), (1, 4), (3, 9)]:
+                exp = dd.rgba16_to_rgba8(entries[pal_base | idx_of(t, s)])
+                self.assertEqual(px[t][s], exp, f"pixel ({t},{s})")
 
 
 if __name__ == "__main__":

--- a/tools/test_decode_dump.py
+++ b/tools/test_decode_dump.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Regression tests for tools/decode_dump.py, focused on issue #50: CI4/CI8
+textures decoded "sheared and miscoloured".
+
+The root cause is the TLUT byte order. RT64's .rice.palette.rdram dump is a *raw*
+copy of RDRAM, and RT64 stores every 32-bit word byte-swapped -- the logical byte
+at address A physically lives at A^3 (see loadWord() in rt64_rdp.cpp,
+`RDRAM[(textureAddress + i) ^ 3]`). Reading the 16-bit palette entries without that
+swap maps each index to a garbled RGBA5551 value; the resulting noise still carries
+the image's index structure, so it reads as a diagonal "shear". These tests pin the
+correct swapped read, and drive main() end-to-end to confirm the emitted PNG colours.
+
+Run: python tools/test_decode_dump.py   (stdlib unittest, no deps)
+"""
+
+import unittest
+
+import decode_dump as dd
+
+
+def to_physical(logical: bytes) -> bytes:
+    """Lay out `logical` bytes the way RT64 stores RDRAM: byte at logical offset L
+    is placed at physical offset L ^ 3 (32-bit word byte swap). Assumes a 4-aligned
+    base, which is what a DMA source always is."""
+    n = (len(logical) + 3) & ~3
+    phys = bytearray(n)
+    for i, b in enumerate(logical):
+        phys[i ^ 3] = b
+    return bytes(phys)
+
+
+def pack_palette_logical(entries):
+    """entries: list of uint16 -> big-endian logical TLUT bytes (as they sit in
+    N64 memory before RT64's physical byte swap)."""
+    out = bytearray()
+    for v in entries:
+        out += bytes(((v >> 8) & 0xFF, v & 0xFF))
+    return bytes(out)
+
+
+class TestRdramByteAddressing(unittest.TestCase):
+    def test_physical_read_undoes_word_swap(self):
+        logical = bytes(range(16))
+        phys = to_physical(logical)
+        got = bytes(dd.rdram_byte(phys, 0, i, swap=True) for i in range(16))
+        self.assertEqual(got, logical)
+
+    def test_no_swap_is_identity(self):
+        phys = bytes(range(16))
+        got = bytes(dd.rdram_byte(phys, 0, i, swap=False) for i in range(16))
+        self.assertEqual(got, phys)
+
+    def test_aligned_base_matches_plain_xor3(self):
+        # DMA sources are 8-aligned, so the anchored swap reduces to a plain L^3.
+        buf = bytes(range(16))
+        for base in (0, 0x1000, 0x2E800):
+            for L in range(16):
+                self.assertEqual(dd.rdram_byte(buf, base, L, swap=True),
+                                 dd.rdram_byte(buf, 0, L, swap=True),
+                                 f"base={base:#x} L={L}")
+
+
+class TestPaletteByteOrder(unittest.TestCase):
+    def test_swapped_read_recovers_entries(self):
+        entries = [0xF801, 0x07C1, 0x003F, 0x0001, 0xFFFF, 0x8421]
+        phys = to_physical(pack_palette_logical(entries))
+        self.assertEqual(dd.read_palette_rdram(phys, len(entries), swap=True), entries)
+
+    def test_unswapped_read_is_wrong_for_this_port(self):
+        # The old default (straight big-endian) is exactly what miscoloured the
+        # textures -- prove it disagrees with the correct swapped read.
+        entries = [0xF801, 0x07C1, 0x003F, 0x8421]
+        phys = to_physical(pack_palette_logical(entries))
+        self.assertNotEqual(dd.read_palette_rdram(phys, len(entries), swap=False),
+                            entries)
+
+
+class TestRiceRdramStart(unittest.TestCase):
+    def test_block_uses_full_ult(self):
+        import json
+        import tempfile
+        from pathlib import Path
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "x.json"
+            p.write_text(json.dumps({
+                "type": "Block", "tile": {"uls": 0, "ult": 2},
+                "texture": {"address": 0x1000, "siz": 0, "width": 8}}))
+            # common_bpr = 8<<0>>1 = 4; +4*2 = 8
+            self.assertEqual(dd.rice_rdram_start(p), 0x1000 + 8)
+
+    def test_missing_file_is_zero(self):
+        from pathlib import Path
+        self.assertEqual(dd.rice_rdram_start(Path("does_not_exist.json")), 0)
+
+
+class TestEndToEnd(unittest.TestCase):
+    """Drive main() over a synthetic dump laid out as RT64 writes it (TMEM in
+    logical order with the odd-row xor, palette in physical RDRAM order) and
+    confirm the emitted PNG pixels carry the intended palette colours."""
+
+    def test_ci8_dump_decodes_to_correct_colours(self):
+        import json
+        import struct
+        import tempfile
+        import zlib
+        from pathlib import Path
+
+        width, height, line = 8, 4, 1        # 8 bytes/row, tmem word stride 8
+        entries = [(((i & 0x1F) << 11) | ((i & 0x3F) << 5) | 0x0001)
+                   for i in range(256)]
+
+        # Build TMEM the way loadTile would: logical bytes, odd rows xor 0x4.
+        tmem = bytearray(4096)
+        for t in range(height):
+            xor = 0x4 if (t & 1) else 0x0
+            for s in range(width):
+                idx = (t * width + s) & 0xFF
+                tmem[(t * line * 8 + s) ^ xor] = idx
+
+        with tempfile.TemporaryDirectory() as d:
+            dump = Path(d)
+            base = "abc0000000000001.v5"
+            tile = {"fmt": dd.FMT_CI, "siz": dd.SIZ_8B, "line": line, "palette": 0,
+                    "tmem": 0, "uls": 0, "ult": 0}
+            (dump / (base + ".tile.json")).write_text(json.dumps(
+                {"tile": tile, "width": width, "height": height, "tlut": "RGBA16"}))
+            (dump / (base + ".tmem")).write_bytes(bytes(tmem))
+            (dump / (base + ".rice.palette.rdram")).write_bytes(
+                to_physical(pack_palette_logical(entries)))
+            (dump / (base + ".rice.palette.json")).write_text(json.dumps(
+                {"tile": {"uls": 0, "ult": 0}, "type": "TLUT",
+                 "texture": {"address": 0x2000, "siz": 2, "width": 256}}))
+
+            out = dump / "png"
+            import sys
+            argv = sys.argv
+            sys.argv = ["decode_dump.py", str(dump), "--out", str(out)]
+            try:
+                self.assertEqual(dd.main(), 0)
+            finally:
+                sys.argv = argv
+
+            png = (out / (base.split(".")[0] + ".png")).read_bytes()
+            self.assertTrue(png.startswith(b"\x89PNG"))
+            idat = b""
+            i = 8
+            w = h = 0
+            while i < len(png):
+                ln = struct.unpack(">I", png[i:i + 4])[0]
+                tag = png[i + 4:i + 8]
+                data = png[i + 8:i + 8 + ln]
+                if tag == b"IHDR":
+                    w, h = struct.unpack(">II", data[:8])
+                elif tag == b"IDAT":
+                    idat += data
+                i += 12 + ln
+            self.assertEqual((w, h), (width, height))
+            raw = zlib.decompress(idat)
+            stride = 1 + width * 4
+            for (t, s) in [(0, 0), (0, 7), (1, 3), (3, 5)]:
+                idx = (t * width + s) & 0xFF
+                exp = dd.rgba16_to_rgba8(entries[idx])
+                off = t * stride + 1 + s * 4
+                self.assertEqual(tuple(raw[off:off + 4]), exp, f"pixel ({t},{s})")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #50.
## Root cause: palette byte order, not the LOAD_BLOCK DXT interleave
`tools/decode_dump.py` decoded CI4/CI8 dumps "sheared **and** miscoloured". The issue hypothesized the block DXT TMEM interleave; the actual cause was the **TLUT byte order**, and it produced *both* symptoms.
`.rice.palette.rdram` is a raw copy of RT64's RDRAM, which stores every 32-bit word byte-swapped — the logical byte at address `A` physically lives at `A ^ 3` (verified in RT64's `loadWord()`, `rt64_rdp.cpp`: `RDRAM[(textureAddress + i) ^ 3]`). The decoder read the 16-bit TLUT entries straight, so every palette index mapped to a garbled RGBA5551 value. Because that noise still carries the image's *index* structure, it reads as a diagonal shear as well as a miscolour — one bug, two faces.
**Fix:** read the palette through the `^3` swap. Texels keep decoding from the logical-order `.tmem` snapshot, which was already correct.
I built and then discarded the issue's suggested alternative (decode CI from the linear `.rice.rdram` slice): a `LOAD_BLOCK` source isn't row-major without replaying the DXT interleave, so a naive stride *shears* padded (`line=2`) textures like the 17×17 HUD icons. `.tmem` already holds the correctly-interleaved data.
## Verification
Empirically confirmed against a fresh demo-race dump (110 textures) built from the shipped binary:
- `aec01187` 512×8 CI4 font atlas → legible `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ`
- 64×64 / 32×32 CI4 sky tiles → clean blue sky and golden clouds (were rainbow noise)
- 17×17 icons → clean, no shear
## Tests
New `tools/test_decode_dump.py` (stdlib `unittest`, no deps): palette word-swap, RDRAM addressing, and **CI4 + CI8** end-to-end colour checks through `main()`. `ruff check` clean on the changed files.
## Review-driven refinement (2nd commit)
A high-effort review flagged an over-engineered per-slice alignment anchor that was both unverifiable in-tree and silently zero-filled a non-4-aligned start. TLUT DMA sources are always 8-aligned, so it's dropped in favour of a plain `^3` — re-verified byte-identical on the real dump — and CI4 e2e coverage was added.
## CLI note
The never-implemented `--source`/`--rdram-byteswap` and the wrong `--pal-byteswap` (`^2`) knobs are replaced by a single `--pal-no-swap` calibration flag (the swapped read is the correct default). No in-repo callers referenced the old flags.
