### PR TITLE
CI: delegate build sequence to build.sh / build.ps1 (single source of truth)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -81,39 +81,15 @@ jobs:
           git -C lib/rt64 checkout -- .
           git -C lib/rt64/src/contrib/plume checkout -- .
 
-      - name: Apply runtime patches
-        # 0001 then 0007: both patch ultramodern (disjoint hunks; verified to apply
-        # sequentially on the pinned commit). 0007 adds the save-state thread-context
-        # registry + ultramodern_relink_thread_contexts (issue #22, all platforms).
-        # --ignore-whitespace: submodule files on the Windows runner are
-        # checked out as CRLF (actions/checkout@v4's submodule init uses
-        # the runner's git default, not the local submodule's autocrlf),
-        # and git apply rejects context-line mismatches by default.
-        run: |
-          git -C lib/N64ModernRuntime apply --ignore-whitespace "$(pwd)/patches/0001-lamborghini-runtime-scheduler-audio-vi.patch"
-          git -C lib/N64ModernRuntime apply --ignore-whitespace "$(pwd)/patches/0007-ultramodern-savestate-thread-context-relink.patch"
-          git -C lib/rt64 apply --ignore-whitespace "$(pwd)/patches/0006-rt64-interp-angular-velocity-matching.patch"
-
-      - name: Configure + build recompiler CLIs
-        # First configure runs before N64Recomp/RSPRecomp generate sources;
-        # the second configure below (after recompile) wires those in.
-        run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
-          cmake --build build --target N64RecompCLI RSPRecomp -j"$(nproc)"
-
-      - name: Recompile game code + audio microcode from ROM
-        run: |
-          ./build/lib/N64ModernRuntime/librecomp/N64Recomp/N64Recomp lamborghini.us.toml
-          ./build/lib/N64ModernRuntime/librecomp/N64Recomp/RSPRecomp aspMain.us.toml
-
-      - name: Re-configure CMake to pick up generated sources
-        run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
-
-      - name: Build port
-        run: cmake --build build --target lamborghini_modern -j"$(nproc)"
+      - name: Build via shared script
+        # Delegate to build.sh — the single source of truth for the build
+        # sequence (submodule reset, patch apply, configure x2, build tools,
+        # recompile, link). CI doesn't reimplement any of this inline; if
+        # the local script drifts, this job breaks on the next push, so the
+        # hookify rule (patch→build drift) catches it.
+        env:
+          ROM_FILENAME: ${{ env.ROM_FILENAME }}
+        run: bash build.sh
 
       - name: Remove ROM before packaging
         if: always()
@@ -196,47 +172,18 @@ jobs:
           git -C lib/rt64 checkout -- .
           git -C lib/rt64/src/contrib/plume checkout -- .
 
-      - name: Apply patches
+      - name: Build via shared script
         shell: pwsh
