### PR TITLE
Add local build scripts (build.sh/build.ps1) mirroring CI; hookify rule for patch->build drift

### DIFF
--- a/.claude/hookify.warn-new-patch-needs-build-sync.local.md
+++ b/.claude/hookify.warn-new-patch-needs-build-sync.local.md
@@ -1,0 +1,34 @@
+---
+name: warn-new-patch-needs-build-sync
+enabled: true
+event: file
+action: warn
+conditions:
+  - field: file_path
+    operator: regex_match
+    pattern: patches[/\\][^/\\]+\.patch$
+---
+
+⚠️ **Patch file written/edited in `patches/`**
+
+A file under `patches/*.patch` was just created or modified. Per the project's
+discipline (see `CLAUDE.md` + memory note about PATCH_BLOCKS-stale-again),
+every patch MUST be wired into all three of:
+
+1. **`build.ps1`** — the `$patches` array (Windows path, lines ~118-123).
+2. **`build.sh`**  — the `PATCHES` bash array (Linux path, ~line 96).
+3. **`.github/workflows/build-release.yml`** — both `build-linux` and
+   `build-windows` jobs have their own `git apply` step (Linux only applies
+   runtime+rt64 patches; Windows also applies the MinGW/D3D12 fixes).
+
+Before declaring this work done:
+
+- For each build file, grep for the new patch's filename (e.g. the
+  `000X-foo.patch` basename) and confirm it appears in the right context.
+- If this patch only applies on one OS (e.g. MinGW-only or D3D12-only),
+  make sure it isn't listed on the other OS — patches are gated per-OS.
+- If you just re-edited an existing patch that's already wired up, ignore
+  this reminder.
+
+Skip this check only if you wrote a temporary patch under a path that does
+NOT start with `patches/` (this rule matches `patches/.*\.patch` only).

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,218 @@
+<#
+.SYNOPSIS
+    Build Automobili Lamborghini: Recompiled on Windows (MinGW GCC + Ninja).
+
+.DESCRIPTION
+    End-to-end build for the N64Recomp static-recompilation port. Mirrors the
+    build-windows job in .github/workflows/build-release.yml so a local build
+    is byte-for-byte the same flow as a CI release build (modulo the toolchain
+    install step). Idempotent: each step detects what's already done and skips.
+
+    Steps:
+      1. Toolchain PATH: Python's CMake (v4.x) ahead of MSYS2's buggy 3.25.1,
+         and MinGW's bin ahead of any cc shim.
+      2. Initialise submodules (recursive; long paths for RT64's deep nesting).
+      3. Defensive submodule reset before patching (CI's "Reset submodules
+         before patching" step — a half-applied patch from a prior run would
+         otherwise break the next apply).
+      4. Apply Lamborghini patches (Windows: 0001, 0006, 0005, 0004) with
+         --ignore-whitespace (CRLF mismatches on Windows git).
+      5. First CMake configure (without RecompiledFuncs/ yet — that's the
+         whole point: build the recompiler tools first).
+      6. Build N64RecompCLI + RSPRecomp.
+      7. Run them against the ROM to (re)generate RecompiledFuncs/ and
+         src/aspMain.cpp (git-ignored; deterministic given the ROM).
+      8. SECOND CMake configure — picks up the newly generated sources via
+         CONFIGURE_DEPENDS / EXISTS checks. Without this, src/aspMain.cpp is
+         silently excluded.
+      9. Build lamborghini_modern.exe.
+
+    The output binary lands at build\lamborghini_modern.exe (run from the repo
+    root so the ROM path resolves).
+
+.PARAMETER Clean
+    Wipe build/ before configuring. Slow (~5-10 min cold link) but useful when
+    chasing stale-link issues with libRecompiledFuncs.a or chasing the
+    PATCH_BLOCKS-stale-again class of bug.
+
+.EXAMPLE
+    .\build.ps1            # incremental build
+    .\build.ps1 -Clean     # full clean rebuild
+#>
+[CmdletBinding()]
+param(
+    [switch]$Clean
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# --- Locate worktree root from this script's own path -----------------------
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Push-Location $ScriptDir
+try {
+    $RepoRoot = (git rev-parse --show-toplevel).Trim()
+    if (-not $RepoRoot) { throw "Not inside a git repository. Run from the worktree root." }
+    Set-Location $RepoRoot
+    Write-Host "[repo] $RepoRoot" -ForegroundColor DarkGray
+
+    # --- 1. Toolchain PATH ----------------------------------------------------
+    # Order matters: Python's CMake must beat MSYS2's; MinGW bin must beat any
+    # cc shim that may sit ahead of gcc on this box. Anything already on PATH
+    # is preserved as the suffix.
+    $PythonScripts = 'C:\Users\alond\AppData\Local\Programs\Python\Python313\Scripts'
+    $MinGW         = 'C:\ProgramData\mingw64\mingw64\bin'
+    $NewPrefix     = @($PythonScripts, $MinGW) | Where-Object { Test-Path $_ }
+    if ($NewPrefix.Count -gt 0) {
+        $env:PATH = ($NewPrefix -join ';') + ';' + $env:PATH
+        Write-Host ("[path] + {0}" -f ($NewPrefix -join '; ')) -ForegroundColor DarkGray
+    }
+
+    # --- 2. Verify the toolchain is actually present --------------------------
+    $cmake = (Get-Command cmake.exe -ErrorAction SilentlyContinue).Source
+    $gcc   = (Get-Command gcc.exe   -ErrorAction SilentlyContinue).Source
+    $gxx   = (Get-Command g++.exe   -ErrorAction SilentlyContinue).Source
+    $ninja = (Get-Command ninja.exe -ErrorAction SilentlyContinue).Source
+    if (-not $cmake) { throw 'cmake.exe not on PATH. Install CMake or extend $PythonScripts.' }
+    if (-not $gcc)   { throw 'gcc.exe not on PATH. Add MinGW to $env:PATH (see comment in script).' }
+    if (-not $gxx)   { throw 'g++.exe not on PATH. Add MinGW to $env:PATH.' }
+    if (-not $ninja) { throw 'ninja not on PATH. Install it (pip install ninja) and put on PATH.' }
+    Write-Host "[tools] cmake=$cmake" -ForegroundColor DarkGray
+    Write-Host "[tools] gcc=$gcc"     -ForegroundColor DarkGray
+    Write-Host "[tools] g++=$gxx"     -ForegroundColor DarkGray
+    Write-Host "[tools] ninja=$ninja" -ForegroundColor DarkGray
+
+    # Sanity check: reject MSYS2's 3.25 cmake if it slipped back onto PATH first.
+    $cmakeVersion = (& $cmake --version | Select-Object -First 1) -replace 'cmake version ', ''
+    if ($cmakeVersion -like '3.25*') {
+        Write-Warning "cmake $cmakeVersion looks like MSYS2's buggy 3.25.1; move $PythonScripts ahead of MSYS2 on PATH."
+    }
+
+    # --- 3. ROM check ---------------------------------------------------------
+    $RomPath = 'Automobili Lamborghini (USA).z64'
+    if (-not (Test-Path $RomPath)) {
+        throw "Missing ROM: $RomPath. Place your legally-dumped USA ROM at the repo root."
+    }
+
+    # --- 4. Submodules --------------------------------------------------------
+    # Long paths for the deep RT64 nesting (Windows default path limit = 260).
+    # CI sets core.longpaths globally before any git call so subsequent
+    # `git apply` invocations for 0004/0005 also honour it (RT64's deep
+    # nesting can produce paths >260 chars). Match that here.
+    git config --global core.longpaths true | Out-Null
+    # The Windows runner's git may inject CRLF on checkout; --ignore-whitespace
+    # in the apply step below neutralises that, but autocrlf=false is also
+    # defensive (CI runs this too).
+    git config --global core.autocrlf false | Out-Null
+    Write-Host "`n[1/5] Initialising submodules..." -ForegroundColor Cyan
+    git submodule update --init --recursive | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw 'submodule update failed.' }
+
+    # --- 5. Defensive submodule reset -----------------------------------------
+    # Mirrors CI's "Reset submodules before patching" — a previous partial
+    # apply would otherwise leave patches failing with "patch failed: ... file:N".
+    Write-Host "[2/5] Resetting submodules to clean state before patching..." -ForegroundColor Cyan
+    git -C lib/N64ModernRuntime checkout -- . | Out-Null
+    git -C lib/rt64 checkout -- . | Out-Null
+    git -C lib/rt64/src/contrib/plume checkout -- . | Out-Null
+
+    # --- 6. Apply Lamborghini patches (Windows: 0001, 0006, 0005, 0004) -------
+    # Mirrors CI's Windows job exactly. 0007 is intentionally omitted — the
+    # current CI doesn't apply it either, suggesting its content has landed
+    # upstream or is unnecessary for a Release build.
+    Write-Host "[2/5] Applying Lamborghini submodule patches..." -ForegroundColor Cyan
+    $patches = @(
+        @{ Sub = 'lib/N64ModernRuntime';       Patch = 'patches/0001-lamborghini-runtime-scheduler-audio-vi.patch' },
+        @{ Sub = 'lib/rt64';                   Patch = 'patches/0006-rt64-interp-angular-velocity-matching.patch' },
+        @{ Sub = 'lib/rt64';                   Patch = 'patches/0005-rt64-mingw-gcc-compat.patch' },
+        @{ Sub = 'lib/rt64/src/contrib/plume'; Patch = 'patches/0004-plume-d3d12-mingw-com-abi-struct-return.patch' }
+    )
+    foreach ($p in $patches) {
+        # Idempotency check: distinguish three states.
+        #   (a) --check 0      -> not yet applied, will apply cleanly
+        #   (b) --check !=0 && --reverse --check 0 -> already applied
+        #   (c) --check !=0 && --reverse --check !=0 -> context drift (submodule changed)
+        # Without distinguishing (b) from (c), drift silently masquerades as
+        # 'already applied' and produces a confusing compile error much later.
+        git -C $p.Sub apply --ignore-whitespace --check $p.Patch 2>&1 | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            git -C $p.Sub apply --ignore-whitespace $p.Patch | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw "patch failed: $($p.Sub) <- $($p.Patch)" }
+            Write-Host "  applied  $($p.Sub) <- $($p.Patch)" -ForegroundColor Green
+        } else {
+            git -C $p.Sub apply --ignore-whitespace --reverse --check $p.Patch 2>&1 | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "  skipped  $($p.Sub) <- $($p.Patch) (already applied)" -ForegroundColor DarkGray
+            } else {
+                throw "patch $($p.Patch) does not apply cleanly to $($p.Sub) and is not already applied - likely submodule drift (upstream context changed). Re-pull the submodule or refresh the patch."
+            }
+        }
+    }
+
+    # --- 7. Optional clean ----------------------------------------------------
+    if ($Clean -and (Test-Path build)) {
+        Write-Host "`n[clean] Removing build/..." -ForegroundColor Yellow
+        Remove-Item -Recurse -Force build
+    }
+
+    # --- 8. CMake configure (FIRST) -------------------------------------------
+    # Pin compilers explicitly: on this box a `cc` shim may sit ahead of gcc in
+    # PATH and CMake's auto-detection would otherwise pick it up — "C compiler
+    # is broken" at project() time.
+    Write-Host "`n[3/5] Configuring CMake (first pass)..." -ForegroundColor Cyan
+    if (-not (Test-Path build)) { New-Item -ItemType Directory build | Out-Null }
+    & $cmake -S . -B build -G Ninja `
+        -DCMAKE_BUILD_TYPE=Release `
+        -DCMAKE_C_COMPILER=gcc.exe `
+        -DCMAKE_CXX_COMPILER=g++.exe
+    if ($LASTEXITCODE -ne 0) { throw 'cmake configure failed.' }
+
+    # --- 9. Build the recompiler tools ----------------------------------------
+    Write-Host "[4/5] Building N64RecompCLI + RSPRecomp..." -ForegroundColor Cyan
+    & $cmake --build build --target N64RecompCLI RSPRecomp -j
+    if ($LASTEXITCODE -ne 0) { throw 'recompiler tool build failed.' }
+
+    # --- 10. Regenerate the ROM-derived translations --------------------------
+    Write-Host "[4/5] Regenerating RecompiledFuncs/ and src/aspMain.cpp..." -ForegroundColor Cyan
+    # Normalise the path to backslashes. PowerShell's `&` call operator hands
+    # the literal string to CreateProcessW, which on some Windows builds
+    # refuses mixed-separator paths (CI uses pure backslashes for the same reason).
+    $n64recomp = (Resolve-Path 'build/lib/N64ModernRuntime/librecomp/N64Recomp/N64Recomp.exe').Path
+    $rsprecomp = (Resolve-Path 'build/lib/N64ModernRuntime/librecomp/N64Recomp/RSPRecomp.exe').Path
+    if (-not (Test-Path $n64recomp)) { throw "missing tool: $n64recomp" }
+    if (-not (Test-Path $rsprecomp)) { throw "missing tool: $rsprecomp" }
+    & $n64recomp lamborghini.us.toml
+    if ($LASTEXITCODE -ne 0) { throw 'N64Recomp failed.' }
+    & $rsprecomp aspMain.us.toml
+    if ($LASTEXITCODE -ne 0) { throw 'RSPRecomp failed.' }
+
+    # --- 11. CMake configure (SECOND) -----------------------------------------
+    # Required: CMakeLists uses if(EXISTS src/aspMain.cpp) and a CONFIGURE_DEPENDS
+    # glob for RecompiledFuncs/. The EXISTS check is configure-time only; the
+    # second configure wires in the freshly generated files. Without it, the
+    # build silently drops src/aspMain.cpp.
+    Write-Host "[4/5] Configuring CMake (second pass - wires in generated sources)..." -ForegroundColor Cyan
+    & $cmake -S . -B build -G Ninja `
+        -DCMAKE_BUILD_TYPE=Release `
+        -DCMAKE_C_COMPILER=gcc.exe `
+        -DCMAKE_CXX_COMPILER=g++.exe
+    if ($LASTEXITCODE -ne 0) { throw 'cmake second configure failed.' }
+
+    # --- 12. Build lamborghini_modern -----------------------------------------
+    Write-Host "`n[5/5] Building lamborghini_modern..." -ForegroundColor Cyan
+    & $cmake --build build --target lamborghini_modern -j
+    if ($LASTEXITCODE -ne 0) { throw 'lamborghini_modern build failed.' }
+
+    # --- 13. Done -------------------------------------------------------------
+    $exe = Join-Path $RepoRoot 'build\lamborghini_modern.exe'
+    if (Test-Path $exe) {
+        $stamp = (Get-Item $exe).LastWriteTime
+        Write-Host "`n[done] $exe  ($stamp)" -ForegroundColor Green
+        Write-Host "Run from repo root:  .\build\lamborghini_modern.exe" -ForegroundColor Green
+    } else {
+        Write-Warning "lamborghini_modern.exe not found at expected path."
+    }
+}
+finally {
+    Pop-Location
+}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#
+# Build Automobili Lamborghini: Recompiled on Linux.
+#
+# Mirrors the build-linux job in .github/workflows/build-release.yml so a local
+# build is the same flow as a CI release build (modulo the apt-get install
+# step). Idempotent: each step detects what's already done and skips.
+#
+# Steps:
+#   1. Toolchain detection (cmake, gcc, g++, ninja, git, nproc).
+#   2. ROM check — the USA ROM is required to translate game code (it's also
+#      git-ignored; CI fetches it from a private assets repo, locally you
+#      place it next to this script).
+#   3. Submodule init (recursive; --c core.longpaths=true not needed on Linux).
+#   4. Defensive submodule reset before patching (CI's "Reset submodules
+#      before patching" — half-applied patches from a prior run would break
+#      the next apply with "patch failed: ... file:N").
+#   5. Apply Lamborghini patches (Linux: 0001, 0006 only — no MinGW/D3D12
+#      fixes needed; no plume patch). With --ignore-whitespace as a
+#      belt-and-suspenders guard for any CRLF drift.
+#   6. First CMake configure — the initial one runs before N64Recomp/
+#      RSPRecomp generate sources. The CMakeLists uses if(EXISTS) on the
+#      ROM-derived files so the first configure can succeed without them.
+#   7. Build N64RecompCLI + RSPRecomp tools.
+#   8. Run them against the ROM to (re)generate RecompiledFuncs/ and
+#      src/aspMain.cpp (git-ignored; deterministic given the ROM).
+#   9. SECOND CMake configure — picks up the newly generated sources. The
+#      CMakeLists uses CONFIGURE_DEPENDS on RecompiledFuncs/ globs AND
+#      if(EXISTS src/aspMain.cpp). The EXISTS check is configure-time only;
+#      the second configure wires it in. Without this, src/aspMain.cpp is
+#      silently excluded.
+#  10. Build lamborghini_modern.
+#
+# Usage:
+#   ./build.sh           # incremental build
+#   ./build.sh --clean   # wipe build/ first (slow: ~5-10 min cold link)
+
+set -euo pipefail
+
+# --- 0. Locate repo root from script location --------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# --- 1. Argument parsing ----------------------------------------------------
+CLEAN=0
+for arg in "$@"; do
+    case "$arg" in
+        --clean) CLEAN=1 ;;
+        -h|--help)
+            sed -n '2,30p' "$0"; exit 0 ;;
+        *) echo "Unknown arg: $arg (try --help)" >&2; exit 1 ;;
+    esac
+done
+
+# --- 2. Toolchain detection -------------------------------------------------
+log()  { printf '\033[1;36m%s\033[0m\n' "$*"; }
+warn() { printf '\033[1;33mWARN\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31mERR\033[0m  %s\n' "$*" >&2; exit 1; }
+
+log "[repo] $(pwd)"
+
+for tool in cmake gcc g++ ninja git; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        die "missing tool: $tool. Install with:
+  sudo apt-get install -y --no-install-recommends \\
+    build-essential cmake ninja-build python3 pkg-config \\
+    libsdl2-dev libvulkan-dev \\
+    libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \\
+    libdbus-1-dev"
+    fi
+done
+
+NPROC="$(nproc)"
+log "[tools] cmake=$(command -v cmake)  gcc=$(command -v gcc)  g++=$(command -v g++)  ninja=$(command -v ninja)  nproc=$NPROC"
+
+# --- 3. ROM check -----------------------------------------------------------
+ROM="Automobili Lamborghini (USA).z64"
+if [ ! -f "$ROM" ]; then
+    die "missing ROM: $ROM
+Place your legally-dumped USA ROM at the repo root and re-run."
+fi
+
+# --- 4. Submodules ----------------------------------------------------------
+log ""
+log "[1/5] Initialising submodules..."
+git submodule update --init --recursive
+
+# --- 5. Defensive submodule reset (mirrors CI) ------------------------------
+log "[2/5] Resetting submodules to clean state before patching..."
+git -C lib/N64ModernRuntime checkout -- .
+git -C lib/rt64 checkout -- .
+git -C lib/rt64/src/contrib/plume checkout -- . 2>/dev/null || true
+
+# --- 6. Apply Lamborghini patches (Linux: 0001, 0006 only) ------------------
+log "[2/5] Applying Lamborghini submodule patches..."
+PATCHES=(
+    "lib/N64ModernRuntime:0001-lamborghini-runtime-scheduler-audio-vi.patch"
+    "lib/rt64:0006-rt64-interp-angular-velocity-matching.patch"
+)
+for entry in "${PATCHES[@]}"; do
+    sub="${entry%%:*}"
+    patch="${entry#*:}"
+    # Idempotency check: distinguish three states.
+    #   (a) --check 0                                         -> not yet applied
+    #   (b) --check !=0 && --reverse --check 0               -> already applied
+    #   (c) --check !=0 && --reverse --check !=0             -> context drift
+    if git -C "$sub" apply --ignore-whitespace --check "patches/$patch" >/dev/null 2>&1; then
+        git -C "$sub" apply --ignore-whitespace "patches/$patch"
+        echo "  applied  $sub <- $patch"
+    elif git -C "$sub" apply --ignore-whitespace --reverse --check "patches/$patch" >/dev/null 2>&1; then
+        echo "  skipped  $sub <- $patch (already applied)"
+    else
+        die "patch $patch does not apply cleanly to $sub and is not already applied — likely submodule drift (upstream context changed). Re-pull the submodule or refresh the patch."
+    fi
+done
+
+# --- 7. Optional clean ------------------------------------------------------
+if [ "$CLEAN" -eq 1 ] && [ -d build ]; then
+    log ""
+    log "[clean] Removing build/..."
+    rm -rf build
+fi
+
+# --- 8. CMake configure (FIRST) ---------------------------------------------
+log ""
+log "[3/5] Configuring CMake (first pass)..."
+mkdir -p build
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+
+# --- 9. Build recompiler tools ----------------------------------------------
+log "[4/5] Building N64RecompCLI + RSPRecomp..."
+cmake --build build --target N64RecompCLI RSPRecomp -j"$NPROC"
+
+# --- 10. Regenerate ROM-derived translations --------------------------------
+log "[4/5] Regenerating RecompiledFuncs/ and src/aspMain.cpp..."
+N64RECOMP=build/lib/N64ModernRuntime/librecomp/N64Recomp/N64Recomp
+RSPRECOMP=build/lib/N64ModernRuntime/librecomp/N64Recomp/RSPRecomp
+[ -x "$N64RECOMP" ] || die "missing tool: $N64RECOMP"
+[ -x "$RSPRECOMP" ] || die "missing tool: $RSPRECOMP"
+"$N64RECOMP" lamborghini.us.toml
+"$RSPRECOMP" aspMain.us.toml
+
+# --- 11. CMake configure (SECOND) -------------------------------------------
+log "[4/5] Configuring CMake (second pass — wires in generated sources)..."
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+
+# --- 12. Build lamborghini_modern -------------------------------------------
+log ""
+log "[5/5] Building lamborghini_modern..."
+cmake --build build --target lamborghini_modern -j"$NPROC"
+
+# --- 13. Done ---------------------------------------------------------------
+EXE=build/lamborghini_modern
+if [ -x "$EXE" ]; then
+    log ""
+    log "[done] $EXE  ($(stat -c '%y' "$EXE" 2>/dev/null || stat -f '%Sm' "$EXE"))"
+    log "Run from repo root:  ./build/lamborghini_modern"
+else
+    warn "lamborghini_modern not found at expected path: $EXE"
+fi


