### PR TITLE
CI: apply patches/0007 in build-linux and build-windows (#61)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -81,13 +81,17 @@ jobs:
           git -C lib/rt64 checkout -- .
           git -C lib/rt64/src/contrib/plume checkout -- .
 
-      - name: Apply runtime patch
+      - name: Apply runtime patches
+        # 0001 then 0007: both patch ultramodern (disjoint hunks; verified to apply
+        # sequentially on the pinned commit). 0007 adds the save-state thread-context
+        # registry + ultramodern_relink_thread_contexts (issue #22, all platforms).
         # --ignore-whitespace: submodule files on the Windows runner are
         # checked out as CRLF (actions/checkout@v4's submodule init uses
         # the runner's git default, not the local submodule's autocrlf),
         # and git apply rejects context-line mismatches by default.
         run: |
           git -C lib/N64ModernRuntime apply --ignore-whitespace "$(pwd)/patches/0001-lamborghini-runtime-scheduler-audio-vi.patch"
+          git -C lib/N64ModernRuntime apply --ignore-whitespace "$(pwd)/patches/0007-ultramodern-savestate-thread-context-relink.patch"
           git -C lib/rt64 apply --ignore-whitespace "$(pwd)/patches/0006-rt64-interp-angular-velocity-matching.patch"
 
       - name: Configure + build recompiler CLIs
@@ -194,6 +198,9 @@ jobs:
 
       - name: Apply patches
         shell: pwsh
+        # 0001 then 0007: both patch ultramodern (disjoint hunks; verified to apply
+        # sequentially on the pinned commit). 0007 adds the save-state thread-context
+        # registry + ultramodern_relink_thread_contexts (issue #22, all platforms).
         # --ignore-whitespace: submodule files on the Windows runner are
         # checked out as CRLF (actions/checkout@v4's submodule init uses
         # the runner's git default, not the local submodule's autocrlf),
@@ -201,6 +208,7 @@ jobs:
         run: |
           $root = (Get-Location).Path
           git -C lib/N64ModernRuntime apply --ignore-whitespace "$root/patches/0001-lamborghini-runtime-scheduler-audio-vi.patch"
+          git -C lib/N64ModernRuntime apply --ignore-whitespace "$root/patches/0007-ultramodern-savestate-thread-context-relink.patch"
           git -C lib/rt64 apply --ignore-whitespace "$root/patches/0006-rt64-interp-angular-velocity-matching.patch"
           git -C lib/rt64 apply --ignore-whitespace "$root/patches/0005-rt64-mingw-gcc-compat.patch"
           git -C lib/rt64/src/contrib/plume apply --ignore-whitespace "$root/patches/0004-plume-d3d12-mingw-com-abi-struct-return.patch"


### PR DESCRIPTION
Patches/0007 in both CI build jobs.

**Chosen approach: Option 2** (sequence with --ignore-whitespace).

**Why not Option 1** (merge into 0001)? Reproduced first — and the
issue's hypothesis ("a sequential git apply of the two fails with
context-conflict at the OSThread.context lines") does NOT hold on the
pinned submodule commit (ae1ffbb). 0001 and 0007 touch disjoint hunks
in ultramodern/src/threads.cpp (0001 adds lines 1-4 + 7-line
LAMBO_THREAD_TRACE instrumentation; 0007 adds lines 5-6 + 35-line
registry + 3 single-line hook insertions at 268/308/347 in the
renumbered file). Plain sequential apply with --ignore-whitespace
succeeds (exit 0) on the pinned commit. Merging would have meant
re-deriving both patches against the upstream ultramodern SHA pinned
in .gitmodules; sequencing them in the workflow is the smaller,
non-rebasing change.

**Why this matters more than the issue first suggested** —
src/lambo_savestate.c:185 calls ultramodern_relink_thread_contexts
(rdram), which only patches/0007 defines. Without 0007 in CI, every
release artifact linking with our savestate loader would either fail
at link time with an undefined reference (when the call is reached
during normal startup) or crash at the F7/F8 cycle (when an actual save
or load runs). BUILDING.md step 2 already lists 0007, so dev builds
were correct; CI was the only divergence.

**Verification done here**:
- git apply --ignore-whitespace -check of 0001 then 0007 on the pinned
  lib/N64ModernRuntime = exit 0.
- Full sequential apply = exit 0; threads.cpp grep confirms both
  LAMBO_THREAD_TRACE (0001) and register_thread_context /
  ultramodern_relink_thread_contexts (0007) coexist on the
  OSThread.context lines.
- gcc.exe -fsyntax-only on the patched threads.cpp / mesgqueue.cpp /
  events.cpp with -std=c++20 -DNOMINMAX and the ultramodern include
  paths = exit 0 for all three. (No semantic change vs the
  BUILDING.md path; just confirms the composition doesn't introduce
  syntax errors.)

**Build-laptop limitation**: I did not run the full CMake configure +
CMake build of lamborghini_modern here (5-10 min link on this box per
the project toolchain notes in CLAUDE.md). The Release artifact
acceptance test from the issue (F7 save / F8 load cycle on a release
build) should be exercised in CI on a real workflow_dispatch run
*after* merge, or via build.sh / build.ps1 once those are added.

**Diff**: .github/workflows/build-release.yml only (9 +/1 -). BUILDING.md
already listed 0007 in the same order, so no doc change needed.