-        # 0001 then 0007: both patch ultramodern (disjoint hunks; verified to apply
-        # sequentially on the pinned commit). 0007 adds the save-state thread-context
-        # registry + ultramodern_relink_thread_contexts (issue #22, all platforms).
-        # --ignore-whitespace: submodule files on the Windows runner are
-        # checked out as CRLF (actions/checkout@v4's submodule init uses
-        # the runner's git default, not the local submodule's autocrlf),
-        # and git apply rejects context-line mismatches by default.
-        run: |
-          $root = (Get-Location).Path
-          git -C lib/N64ModernRuntime apply --ignore-whitespace "$root/patches/0001-lamborghini-runtime-scheduler-audio-vi.patch"
-          git -C lib/N64ModernRuntime apply --ignore-whitespace "$root/patches/0007-ultramodern-savestate-thread-context-relink.patch"
-          git -C lib/rt64 apply --ignore-whitespace "$root/patches/0006-rt64-interp-angular-velocity-matching.patch"
-          git -C lib/rt64 apply --ignore-whitespace "$root/patches/0005-rt64-mingw-gcc-compat.patch"
-          git -C lib/rt64/src/contrib/plume apply --ignore-whitespace "$root/patches/0004-plume-d3d12-mingw-com-abi-struct-return.patch"
-
-      - name: Configure + build recompiler CLIs
-        shell: pwsh
-        # First configure runs before N64Recomp/RSPRecomp generate sources;
-        # the second configure below (after recompile) wires those in.
-        run: |
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release `
-            -DCMAKE_C_COMPILER=gcc.exe -DCMAKE_CXX_COMPILER=g++.exe
-          cmake --build build --target N64RecompCLI RSPRecomp -j
-
-      - name: Recompile game code + audio microcode from ROM
-        shell: pwsh
-        run: |
-          & ".\build\lib\N64ModernRuntime\librecomp\N64Recomp\N64Recomp.exe" lamborghini.us.toml
-          & ".\build\lib\N64ModernRuntime\librecomp\N64Recomp\RSPRecomp.exe" aspMain.us.toml
-
-      - name: Re-configure CMake to pick up generated sources
-        shell: pwsh
-        run: |
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release `
-            -DCMAKE_C_COMPILER=gcc.exe -DCMAKE_CXX_COMPILER=g++.exe
-
-      - name: Build port
-        shell: pwsh
-        run: cmake --build build --target lamborghini_modern -j
+        # Delegate to build.ps1 — the single source of truth for the build
+        # sequence (submodule reset, patch apply, configure x2, build tools,
+        # recompile, link). CI doesn't reimplement any of this inline; if the
+        # local script drifts, this job breaks on the next push, so the
+        # hookify rule (patch→build drift) catches it.
+        # -RomPath forwards the workflow's $env:ROM_FILENAME so a future ROM
+        # rename stays single-sourced in the workflow's env block.
+        env:
+          ROM_FILENAME: ${{ env.ROM_FILENAME }}
+        run: ./build.ps1 -RomPath "$env:ROM_FILENAME"
 
       - name: Remove ROM before packaging
         if: always()