### PR DESCRIPTION
## Summary

Adds two local build scripts that mirror `.github/workflows/build-release.yml`
byte-for-byte (modulo the toolchain-install and ROM-fetch steps, which are
CI-only by design):

- **`build.sh`** (Linux) — mirrors `build-linux` job. Patches: `0001` + `0006`.
- **`build.ps1`** (Windows, MinGW + Ninja) — mirrors `build-windows` job. Patches: `0001` + `0006` + `0005` + `0004`. Sets `core.longpaths` globally so deep RT64 paths work; pins `gcc.exe`/`g++.exe` explicitly to defeat any `cc` shim; prepends Python's CMake (v4.x) ahead of MSYS2's buggy 3.25.1.

Both scripts:
- Are idempotent (`--clean` / `-Clean` flag wipes `build/`; default re-runs only changed work)
- Distinguish "already applied" from "context drift" via `git apply --check` + `git apply --reverse --check`, so submodule drift surfaces as a hard error
- Run a **second cmake configure** after the recompilers run (CMakeLists uses `if(EXISTS src/aspMain.cpp)` which is configure-time only — the `CONFIGURE_DEPENDS` glob on `RecompiledFuncs/` does NOT re-fire it)

Plus a **hookify rule** (`.claude/hookify.warn-new-patch-needs-build-sync.local.md`)
that fires PostToolUse on any `Write`/`Edit` matching `patches/*.patch` and
reminds the agent to wire the new patch into all four sites (`build.ps1`,
`build.sh`, and the two yml patch-list blocks).

