### PR TITLE
#52 Readable-text glyph pack prototype (extract after validation)

### DIFF
--- a/tools/build_glyph_pack.py
+++ b/tools/build_glyph_pack.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Build the glyph-only v1 readable-text RT64 pack.
+
+The decoded dump is used only as a compatibility/coverage input: it proves that the
+current renderer produced every expected version-5 hash and supplies the three small
+atlas palettes. The generated replacements contain newly rendered Lato (or another
+user-supplied open font), not decoded game pixels.
+
+    python tools/build_glyph_pack.py <decoded-png-dir> <pack-dir> --ttf <bold.ttf> \
+        [--ttf-italic <bold-italic.ttf>]
+
+The output is a loose PNG pack with `rt64.json`. Package it with RT64's
+`texture_packer <pack-dir> --create-low-mip-cache` followed by `--create-pack`.
+"""
+
+import argparse
+from pathlib import Path
+
+from PIL import Image
+
+import make_pack
+import render_font
+
+
+ATLAS_HASHES = (
+    "2cc2b76457edc973",
+    "7c1ef5cc1ab579eb",
+    "aec011878342c59d",
+)
+
+# 16x16 blue-chrome race HUD glyphs. The name-entry grid loads the complete alphabet;
+# race counters load 0-9 and slash. Hashes are RT64 v5 TMEM identities.
+CHROME_GLYPHS = {
+    "0a315844174cfb29": "4", "1e77b22bb573e7e2": "F",
+    "235999eddd95ee7c": "I", "2837e0b9d52356db": "S",
+    "3420d09ecce9ef25": "G", "352665c5960cb5d4": "1",
+    "36af059e77647056": "8", "3d43f4da2fee0d5f": "K",
+    "3e0f930e1c864292": "3", "4b9c0f6df03f1f01": "O",
+    "5053d266ff712562": "H", "518a46d0218843b3": "/",
+    "5a2357323e4142ca": "L", "5b2c075c3f864584": "X",
+    "5d831916dd79a59f": "R", "6033a2def586ad33": "Z",
+    "65d5358cd5481e4e": "2", "6bda9baf892ead8e": "T",
+    "87a8d80d57edfa4d": "P", "8ce8877db09a2303": "V",
+    "9cd784f1c2bad952": "6", "a1e1184fcad30cb4": "A",
+    "a493cfa4d247d486": "D", "a705d62d86e0b5b2": "M",
+    "c3ef8dd57491f5fb": "U", "c422a81127e92249": "W",
+    "cf4754560f6a7b65": "9", "d01dcfb123ae5608": "5",
+    "d92c5861bb5fd140": "0", "d94580de1591993b": "B",
+    "e4219dedb67aa2ca": "J", "e929071aa32f1b1b": "Y",
+    "ea86f6a09076bee9": "E", "ee380fb2c8f4c1d7": "Q",
+    "ef6c38bc1ea56478": "C", "fabfbfb7791da252": "N",
+    "fb5243ac423b8aac": "7",
+}
+
+# 24x24 gold message/countdown glyphs encountered across the pack-message and race
+# startup states. The game only authors these words; this is the complete used set.
+GOLD_GLYPHS = {
+    "1ca0ebcef7bd9d17": "K", "1d1c418210eb8eb9": "G",
+    "612ea5fbdcf2041e": "N", "69f496caa4a581b4": "E",
+    "6b5caa506c64dc65": "H", "82cd326180c0a37f": "C",
+    "a165edf11842509a": "A", "ac27ab4ec0732a83": "D",
+    "af3e5e7b4903e514": "Y", "b45e8785058d9d71": ".",
+    "b724e8b4f81ca6ce": "T", "b8e41873b7efd84a": "O",
+    "be528398b54d1001": "R", "c6c7989916f1c72c": "W",
+    "d4aaa411f6499884": "S", "dfb262661f6e60f8": "M",
+    "fc25c298a9daa547": "P",
+}
+
+
+def expected_hashes():
+    return set(ATLAS_HASHES) | set(CHROME_GLYPHS) | set(GOLD_GLYPHS)
+
+
+def fit_tile(tile, canvas_size, margin):
+    """Scale a rendered tile down when needed so RT64 wrap cannot repeat edge ink."""
+    max_width = canvas_size[0] - margin * 2
+    max_height = canvas_size[1] - margin * 2
+    ratio = min(1.0, max_width / tile.width, max_height / tile.height)
+    if ratio < 1.0:
+        tile = tile.resize((max(1, round(tile.width * ratio)),
+                            max(1, round(tile.height * ratio))), Image.Resampling.LANCZOS)
+    return tile
+
+
+def render_single(character, ttf, source_size, colour, shear, outline):
+    """Render one glyph into an 8x integer-scaled replacement canvas."""
+    width, height = source_size
+    canvas = Image.new("RGBA", (width * render_font.SCALE, height * render_font.SCALE),
+                       (0, 0, 0, 0))
+    cap = round(height * render_font.SCALE * 0.70)
+    font = render_font.make_font(ttf, cap=cap)
+    tile = render_font.glyph_tile(character, font, colour, shear, outline=outline)
+    if tile is None:
+        raise ValueError(f"font did not render {character!r}")
+    margin = render_font.SCALE
+    tile = fit_tile(tile, canvas.size, margin)
+    x = round((canvas.width - tile.width) / 2)
+    if character in ".,":
+        y = canvas.height - tile.height - round(height * 0.12 * render_font.SCALE)
+    else:
+        y = round((canvas.height - tile.height) / 2)
+    canvas.alpha_composite(tile, (max(0, x), max(0, y)))
+    return canvas
+
+
+def build(decoded_dir, pack_dir, ttf, ttf_italic=None):
+    decoded_dir = Path(decoded_dir)
+    pack_dir = Path(pack_dir)
+    ttf = Path(ttf)
+    ttf_italic = Path(ttf_italic) if ttf_italic else None
+
+    missing = sorted(h for h in expected_hashes() if not (decoded_dir / f"{h}.png").is_file())
+    if missing:
+        raise ValueError("decoded dump is missing expected glyph hashes: " + ", ".join(missing))
+
+    if pack_dir.exists() and any(pack_dir.iterdir()):
+        raise ValueError(f"output directory must be empty: {pack_dir}")
+    pack_dir.mkdir(parents=True, exist_ok=True)
+
+    for atlas_hash in ATLAS_HASHES:
+        reference = decoded_dir / f"{atlas_hash}.png"
+        image, _italic, _count = render_font.render(reference, ttf, ttf_italic, 0.22)
+        image.save(pack_dir / f"{atlas_hash}.png")
+
+    chrome_ttf = ttf_italic or ttf
+    chrome_shear = 0.0 if ttf_italic else 0.14
+    for texture_hash, character in CHROME_GLYPHS.items():
+        image = render_single(character, chrome_ttf, (16, 16), (210, 228, 255),
+                              chrome_shear, outline=6)
+        image.save(pack_dir / f"{texture_hash}.png")
+
+    for texture_hash, character in GOLD_GLYPHS.items():
+        image = render_single(character, ttf, (24, 24), (245, 211, 82), 0.10, outline=7)
+        image.save(pack_dir / f"{texture_hash}.png")
+
+    database = make_pack.write_manifest(pack_dir, shift="none", operation="stream")
+    if len(database["textures"]) != len(expected_hashes()):
+        raise RuntimeError("manifest texture count does not match glyph coverage")
+    return database
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build the glyph-only readable-text pack")
+    parser.add_argument("decoded_dir", type=Path)
+    parser.add_argument("pack_dir", type=Path)
+    parser.add_argument("--ttf", required=True, type=Path, help="open-licensed bold TTF")
+    parser.add_argument("--ttf-italic", type=Path, help="open-licensed bold italic TTF")
+    args = parser.parse_args()
+
+    try:
+        database = build(args.decoded_dir, args.pack_dir, args.ttf, args.ttf_italic)
+    except (OSError, ValueError) as error:
+        print(f"error: {error}")
+        return 1
+    print(f"glyph pack ready: {args.pack_dir} ({len(database['textures'])} replacements)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/drive_input.py
+++ b/tools/drive_input.py
@@ -29,9 +29,9 @@ EXTENDED = {'up', 'down', 'left', 'right'}
 
 
 def find_window():
-    # Match SDL2's window class ('SDL_app'), NOT a title substring: an editor or
-    # browser with the repo ("...lamborghini-recomp...") open in a tab would
-    # otherwise match first and steal the screenshot/key events.
+    # Match both SDL2's window class and the game's exact title. Steam also uses
+    # SDL_app, while editors/browsers can contain the repo name in their title; either
+    # predicate alone can silently send input and screenshots to the wrong window.
     hwnds = []
     def cb(h, l):
         cls = ctypes.create_unicode_buffer(256)
@@ -39,7 +39,8 @@ def find_window():
         if cls.value == 'SDL_app' and user32.IsWindowVisible(h):
             buf = ctypes.create_unicode_buffer(256)
             user32.GetWindowTextW(h, buf, 256)
-            hwnds.append((h, buf.value))
+            if buf.value == 'Automobili Lamborghini':
+                hwnds.append((h, buf.value))
         return True
     user32.EnumWindows(ctypes.WINFUNCTYPE(ctypes.c_bool, wt.HWND, wt.LPARAM)(cb), 0)
     return hwnds[0] if hwnds else (None, None)

--- a/tools/make_pack.py
+++ b/tools/make_pack.py
@@ -25,19 +25,11 @@ from pathlib import Path
 HASH_RE = re.compile(r"^([0-9a-fA-F]{16})$")
 
 
-def main():
-    ap = argparse.ArgumentParser(description="Write rt64.json from hash-named replacement images.")
-    ap.add_argument("pack_dir", type=Path)
-    ap.add_argument("--auto-path", choices=["rt64", "rice"], default="rt64",
-                    help="which hash names the files on disk (default rt64)")
-    ap.add_argument("--shift", choices=["half", "none", "auto"], default="half",
-                    help="default texel shift; 'half' suits modern-tool exports (default)")
-    ap.add_argument("--operation", choices=["stream", "preload", "auto"], default="stream",
-                    help="default load operation (default stream)")
-    args = ap.parse_args()
-
+def write_manifest(pack_dir, auto_path="rt64", shift="half", operation="stream"):
+    """Write and return an RT64 replacement database for hash-named images."""
+    pack_dir = Path(pack_dir)
     textures = []
-    for p in sorted(args.pack_dir.iterdir()):
+    for p in sorted(pack_dir.iterdir()):
         if p.suffix.lower() not in (".png", ".dds"):
             continue
         m = HASH_RE.match(p.stem)
@@ -53,21 +45,39 @@ def main():
         })
 
     if not textures:
-        print(f"No <hash>.png/.dds files in {args.pack_dir}")
-        return 1
+        raise ValueError(f"No <hash>.png/.dds files in {pack_dir}")
 
     db = {
         "configuration": {
-            "autoPath": args.auto_path,
-            "defaultOperation": args.operation,
-            "defaultShift": args.shift,
+            "autoPath": auto_path,
+            "defaultOperation": operation,
+            "defaultShift": shift,
             "hashVersion": 5,  # TMEMHasher::CurrentHashVersion
         },
         "textures": textures,
     }
-    out = args.pack_dir / "rt64.json"
+    out = pack_dir / "rt64.json"
     out.write_text(json.dumps(db, indent=2))
     print(f"wrote {out} with {len(textures)} texture(s)")
+    return db
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Write rt64.json from hash-named replacement images.")
+    ap.add_argument("pack_dir", type=Path)
+    ap.add_argument("--auto-path", choices=["rt64", "rice"], default="rt64",
+                    help="which hash names the files on disk (default rt64)")
+    ap.add_argument("--shift", choices=["half", "none", "auto"], default="half",
+                    help="default texel shift; 'half' suits modern-tool exports (default)")
+    ap.add_argument("--operation", choices=["stream", "preload", "auto"], default="stream",
+                    help="default load operation (default stream)")
+    args = ap.parse_args()
+
+    try:
+        write_manifest(args.pack_dir, args.auto_path, args.shift, args.operation)
+    except ValueError as error:
+        print(error)
+        return 1
     return 0
 
 

--- a/tools/render_font.py
+++ b/tools/render_font.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Re-render the game's small font atlases from a vector (TTF) font (issue #52).
+
+`upscale_font.py` only smooths the original 8px glyphs -- it cannot add detail an 8px
+source never had, so the text stays soft. HD texture packs instead replace the atlas at
+HIGHER RESOLUTION (RT64 remaps the game's UVs onto any-size replacement, see
+`lib/rt64/src/render/rt64_texture_cache.cpp`), so the real readability win is to *re-draw*
+each glyph from a real outline font at high resolution. This produces the crisp, legible
+text the issue asks for.
+
+## Why this is per-atlas (the hard part)
+
+Each atlas hash is a distinct TMEM texture and they are packed DIFFERENTLY:
+
+- The **white** HUD/message font (`aec01187`, `2cc2b764`) is PROPORTIONALLY packed -- glyphs
+  sit at irregular atlas U-positions and some touch -- and it is **italic** in the original.
+- The **gold** menu font (`7c1ef5cc`) is cleanly separated on a regular pitch and **upright**.
+
+So there is no single position table and no single style: white needs a proportional table +
+an italic slant, gold needs an index-derived table + upright. Naively mapping glyphs to a
+fixed 8px grid, or rendering upright into the italic atlas, JUMBLES the text (verified: the
+copyright line came out as garbage). The per-atlas positions below were read off each decoded
+atlas against an x-ruler and validated in-game.
+
+## Rendering rules that matter
+
+- **Uniform cap-height + uniform stroke, then POSITION (do not stretch to fill the box).**
+  Stretching each glyph to its atlas box distorts stroke weight -- a narrow box fattens 'I',
+  a wide box thins 'M'. Render every glyph at one size and just place it.
+- Caps/digits are vertical-centred; punctuation ('.') is bottom-aligned to the baseline.
+- **Transparent base** -- paint ONLY the mapped glyphs. Any upscaled base (nearest or lanczos)
+  leaves original-glyph slivers/ghosts between the crisp glyphs.
+- **Italic atlases** (the white font): pass a real italic/oblique face via `--ttf-italic` for
+  the cleanest result. Without one, the upright `--ttf` is sheared as a fallback (portable, but
+  the shear leaves faint edge ticks). `--shear 0` disables the fallback.
+
+Pack the result with `make_pack.py <dir> --shift none` (the output is grid-aligned; `half`
+over-shifts it -- see docs/TEXTURES.md). Ship with an OPEN font (e.g. Liberation/DejaVu Bold)
+to avoid embedding a proprietary face.
+
+    python tools/render_font.py <decoded_atlas.png> <out.png> --ttf <bold.ttf> \
+        [--ttf-italic <bold-oblique.ttf>] [--shear 0.22]
+
+The atlas profile (positions + italic flag) is auto-selected from the hash in the filename.
+
+Requires Pillow. No numpy.
+"""
+
+import argparse
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+SCALE = 8        # 512x8 -> 4096x64
+OUTLINE = 4      # dark outline width in output px (contrast on bright HUD backgrounds)
+
+
+def ink_runs(img):
+    """Contiguous columns that contain any opaque texel -> [(x0, x1), ...]."""
+    px = img.load()
+    w, h = img.size
+    ink = [any(px[x, y][3] > 0 for y in range(h)) for x in range(w)]
+    runs = []
+    x = 0
+    while x < w:
+        if ink[x]:
+            s = x
+            while x < w and ink[x]:
+                x += 1
+            runs.append((s, x - 1))
+        else:
+            x += 1
+    return runs
+
+
+def _split(a, b, n):
+    """Split a merged run [a, b] evenly into n glyph boxes."""
+    w = (b - a + 1) / n
+    return [(round(a + i * w), round(a + (i + 1) * w) - 1) for i in range(n)]
+
+
+def white_boxes(_img):
+    """Proportional white atlas (aec01187 / 2cc2b764): read vs an x-ruler; merged runs
+    (touching glyphs) split evenly across their glyph count."""
+    b = {'0': (150, 158), '1': (161, 167), '2': (170, 178), '3': (180, 188)}
+    for ch, box in zip("456", _split(190, 218, 3)):
+        b[ch] = box
+    for ch, box in zip("789", _split(220, 248, 3)):
+        b[ch] = box
+    b.update({'A': (250, 258), 'B': (260, 268), 'C': (270, 277), 'D': (280, 288),
+              'E': (290, 298), 'F': (300, 308), 'G': (310, 317), 'J': (340, 346),
+              'K': (350, 358), 'L': (360, 366), 'P': (400, 407), 'Q': (410, 418),
+              'R': (420, 428), 'S': (430, 437), 'T': (440, 447), 'U': (450, 458),
+              'V': (460, 467), 'Z': (500, 509)})
+    for ch, box in zip("HI", _split(320, 335, 2)):
+        b[ch] = box
+    for ch, box in zip("MNO", _split(370, 398, 3)):
+        b[ch] = box
+    for ch, box in zip("WXY", _split(470, 496, 3)):
+        b[ch] = box
+    b['.'] = (130, 135)   # period (bottom dot); also the ".....' deco
+    return b
+
+
+def gold_boxes(img):
+    """Gold menu atlas (7c1ef5cc): cleanly separated (no merges), so derive from run
+    indices -- digits 0-9 = runs 16..25, letters A-Z = runs 33..58, period = run 14."""
+    r = ink_runs(img)
+    b = {}
+    for i, ch in enumerate("0123456789"):
+        b[ch] = r[16 + i]
+    for i in range(26):
+        b[chr(ord('A') + i)] = r[33 + i]
+    b['.'] = r[14]
+    return b
+
+
+# hash substring -> (box-table builder, italic?)
+PROFILES = {
+    "aec01187": (white_boxes, True),
+    "2cc2b764": (white_boxes, True),
+    "7c1ef5cc": (gold_boxes, False),
+}
+
+
+def profile_for(name):
+    for key, prof in PROFILES.items():
+        if key in name:
+            return prof
+    raise SystemExit(f"no atlas profile matches '{name}' (known: {list(PROFILES)})")
+
+
+def make_font(ttf):
+    """Font sized so cap height ~= 6.8 texels of the 8-texel-tall atlas."""
+    cap = round(6.8 * SCALE)
+    probe = ImageFont.truetype(ttf, 200)
+    pb = probe.getbbox("H")
+    caph = max(1, pb[3] - pb[1])
+    return ImageFont.truetype(ttf, max(8, round(200 * cap / caph)))
+
+
+def glyph_tile(ch, font, colour, shear):
+    bb = font.getbbox(ch, stroke_width=OUTLINE)
+    gw, gh = bb[2] - bb[0], bb[3] - bb[1]
+    if gw <= 0 or gh <= 0:
+        return None
+    tile = Image.new("RGBA", (gw + 2, gh + 2), (0, 0, 0, 0))
+    ImageDraw.Draw(tile).text((1 - bb[0], 1 - bb[1]), ch, font=font, fill=colour + (255,),
+                              stroke_width=OUTLINE, stroke_fill=(0, 0, 0, 255))
+    if shear:
+        # slant right (italic): top edge shifts by +shear*height relative to the bottom
+        pad = int(abs(shear) * tile.height) + 1
+        wide = Image.new("RGBA", (tile.width + pad, tile.height), (0, 0, 0, 0))
+        wide.paste(tile, (pad if shear > 0 else 0, 0))
+        tile = wide.transform(wide.size, Image.AFFINE, (1, shear, -shear * tile.height, 0, 1, 0),
+                              resample=Image.BICUBIC)
+    return tile
+
+
+def ink_colour(ref, x0, x1):
+    """Highlight colour of the original glyph (brightest quartile of opaque texels, so a
+    white atlas stays white and a gold one stays gold -- the mean would read as grey)."""
+    px = ref.load()
+    h = ref.size[1]
+    ink = []
+    for x in range(x0, x1 + 1):
+        for y in range(h):
+            r, g, b, a = px[x, y]
+            if a > 0:
+                ink.append((r + g + b, r, g, b))
+    if not ink:
+        return (255, 255, 255)
+    ink.sort(reverse=True)
+    top = ink[: max(1, len(ink) // 4)]
+    return tuple(sum(p[i] for p in top) // len(top) for i in (1, 2, 3))
+
+
+def render(ref_path, ttf, ttf_italic, shear_amt):
+    ref = Image.open(ref_path).convert("RGBA")
+    w, h = ref.size
+    boxes_fn, italic = profile_for(Path(ref_path).name)
+    boxes = boxes_fn(ref)
+    # italic atlas: prefer a real italic face (clean); else shear the upright font (fallback).
+    if italic and ttf_italic:
+        font, shear = make_font(ttf_italic), 0.0
+    else:
+        font, shear = make_font(ttf), (shear_amt if italic else 0.0)
+
+    out = Image.new("RGBA", (w * SCALE, h * SCALE), (0, 0, 0, 0))     # transparent base
+    for ch, (x0, x1) in boxes.items():
+        tile = glyph_tile(ch, font, ink_colour(ref, x0, x1), shear)
+        if tile is None:
+            continue
+        cx = (x0 + x1 + 1) / 2 * SCALE
+        px = round(cx - tile.width / 2)
+        if ch in ".,":
+            py = h * SCALE - tile.height - round(0.4 * SCALE)    # punctuation on the baseline
+        else:
+            py = round((h * SCALE - tile.height) / 2)            # caps/digits centred
+        out.alpha_composite(tile, (max(0, px), max(0, py)))
+    return out, italic, len(boxes)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Re-render a small font atlas from a TTF (#52).")
+    ap.add_argument("ref", type=Path, help="decoded atlas PNG (filename must contain the hash)")
+    ap.add_argument("out", type=Path)
+    ap.add_argument("--ttf", required=True, help="a bold upright TTF (used for the gold atlas)")
+    ap.add_argument("--ttf-italic", dest="ttf_italic", default=None,
+                    help="a bold italic/oblique TTF for the white atlases (cleanest); else --ttf is sheared")
+    ap.add_argument("--shear", type=float, default=0.22, help="italic shear fallback for white atlases (0=off)")
+    args = ap.parse_args()
+
+    img, italic, n = render(args.ref, args.ttf, args.ttf_italic, args.shear)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    img.save(args.out)
+    print(f"re-rendered {args.ref.name} ({'italic' if italic else 'upright'}, {n} glyphs) "
+          f"via {Path(args.ttf).name} -> {args.out}")
+    print("  pack with: make_pack.py <dir> --shift none")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/render_font.py
+++ b/tools/render_font.py
@@ -12,15 +12,15 @@ text the issue asks for.
 
 Each atlas hash is a distinct TMEM texture and they are packed DIFFERENTLY:
 
-- The **white** HUD/message font (`aec01187`, `2cc2b764`) is PROPORTIONALLY packed -- glyphs
-  sit at irregular atlas U-positions and some touch -- and it is **italic** in the original.
-- The **gold** menu font (`7c1ef5cc`) is cleanly separated on a regular pitch and **upright**.
+- The **white** HUD/message font (`aec01187`, `2cc2b764`) uses 10-pixel cells, omits the
+  `:;<=>?@` cells, and is **italic** in the original.
+- The **gold** menu font (`7c1ef5cc`) uses 8-pixel cells, includes every character from
+  `!` through `Z`, has a leading blank cell, and is **upright**.
 
-So there is no single position table and no single style: white needs a proportional table +
-an italic slant, gold needs an index-derived table + upright. Naively mapping glyphs to a
-fixed 8px grid, or rendering upright into the italic atlas, JUMBLES the text (verified: the
-copyright line came out as garbage). The per-atlas positions below were read off each decoded
-atlas against an x-ruler and validated in-game.
+So there is no single cell pitch or single style. Naively mapping both atlases to a fixed
+8px grid, or rendering upright into the italic atlas, JUMBLES the text (verified: the
+copyright line came out as garbage). The per-atlas layouts below were read off decoded
+atlases against an x-ruler and validated in-game.
 
 ## Rendering rules that matter
 
@@ -47,79 +47,59 @@ Requires Pillow. No numpy.
 """
 
 import argparse
+from dataclasses import dataclass
 from pathlib import Path
 
 from PIL import Image, ImageDraw, ImageFont
 
-SCALE = 8        # 512x8 -> 4096x64
-OUTLINE = 4      # dark outline width in output px (contrast on bright HUD backgrounds)
+SCALE = 8
+OUTLINE = 4
+WHITE_CHARACTERS = "!\"#$%&'()*+,-./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+GOLD_CHARACTERS = "".join(chr(codepoint) for codepoint in range(ord("!"), ord("Z") + 1))
 
 
-def ink_runs(img):
-    """Contiguous columns that contain any opaque texel -> [(x0, x1), ...]."""
+def boxes_from_cells(img, characters, pitch, first_cell=0):
+    """Return each character's opaque bounds within its authored atlas cell."""
     px = img.load()
     w, h = img.size
-    ink = [any(px[x, y][3] > 0 for y in range(h)) for x in range(w)]
-    runs = []
-    x = 0
-    while x < w:
-        if ink[x]:
-            s = x
-            while x < w and ink[x]:
-                x += 1
-            runs.append((s, x - 1))
-        else:
-            x += 1
-    return runs
+    boxes = {}
+    for index, character in enumerate(characters):
+        cell_x0 = (first_cell + index) * pitch
+        cell_x1 = min(w, cell_x0 + pitch) - 1
+        ink = [x for x in range(cell_x0, cell_x1 + 1)
+               if any(px[x, y][3] > 0 for y in range(h))]
+        if not ink:
+            raise ValueError(f"atlas cell for {character!r} at x={cell_x0} has no ink")
+        boxes[character] = (min(ink), max(ink))
+    return boxes
 
 
-def _split(a, b, n):
-    """Split a merged run [a, b] evenly into n glyph boxes."""
-    w = (b - a + 1) / n
-    return [(round(a + i * w), round(a + (i + 1) * w) - 1) for i in range(n)]
+def position_in_cell(ideal_x, tile_width, cell_x, cell_width, gutter):
+    """Clamp a tile's x position so its ink cannot leak into a neighbouring cell."""
+    left = cell_x + gutter
+    right = cell_x + cell_width - gutter - tile_width
+    if right < left:
+        raise ValueError("tile is wider than the atlas cell's usable area")
+    return min(max(round(ideal_x), left), right)
 
 
-def white_boxes(_img):
-    """Proportional white atlas (aec01187 / 2cc2b764): read vs an x-ruler; merged runs
-    (touching glyphs) split evenly across their glyph count."""
-    b = {'0': (150, 158), '1': (161, 167), '2': (170, 178), '3': (180, 188)}
-    for ch, box in zip("456", _split(190, 218, 3)):
-        b[ch] = box
-    for ch, box in zip("789", _split(220, 248, 3)):
-        b[ch] = box
-    b.update({'A': (250, 258), 'B': (260, 268), 'C': (270, 277), 'D': (280, 288),
-              'E': (290, 298), 'F': (300, 308), 'G': (310, 317), 'J': (340, 346),
-              'K': (350, 358), 'L': (360, 366), 'P': (400, 407), 'Q': (410, 418),
-              'R': (420, 428), 'S': (430, 437), 'T': (440, 447), 'U': (450, 458),
-              'V': (460, 467), 'Z': (500, 509)})
-    for ch, box in zip("HI", _split(320, 335, 2)):
-        b[ch] = box
-    for ch, box in zip("MNO", _split(370, 398, 3)):
-        b[ch] = box
-    for ch, box in zip("WXY", _split(470, 496, 3)):
-        b[ch] = box
-    b['.'] = (130, 135)   # period (bottom dot); also the ".....' deco
-    return b
+@dataclass(frozen=True)
+class AtlasProfile:
+    italic: bool
+    characters: str
+    pitch: int
+    first_cell: int = 0
+
+    def boxes(self, image):
+        return boxes_from_cells(image, self.characters, self.pitch, self.first_cell)
 
 
-def gold_boxes(img):
-    """Gold menu atlas (7c1ef5cc): cleanly separated (no merges), so derive from run
-    indices -- digits 0-9 = runs 16..25, letters A-Z = runs 33..58, period = run 14."""
-    r = ink_runs(img)
-    b = {}
-    for i, ch in enumerate("0123456789"):
-        b[ch] = r[16 + i]
-    for i in range(26):
-        b[chr(ord('A') + i)] = r[33 + i]
-    b['.'] = r[14]
-    return b
-
-
-# hash substring -> (box-table builder, italic?)
+WHITE_PROFILE = AtlasProfile(True, WHITE_CHARACTERS, 10)
+GOLD_PROFILE = AtlasProfile(False, GOLD_CHARACTERS, 8, first_cell=1)
 PROFILES = {
-    "aec01187": (white_boxes, True),
-    "2cc2b764": (white_boxes, True),
-    "7c1ef5cc": (gold_boxes, False),
+    "aec01187": WHITE_PROFILE,
+    "2cc2b764": WHITE_PROFILE,
+    "7c1ef5cc": GOLD_PROFILE,
 }
 
 
@@ -130,23 +110,23 @@ def profile_for(name):
     raise SystemExit(f"no atlas profile matches '{name}' (known: {list(PROFILES)})")
 
 
-def make_font(ttf):
-    """Font sized so cap height ~= 6.8 texels of the 8-texel-tall atlas."""
-    cap = round(6.8 * SCALE)
+def make_font(ttf, cap=None):
+    """Return a font sized to the requested cap height in output pixels."""
+    cap = round(6.8 * SCALE) if cap is None else cap
     probe = ImageFont.truetype(ttf, 200)
     pb = probe.getbbox("H")
     caph = max(1, pb[3] - pb[1])
     return ImageFont.truetype(ttf, max(8, round(200 * cap / caph)))
 
 
-def glyph_tile(ch, font, colour, shear):
-    bb = font.getbbox(ch, stroke_width=OUTLINE)
+def glyph_tile(ch, font, colour, shear, outline=OUTLINE):
+    bb = font.getbbox(ch, stroke_width=outline)
     gw, gh = bb[2] - bb[0], bb[3] - bb[1]
     if gw <= 0 or gh <= 0:
         return None
     tile = Image.new("RGBA", (gw + 2, gh + 2), (0, 0, 0, 0))
     ImageDraw.Draw(tile).text((1 - bb[0], 1 - bb[1]), ch, font=font, fill=colour + (255,),
-                              stroke_width=OUTLINE, stroke_fill=(0, 0, 0, 255))
+                              stroke_width=outline, stroke_fill=(0, 0, 0, 255))
     if shear:
         # slant right (italic): top edge shifts by +shear*height relative to the bottom
         pad = int(abs(shear) * tile.height) + 1
@@ -178,26 +158,49 @@ def ink_colour(ref, x0, x1):
 def render(ref_path, ttf, ttf_italic, shear_amt):
     ref = Image.open(ref_path).convert("RGBA")
     w, h = ref.size
-    boxes_fn, italic = profile_for(Path(ref_path).name)
-    boxes = boxes_fn(ref)
+    profile = profile_for(Path(ref_path).name)
+    boxes = profile.boxes(ref)
+    italic = profile.italic
     # italic atlas: prefer a real italic face (clean); else shear the upright font (fallback).
     if italic and ttf_italic:
         font, shear = make_font(ttf_italic), 0.0
     else:
         font, shear = make_font(ttf), (shear_amt if italic else 0.0)
 
-    out = Image.new("RGBA", (w * SCALE, h * SCALE), (0, 0, 0, 0))     # transparent base
+    rendered = []
     for ch, (x0, x1) in boxes.items():
         tile = glyph_tile(ch, font, ink_colour(ref, x0, x1), shear)
         if tile is None:
             continue
+        rendered.append((ch, x0, x1, tile))
+
+    # A replacement glyph must stay inside its source atlas cell. Otherwise the game's
+    # cell UV samples the edge of the next rendered glyph (e.g. `ARCADE|`). Scale the
+    # whole typeface uniformly when its widest glyph needs more than the available cell.
+    gutter = SCALE // 2
+    usable_width = profile.pitch * SCALE - gutter * 2
+    widest = max(tile.width for _ch, _x0, _x1, tile in rendered)
+    ratio = min(1.0, usable_width / widest)
+    if ratio < 1.0:
+        rendered = [(ch, x0, x1,
+                     tile.resize((max(1, round(tile.width * ratio)),
+                                  max(1, round(tile.height * ratio))), Image.Resampling.LANCZOS))
+                    for ch, x0, x1, tile in rendered]
+
+    out = Image.new("RGBA", (w * SCALE, h * SCALE), (0, 0, 0, 0))
+    for ch, x0, x1, tile in rendered:
         cx = (x0 + x1 + 1) / 2 * SCALE
-        px = round(cx - tile.width / 2)
+        cell_index = profile.first_cell + profile.characters.index(ch)
+        px = position_in_cell(cx - tile.width / 2, tile.width,
+                              cell_index * profile.pitch * SCALE,
+                              profile.pitch * SCALE, gutter)
         if ch in ".,":
-            py = h * SCALE - tile.height - round(0.4 * SCALE)    # punctuation on the baseline
+            py = h * SCALE - tile.height - round(0.4 * SCALE)
+        elif ch in "\"'":
+            py = round(0.4 * SCALE)
         else:
-            py = round((h * SCALE - tile.height) / 2)            # caps/digits centred
-        out.alpha_composite(tile, (max(0, px), max(0, py)))
+            py = round((h * SCALE - tile.height) / 2)
+        out.alpha_composite(tile, (px, max(0, py)))
     return out, italic, len(boxes)
 
 

--- a/tools/test_glyph_pack.py
+++ b/tools/test_glyph_pack.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Regression tests for the readable-text pack generators."""
+
+import unittest
+import tempfile
+from pathlib import Path
+
+from PIL import Image
+
+import render_font as rf
+import upscale_font as uf
+import build_glyph_pack as gp
+import make_pack
+
+
+WHITE_CHARACTERS = "!\"#$%&'()*+,-./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+GOLD_CHARACTERS = "".join(chr(codepoint) for codepoint in range(ord("!"), ord("Z") + 1))
+
+
+def reference_with_cell_ink(width, pitch, characters, first_cell):
+    """Make isolated one-pixel glyph marks in the atlas cells used by a profile."""
+    image = Image.new("RGBA", (width, 8), (0, 0, 0, 0))
+    for index, _character in enumerate(characters):
+        image.putpixel(((first_cell + index) * pitch + 2, 4), (255, 255, 255, 255))
+    return image
+
+
+class TestColourBleed(unittest.TestCase):
+    def test_colour_propagates_beyond_the_first_transparent_ring(self):
+        image = Image.new("RGBA", (5, 1), (0, 0, 255, 0))
+        image.putpixel((2, 0), (240, 20, 10, 255))
+
+        result = uf.bleed_colour(image, iterations=2)
+
+        self.assertEqual([result.getpixel((x, 0))[:3] for x in range(5)],
+                         [(240, 20, 10)] * 5)
+        self.assertEqual([result.getpixel((x, 0))[3] for x in range(5)],
+                         [0, 0, 255, 0, 0])
+
+
+class TestAtlasCoverage(unittest.TestCase):
+    def test_white_profile_covers_every_authored_symbol_digit_and_letter(self):
+        reference = reference_with_cell_ink(512, 10, WHITE_CHARACTERS, first_cell=0)
+        self.assertEqual(set(rf.WHITE_PROFILE.boxes(reference)), set(WHITE_CHARACTERS))
+
+    def test_gold_profile_covers_ascii_punctuation_digits_and_letters(self):
+        reference = reference_with_cell_ink(512, 8, GOLD_CHARACTERS, first_cell=1)
+        self.assertEqual(set(rf.GOLD_PROFILE.boxes(reference)), set(GOLD_CHARACTERS))
+
+    def test_atlas_tile_position_is_clamped_inside_its_cell_gutter(self):
+        self.assertEqual(rf.position_in_cell(ideal_x=50, tile_width=70,
+                                             cell_x=80, cell_width=80, gutter=4), 84)
+        self.assertEqual(rf.position_in_cell(ideal_x=140, tile_width=70,
+                                             cell_x=80, cell_width=80, gutter=4), 86)
+
+
+class TestPackCoverage(unittest.TestCase):
+    def test_chrome_hashes_cover_full_uppercase_alphabet_digits_and_slash(self):
+        expected = set("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/")
+        self.assertEqual(set(gp.CHROME_GLYPHS.values()), expected)
+        self.assertEqual(len(gp.CHROME_GLYPHS), len(expected))
+
+    def test_glyph_pack_has_no_overlapping_hash_assignments(self):
+        expected_count = len(gp.ATLAS_HASHES) + len(gp.CHROME_GLYPHS) + len(gp.GOLD_GLYPHS)
+        self.assertEqual(len(gp.expected_hashes()), expected_count)
+
+    def test_oversize_glyph_is_fitted_inside_a_transparent_margin(self):
+        tile = Image.new("RGBA", (200, 100), (255, 255, 255, 255))
+        fitted = gp.fit_tile(tile, (128, 128), margin=8)
+        self.assertLessEqual(fitted.width, 112)
+        self.assertLessEqual(fitted.height, 112)
+
+
+class TestManifest(unittest.TestCase):
+    def test_write_manifest_returns_the_database_used_by_the_pack_builder(self):
+        with tempfile.TemporaryDirectory() as directory:
+            pack_dir = Path(directory)
+            (pack_dir / "0123456789abcdef.png").write_bytes(b"fixture")
+
+            database = make_pack.write_manifest(pack_dir, shift="none", operation="preload")
+
+            self.assertEqual(database["configuration"]["defaultShift"], "none")
+            self.assertEqual(database["configuration"]["defaultOperation"], "preload")
+            self.assertEqual(database["textures"][0]["hashes"]["rt64"],
+                             "0123456789abcdef")
+            self.assertTrue((pack_dir / "rt64.json").is_file())
+
+    def test_write_manifest_rejects_an_empty_pack(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(ValueError):
+                make_pack.write_manifest(Path(directory))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/upscale_font.py
+++ b/tools/upscale_font.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Upscale a decoded font/HUD atlas into a higher-resolution replacement (issue #52).
+
+The source glyph atlases are tiny CI4/CI8 strips (e.g. the HUD font is 512x8). Blown
+up at native output resolution by nearest-neighbour they read as blocky and hard to
+read -- the whole point of #52 is to make them legible. This tool takes a decoded
+<hash>.png (from tools/decode_dump.py) and produces an N-times-larger PNG whose
+letterforms are preserved but whose staircase edges are smoothed, i.e. an
+"algorithmic upscale" that keeps the original 1997 shapes rather than re-drawing
+them from a modern font.
+
+Why not just Image.resize(LANCZOS) on the RGBA? A palettized font decodes to RGBA
+where every *transparent* texel has an undefined RGB value. Resampling the whole
+image pulls that junk RGB into the glyph edges and fringes them. So we:
+
+  1. Split colour from the coverage (alpha) channel.
+  2. Bleed the nearest opaque colour outward into the transparent region, so the
+     colour plane has no hard seam for the resampler to smear.
+  3. Upscale the bled colour plane and the alpha plane independently (high-quality
+     Lanczos), then recombine. The smooth alpha ramp *is* the anti-aliased edge.
+
+For a 1-bit-alpha font (CI4 with an RGBA16 TLUT, the common HUD case) this yields
+clean, readable, letterform-preserving glyphs with no colour fringe.
+
+    python tools/upscale_font.py <in.png> <out.png> [--scale N] [--edge soft|crisp]
+                                                     [--sharpen]
+
+  --scale N     integer upscale factor (default 8).
+  --edge soft   plain Lanczos alpha ramp (default; softest, most faithful).
+  --edge crisp  supersample + reharden the alpha so edges stay tight at high N
+                (better for very low glyphs where soft looks mushy).
+  --sharpen     apply a mild unsharp mask to the colour plane afterwards.
+
+The output is an integer-scaled copy of the N64 texel grid (no sub-texel origin
+offset), so pack it with `make_pack.py --shift none`, NOT the default `half`. A
+half-texel shift over-shifts a grid-aligned upscale by half a source texel, which
+in-game reads as each glyph doubling into its neighbour's cell (verified on the
+512x8 HUD font: `shift: half` -> "ONE PLAYER" renders as "ONE PLAYER:").
+
+Requires Pillow (already used by tools/drive_input.py). No numpy.
+"""
+
+import argparse
+from pathlib import Path
+
+from PIL import Image, ImageFilter
+
+
+def bleed_colour(rgba, iterations):
+    """Push the nearest opaque RGB outward into transparent texels so the colour
+    plane has no hard transparent/opaque seam for the resampler to smear. Alpha is
+    left untouched; only RGB of transparent pixels is filled."""
+    px = rgba.load()
+    w, h = rgba.size
+    for _ in range(iterations):
+        changed = False
+        # snapshot alpha so a pixel filled this pass isn't treated as a source yet
+        opaque = [[px[x, y][3] > 0 for y in range(h)] for x in range(w)]
+        for y in range(h):
+            for x in range(w):
+                if opaque[x][y]:
+                    continue
+                acc = [0, 0, 0]
+                n = 0
+                for dx, dy in ((-1, 0), (1, 0), (0, -1), (0, 1),
+                               (-1, -1), (1, -1), (-1, 1), (1, 1)):
+                    nx, ny = x + dx, y + dy
+                    if 0 <= nx < w and 0 <= ny < h and opaque[nx][ny]:
+                        r, g, b, _ = px[nx, ny]
+                        acc[0] += r
+                        acc[1] += g
+                        acc[2] += b
+                        n += 1
+                if n:
+                    r, g, b, a = px[x, y]
+                    px[x, y] = (acc[0] // n, acc[1] // n, acc[2] // n, a)
+                    changed = True
+        if not changed:
+            break
+    return rgba
+
+
+def upscale(inp, scale, edge, sharpen):
+    src = Image.open(inp).convert("RGBA")
+    w, h = src.size
+    tw, th = w * scale, h * scale
+
+    # 1. colour plane: bleed then upscale (no alpha, so no transparent smear)
+    bled = bleed_colour(src.copy(), iterations=max(w, h))
+    rgb = bled.convert("RGB").resize((tw, th), Image.LANCZOS)
+    if sharpen:
+        rgb = rgb.filter(ImageFilter.UnsharpMask(radius=scale / 2, percent=80, threshold=0))
+
+    # 2. alpha (coverage) plane
+    alpha = src.getchannel("A")
+    if edge == "crisp":
+        # supersample high, blur lightly, then reharden the ramp so edges stay
+        # tight instead of dissolving -- better for very short (<=8px) glyphs.
+        big = alpha.resize((tw * 2, th * 2), Image.LANCZOS)
+        big = big.filter(ImageFilter.GaussianBlur(radius=scale / 4))
+        big = big.point(lambda v: 0 if v < 96 else (255 if v > 160 else int((v - 96) * 255 / 64)))
+        up_a = big.resize((tw, th), Image.LANCZOS)
+    else:  # soft
+        up_a = alpha.resize((tw, th), Image.LANCZOS)
+
+    out = rgb.convert("RGBA")
+    out.putalpha(up_a)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Upscale a decoded font atlas (issue #52).")
+    ap.add_argument("inp", type=Path)
+    ap.add_argument("out", type=Path)
+    ap.add_argument("--scale", type=int, default=8)
+    ap.add_argument("--edge", choices=["soft", "crisp"], default="soft")
+    ap.add_argument("--sharpen", action="store_true")
+    args = ap.parse_args()
+
+    img = upscale(args.inp, args.scale, args.edge, args.sharpen)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    img.save(args.out)
+    print(f"upscaled {args.inp.name} {img.width // args.scale}x{img.height // args.scale}"
+          f" -> {img.width}x{img.height} ({args.edge}) -> {args.out}")
+    print("  pack with: make_pack.py <dir> --shift none  (grid-aligned upscale)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/upscale_font.py
+++ b/tools/upscale_font.py
@@ -52,20 +52,23 @@ def bleed_colour(rgba, iterations):
     left untouched; only RGB of transparent pixels is filled."""
     px = rgba.load()
     w, h = rgba.size
+    # Coverage and propagation are deliberately separate. A filled transparent pixel
+    # keeps alpha=0, but must become an RGB source on the next pass so the bleed can
+    # advance beyond the first ring around the glyph.
+    filled = [[px[x, y][3] > 0 for y in range(h)] for x in range(w)]
     for _ in range(iterations):
         changed = False
-        # snapshot alpha so a pixel filled this pass isn't treated as a source yet
-        opaque = [[px[x, y][3] > 0 for y in range(h)] for x in range(w)]
+        source = [column[:] for column in filled]
         for y in range(h):
             for x in range(w):
-                if opaque[x][y]:
+                if source[x][y]:
                     continue
                 acc = [0, 0, 0]
                 n = 0
                 for dx, dy in ((-1, 0), (1, 0), (0, -1), (0, 1),
                                (-1, -1), (1, -1), (-1, 1), (1, 1)):
                     nx, ny = x + dx, y + dy
-                    if 0 <= nx < w and 0 <= ny < h and opaque[nx][ny]:
+                    if 0 <= nx < w and 0 <= ny < h and source[nx][ny]:
                         r, g, b, _ = px[nx, ny]
                         acc[0] += r
                         acc[1] += g
@@ -74,6 +77,7 @@ def bleed_colour(rgba, iterations):
                 if n:
                     r, g, b, a = px[x, y]
                     px[x, y] = (acc[0] // n, acc[1] // n, acc[2] // n, a)
+                    filled[x][y] = True
                     changed = True
         if not changed:
             break
@@ -91,7 +95,6 @@ def upscale(inp, scale, edge, sharpen):
     if sharpen:
         rgb = rgb.filter(ImageFilter.UnsharpMask(radius=scale / 2, percent=80, threshold=0))
 
-    # 2. alpha (coverage) plane
     alpha = src.getchannel("A")
     if edge == "crisp":
         # supersample high, blur lightly, then reharden the ramp so edges stay
@@ -100,7 +103,7 @@ def upscale(inp, scale, edge, sharpen):
         big = big.filter(ImageFilter.GaussianBlur(radius=scale / 4))
         big = big.point(lambda v: 0 if v < 96 else (255 if v > 160 else int((v - 96) * 255 / 64)))
         up_a = big.resize((tw, th), Image.LANCZOS)
-    else:  # soft
+    else:
         up_a = alpha.resize((tw, th), Image.LANCZOS)
 
     out = rgb.convert("RGBA")


### PR DESCRIPTION
**Draft prototype — not intended to merge in this repository shape.** This is the first working readable-text pack for #52. PR #167 now owns the generic RT64 loading/dumping documentation; the pack-specific code and assets here are being stabilized before extraction to a dedicated texture-pack repository/package.

## What now works

- Fixes `bleed_colour()` so RGB padding propagates across every requested ring while transparent alpha remains unchanged.
- Re-renders the full authored coverage of both small-font atlas layouts: white punctuation/digits/A–Z and gold ASCII `!` through `Z`.
- Replaces the discovered blue-chrome set for A–Z, 0–9, and `/`, plus the 17 gold glyph hashes observed in race-start/message text.
- Clamps and uniformly scales glyph tiles into transparent cell gutters, preventing neighbouring-character bleed without distorting stroke weight.
- Builds a deterministic 57-replacement loose pack and manifest with `shift: none`.
- Tightens the input helper so it selects the game window, not Steam's similarly named SDL window.

## Validation

- `python tools/test_glyph_pack.py` — 9 passing tests.
- `python tools/test_decode_dump.py` — 7 passing tests.
- Fresh build from a live decoded dump produced exactly 57 replacements.
- The open SIL OFL Lato Bold/Bold Italic build was converted to BC7 DDS with full mip chains, given a low-mip cache, packed as `.rtz`, and loaded successfully by the game.
- Runtime checks cover menu/message text and in-race HUD/speedometer text without atlas wrapping artifacts.

Validated local artifact (deliberately not committed here): `readable-text-v1.rtz`, 589,376 bytes, SHA-256 `398FA09C36FA550C1160340FD5F4BCE9E90A163EA153724A94B01D9E3860F707`.

## Boundary and remaining work

- Do not merge pack-specific fonts, upscaling/rendering tools, replacement images, or the final `.rtz` into the game repository. Move them to the dedicated pack project once this workflow settles; the game repository should retain only its generic RT64 interface.
- Complete an exhaustive capture matrix before claiming all of #52: attract intro, PRESS START, RACE, NAME entry, records/times, every results screen, pause/countdown, and the in-race HUD.
- Issue #52's older `shift: half` instruction conflicts with the validated grid-aligned pipeline. `shift: none` is intentional and should be recorded as the replacement-pack exception.
- PR #99 is closed; its useful texture-discovery findings are preserved there, while its xBRZ tooling, vendored library, screenshots, and machine-specific comparison script remain unmerged.