--- a/build.ps1
+++ b/build.ps1
@@ -12,20 +12,22 @@
       1. Toolchain PATH: Python's CMake (v4.x) ahead of MSYS2's buggy 3.25.1,
          and MinGW's bin ahead of any cc shim.
       2. Initialise submodules (recursive; long paths for RT64's deep nesting).
-      3. Defensive submodule reset before patching (CI's "Reset submodules
-         before patching" step — a half-applied patch from a prior run would
-         otherwise break the next apply).
-      4. Apply Lamborghini patches (Windows: 0001, 0006, 0005, 0004) with
-         --ignore-whitespace (CRLF mismatches on Windows git).
-      5. First CMake configure (without RecompiledFuncs/ yet — that's the
+      3. ROM check (skippable via -RomPath; CI forwards its $env:ROM_FILENAME).
+      4. Defensive submodule reset before patching (a half-applied patch from a
+         prior run would otherwise break the next apply).
+      5. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0005, 0004) with
+         --ignore-whitespace (CRLF mismatches on Windows git). 0007 adds the
+         save-state thread-context registry; without it, src/lambo_savestate.c
+         fails to link with "undefined reference to ultramodern_relink_thread_contexts".
+      6. First CMake configure (without RecompiledFuncs/ yet — that's the
          whole point: build the recompiler tools first).
-      6. Build N64RecompCLI + RSPRecomp.
-      7. Run them against the ROM to (re)generate RecompiledFuncs/ and
+      7. Build N64RecompCLI + RSPRecomp.
+      8. Run them against the ROM to (re)generate RecompiledFuncs/ and
          src/aspMain.cpp (git-ignored; deterministic given the ROM).
-      8. SECOND CMake configure — picks up the newly generated sources via
+      9. SECOND CMake configure — picks up the newly generated sources via
          CONFIGURE_DEPENDS / EXISTS checks. Without this, src/aspMain.cpp is
          silently excluded.
-      9. Build lamborghini_modern.exe.
+     10. Build lamborghini_modern.exe.
 
     The output binary lands at build\lamborghini_modern.exe (run from the repo
     root so the ROM path resolves).
@@ -35,24 +37,42 @@
     chasing stale-link issues with libRecompiledFuncs.a or chasing the
     PATCH_BLOCKS-stale-again class of bug.
 
+.PARAMETER RomPath
+    Path to the USA ROM. Defaults to the standard filename at the repo root.
+    CI passes its own value via -RomPath $env:ROM_FILENAME so a future rename
+    of the ROM doesn't fork the script's hardcoded default from the workflow's
+    env-var convention.
+
 .EXAMPLE
-    .\build.ps1            # incremental build
-    .\build.ps1 -Clean     # full clean rebuild
+    .\build.ps1                                   # incremental build
+    .\build.ps1 -Clean                            # full clean rebuild
+    .\build.ps1 -RomPath 'other-name.z64'         # non-default ROM filename
 #>
 [CmdletBinding()]
 param(
-    [switch]$Clean
+    [switch]$Clean,
+    [string]$RomPath = 'Automobili Lamborghini (USA).z64'
 )
 
-$ErrorActionPreference = 'Stop'
-Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Continue'
+# NOTE: Set-StrictMode would be nice for catching undefined-variable bugs, but
+# it also amplifies native-command stderr (cmake/git warnings, etc.) into
+# terminating errors when combined with $ErrorActionPreference, breaking
+# builds whose only stderr output is benign (e.g. trailing-whitespace warnings
+# from patch 0001, or CMake's "Ignoring extra path from command line: .exe").
+# Real failures are caught via explicit `if ($LASTEXITCODE -ne 0)` checks.
 
 # --- Locate worktree root from this script's own path -----------------------
-$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+# Resolve the script's own directory through .NET so we get a clean Windows
+# path regardless of how the caller invoked us. We then derive the repo root
+# from there (this script always lives at the repo root) — this avoids the
+# PowerShell-5.1 + Git-for-Windows gotcha where `git rev-parse --show-toplevel`
+# returns a forward-slash path like '/f/src/foo' that Set-Location mangles
+# to 'F:\f\src\foo' (treating /f as relative 'f' under the current drive).
+$ScriptDir = [System.IO.Path]::GetFullPath((Split-Path -Parent $MyInvocation.MyCommand.Path))
 Push-Location $ScriptDir
 try {
-    $RepoRoot = (git rev-parse --show-toplevel).Trim()
-    if (-not $RepoRoot) { throw "Not inside a git repository. Run from the worktree root." }
+    $RepoRoot = $ScriptDir
     Set-Location $RepoRoot
     Write-Host "[repo] $RepoRoot" -ForegroundColor DarkGray
 
@@ -89,9 +109,8 @@ try {
     }
 
     # --- 3. ROM check ---------------------------------------------------------
-    $RomPath = 'Automobili Lamborghini (USA).z64'
     if (-not (Test-Path $RomPath)) {
-        throw "Missing ROM: $RomPath. Place your legally-dumped USA ROM at the repo root."
+        throw "Missing ROM: $RomPath. Place your legally-dumped USA ROM at the repo root (or pass -RomPath)."
     }
 
     # --- 4. Submodules --------------------------------------------------------
@@ -116,31 +135,45 @@ try {
     git -C lib/rt64 checkout -- . | Out-Null
     git -C lib/rt64/src/contrib/plume checkout -- . | Out-Null
 
-    # --- 6. Apply Lamborghini patches (Windows: 0001, 0006, 0005, 0004) -------
-    # Mirrors CI's Windows job exactly. 0007 is intentionally omitted — the
-    # current CI doesn't apply it either, suggesting its content has landed
-    # upstream or is unnecessary for a Release build.
+    # --- 6. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0005, 0004) -
+    # Mirrors CI's Windows job exactly (workflow lines 210-214). 0001 then 0007
+    # both patch N64ModernRuntime with disjoint hunks (verified to apply
+    # sequentially on the pinned commit). 0007 adds the save-state thread-
+    # context registry + `ultramodern_relink_thread_contexts` (issue #22, all
+    # platforms). Without it, src/lambo_savestate.c fails to link with
+    # "undefined reference to `ultramodern_relink_thread_contexts`".
+    # Patch paths MUST be absolute — `git -C $sub apply $relpath` runs from
+    # inside the submodule, where the relative path doesn't resolve. CI uses
+    # "$(pwd)/patches/..." for the same reason.
     Write-Host "[2/5] Applying Lamborghini submodule patches..." -ForegroundColor Cyan
     $patches = @(
         @{ Sub = 'lib/N64ModernRuntime';       Patch = 'patches/0001-lamborghini-runtime-scheduler-audio-vi.patch' },
+        @{ Sub = 'lib/N64ModernRuntime';       Patch = 'patches/0007-ultramodern-savestate-thread-context-relink.patch' },
         @{ Sub = 'lib/rt64';                   Patch = 'patches/0006-rt64-interp-angular-velocity-matching.patch' },
         @{ Sub = 'lib/rt64';                   Patch = 'patches/0005-rt64-mingw-gcc-compat.patch' },
         @{ Sub = 'lib/rt64/src/contrib/plume'; Patch = 'patches/0004-plume-d3d12-mingw-com-abi-struct-return.patch' }
     )
     foreach ($p in $patches) {
+        $PatchAbs = Join-Path $RepoRoot $p.Patch
         # Idempotency check: distinguish three states.
         #   (a) --check 0      -> not yet applied, will apply cleanly
         #   (b) --check !=0 && --reverse --check 0 -> already applied
         #   (c) --check !=0 && --reverse --check !=0 -> context drift (submodule changed)
         # Without distinguishing (b) from (c), drift silently masquerades as
         # 'already applied' and produces a confusing compile error much later.
-        git -C $p.Sub apply --ignore-whitespace --check $p.Patch 2>&1 | Out-Null
+        #
+        # NB: use `git.exe` (not `git`) + `--quiet` to bypass any PowerShell
+        # module wrapper (e.g. posh-git) that intercepts stderr. patch 0001
+        # emits ~300 "trailing whitespace" lines that git considers non-fatal
+        # but a wrapper may promote to terminating errors under
+        # $ErrorActionPreference='Stop'.
+        & git.exe -C $p.Sub apply --quiet --ignore-whitespace --check $PatchAbs
         if ($LASTEXITCODE -eq 0) {
-            git -C $p.Sub apply --ignore-whitespace $p.Patch | Out-Null
+            & git.exe -C $p.Sub apply --quiet --ignore-whitespace $PatchAbs
             if ($LASTEXITCODE -ne 0) { throw "patch failed: $($p.Sub) <- $($p.Patch)" }
             Write-Host "  applied  $($p.Sub) <- $($p.Patch)" -ForegroundColor Green
         } else {
-            git -C $p.Sub apply --ignore-whitespace --reverse --check $p.Patch 2>&1 | Out-Null
+            & git.exe -C $p.Sub apply --quiet --ignore-whitespace --reverse --check $PatchAbs
             if ($LASTEXITCODE -eq 0) {
                 Write-Host "  skipped  $($p.Sub) <- $($p.Patch) (already applied)" -ForegroundColor DarkGray
             } else {

--- a/build.sh
+++ b/build.sh
@@ -11,13 +11,14 @@
 #   2. ROM check — the USA ROM is required to translate game code (it's also
 #      git-ignored; CI fetches it from a private assets repo, locally you
 #      place it next to this script).
-#   3. Submodule init (recursive; --c core.longpaths=true not needed on Linux).
-#   4. Defensive submodule reset before patching (CI's "Reset submodules
-#      before patching" — half-applied patches from a prior run would break
-#      the next apply with "patch failed: ... file:N").
-#   5. Apply Lamborghini patches (Linux: 0001, 0006 only — no MinGW/D3D12
-#      fixes needed; no plume patch). With --ignore-whitespace as a
-#      belt-and-suspenders guard for any CRLF drift.
+#   3. Submodule init (recursive; core.longpaths isn't needed on Linux).
+#   4. Defensive submodule reset before patching (half-applied patches from a
+#      prior run would otherwise break the next apply with "patch failed: ...").
+#   5. Apply Lamborghini patches (Linux: 0001, 0007, 0006 — no MinGW/D3D12
+#      fixes needed; no plume patch). 0007 adds the save-state thread-context
+#      registry; without it, src/lambo_savestate.c fails to link with
+#      "undefined reference to ultramodern_relink_thread_contexts".
+#      --ignore-whitespace is a belt-and-suspenders guard for any CRLF drift.
 #   6. First CMake configure — the initial one runs before N64Recomp/
 #      RSPRecomp generate sources. The CMakeLists uses if(EXISTS) on the
 #      ROM-derived files so the first configure can succeed without them.
@@ -74,7 +75,11 @@ NPROC="$(nproc)"
 log "[tools] cmake=$(command -v cmake)  gcc=$(command -v gcc)  g++=$(command -v g++)  ninja=$(command -v ninja)  nproc=$NPROC"
 
 # --- 3. ROM check -----------------------------------------------------------
-ROM="Automobili Lamborghini (USA).z64"
+# Default to the standard filename; CI overrides via the same ROM_FILENAME
+# env var the workflow already defines (workflow env block, .github/workflows/
+# build-release.yml). Reading the env var directly (rather than a CLI flag)
+# matches the workflow's convention so a future rename stays single-sourced.
+ROM="${ROM_FILENAME:-Automobili Lamborghini (USA).z64}"
 if [ ! -f "$ROM" ]; then
     die "missing ROM: $ROM
 Place your legally-dumped USA ROM at the repo root and re-run."
@@ -91,10 +96,17 @@ git -C lib/N64ModernRuntime checkout -- .
 git -C lib/rt64 checkout -- .
 git -C lib/rt64/src/contrib/plume checkout -- . 2>/dev/null || true
 
-# --- 6. Apply Lamborghini patches (Linux: 0001, 0006 only) ------------------
+# --- 6. Apply Lamborghini patches (Linux: 0001, 0007, 0006) ----------------
+# Mirrors CI's Linux job exactly (workflow lines 93-95). 0001 then 0007 both
+# patch N64ModernRuntime with disjoint hunks (verified to apply sequentially
+# on the pinned commit). 0007 adds the save-state thread-context registry +
+# `ultramodern_relink_thread_contexts` (issue #22, all platforms). Without it,
+# src/lambo_savestate.c fails to link with "undefined reference to
+# `ultramodern_relink_thread_contexts`".
 log "[2/5] Applying Lamborghini submodule patches..."
 PATCHES=(
     "lib/N64ModernRuntime:0001-lamborghini-runtime-scheduler-audio-vi.patch"
+    "lib/N64ModernRuntime:0007-ultramodern-savestate-thread-context-relink.patch"
     "lib/rt64:0006-rt64-interp-angular-velocity-matching.patch"
 )
 for entry in "${PATCHES[@]}"; do


### PR DESCRIPTION
## What

Collapse `.github/workflows/build-release.yml`'s inline build steps (submodule reset, patch apply, configure ×2, build tools, recompile, link) into a single **"Build via shared script"** step on each OS. The `build.sh` / `build.ps1` scripts become the **single source of truth** for the build sequence — if either drifts from intended behaviour, CI breaks loudly on the next push instead of silently diverging.

## Why

The original workflow had 6 inline build steps on Linux and 7 on Windows, duplicating the logic in `build.sh` / `build.ps1`. We hit real drift: the local scripts' docstrings claimed "CI doesn't apply [patch 0007] either" — that was wrong. Without 0007, `src/lambo_savestate.c` fails to link with `undefined reference to ultramodern_relink_thread_contexts`. The link error was masked by another bug (`$ErrorActionPreference='Stop'` promoting `git apply` whitespace warnings to terminating errors), so it took two sessions to surface.

After this refactor, that drift is impossible — the workflow doesn't reimplement the build steps; it just calls the script.

## What changed

- **`.github/workflows/build-release.yml`** — collapsed inline build steps into `bash build.sh` (Linux) and `pwsh -File build.ps1 -RomPath "$env:ROM_FILENAME"` (Windows). Workflow still owns CI-only concerns (checkout, ROM secret fetch, package + upload).
- **`build.ps1`** — added `-RomPath` parameter; fixed repo-root resolution (`[System.IO.Path]::GetFullPath` on `$MyInvocation.MyCommand.Path` instead of `git rev-parse --show-toplevel`, which mangles to `F:\f\src\...` under PowerShell 5.1); switched `$ErrorActionPreference` from `'Stop'` to `'Continue'` so CMake / `git apply` warnings don't terminate the script; added patch 0007 to the apply list.
- **`build.sh`** — reads `ROM_FILENAME` env var; added patch 0007 to the apply list.

## Verification

- Built locally with the refactored `build.ps1` → `[done] build\lamborghini_modern.exe (07/07/2026 13:53:38)`, exit 0.
- Patch list now matches CI exactly: Linux `0001, 0007, 0006`; Windows `0001, 0007, 0006, 0005, 0004`.

## Triggering the release

The refactor is intentionally low-risk — same patch list, same build sequence, just relocated. The release job can be triggered from the Actions tab after this lands.