## Why

The local workflow before this PR was: edit source, run an ad-hoc incantation
of `cmake -S . -B build ...` + `cmake --build build --target lamborghini_modern`,
and hope the patch had been applied and the recompiled sources had been wired
in. CI does it correctly (with the second-configure dance); local devs had
no canonical recipe. A few specific failure modes this addresses:

- **Bug**: previously a single cmake configure would silently drop `src/aspMain.cpp` from the link (the EXISTS check fires at configure time; the recompilers hadn't run yet).
- **Bug**: silently treated submodule drift as "patch already applied".
- **Drift risk**: when a patch is added, the four places it needs to be referenced can fall out of sync. The hookify rule is a structural guard (a real fix would extract the patch list to a single source of truth).

## Discovered during this work

`patches/0007-ultramodern-savestate-thread-context-relink.patch` is in the
repo and listed in `BUILDING.md` as "all platforms", but **neither CI job
applies it**. Tracking this separately — the cleanest fix is to merge `0007`
into `0001` (both touch `ultramodern/src/threads.cpp`).

**Closes #61**

## Test plan

- [x] `bash -n build.sh` (syntax check)
- [x] PowerShell AST parse of `build.ps1`
- [x] Hookify regex verified against actual paths (Unix, Windows absolute, nested, non-patches)
- [ ] (Local, post-merge) Run `.\build.ps1 -Clean` from a fresh worktree on Windows; verify `build\lamborghini_modern.exe` links and boots.
- [ ] (Local, post-merge) Run `./build.sh --clean` from a fresh worktree on Linux; verify `build/lamborghini_modern` links and boots.