### PR TITLE
Add contributor-facing artefacts: CONTRIBUTING.md + issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,99 @@
+---
+name: Bug report
+about: Report a bug in the port. The fields below map to the layers the maintainer has to peel back to fix anything (ROM, build, config, runtime) — please fill them in.
+title: "[BUG] "
+labels: "bug"
+assignees: ""
+---
+
+## Pre-flight
+
+**ROM identifier.** The port only supports the USA release (`Automobili Lamborghini (USA).z64`). Other regions will misbehave.
+
+- ROM filename:
+- SHA1 (preferred) or CRC32: <!-- `sha1sum "Automobili Lamborghini (USA).z64"` on Linux, `certutil -hashfile "Automobili Lamborghini (USA).z64" SHA1` on Windows -->
+
+**Build source.** Builds drift when submodules or patches are off the pinned commits — this is the #1 source of "works on my machine".
+
+- Commit SHA (`git rev-parse HEAD`):
+- Built with `build.sh` / `build.ps1`, or hand-rolled cmake?
+- If hand-rolled, list which dependency patches you applied (the set is platform-specific — see `BUILDING.md` §2):
+
+**Vanilla check.** Does the same thing happen on original N64 hardware, or in ares running the same ROM? *(Optional but huge — distinguishes port bugs from ROM bugs. If yes, link the ares run / save.)*
+
+**GPU driver.** If you're on **Windows + Nvidia and the game crashes on boot, update your driver first** before filing. Old Nvidia drivers are the most common cause of boot crashes here.
+
+- GPU:
+- Driver version:
+
+**Mods / local overrides.** *(Answer "no" if none.)*
+
+- Any mods installed?
+- Edited `graphics.json` from the defaults in `README.md`?
+- Custom `lamborghini.syms.toml`, `force_stub.txt`, or `patches/` edits?
+
+## The bug
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior. If a `LAMBO_WARP=N` env var reproduces it from cold boot, **say so** — it makes triage much faster than "drive to the bug".
+
+1. Go to '...'
+2. Press '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+## Artifacts
+
+**Save state.** The port supports full RDRAM snapshot save states (`F7` = save, `F8` = load; also `LAMBO_STATE_SAVE` / `LAMBO_STATE_LOAD` env vars; default file `lambo_savestate.lstate` written to the directory you launched the binary from — override with `LAMBO_STATE_FILE=<path>`). If you can attach a `.lstate` captured at the moment of the bug, it cuts triage from hours to minutes. Drag the file into the issue.
+
+> If the bug is a *crash*, capture the state *just before* the crash triggers (the state file is the RDRAM snapshot — capturing during a faulted frame is unreliable).
+
+**Warp recipe.** If reproducible via `LAMBO_WARP=circuit[:laps[:car[:players]]]` at boot, paste the exact value here.
+
+**Screenshots / short video.** Drag into the issue, or link to a GitHub gist / imgur. Pastebins die.
+
+## Environment
+
+**Desktop:**
+- OS: [Windows 10, Windows 11, Linux distro + version]
+- CPU:
+- GPU:
+- GPU driver version:
+
+**Window:** *(copy from your `graphics.json`, or say "defaults")*
+- `wm_option` (windowed / fullscreen):
+- Monitor refresh rate:
+- `res_option`, `ar_option`, `hr_option`, `rr_option`, `msaa_option`, `api_option`:
+
+**Input:**
+- Controller type (gamepad / keyboard / other):
+- Number of active players (1P / 2P / 3P / 4P):
+
+**Audio affected?** (yes / no / one-line description):
+**Are you on the latest release?** (yes / no / commit SHA):
+
+## Logs
+
+**Stderr.** Paste the **last ~30–50 lines of stderr** from `./build/lamborghini_modern`. The port logs warp lines (`[warp] CIRCUIT N: …`), audio warnings, and crash breadcrumbs to stderr — a single `[error]` line often names the function.
+
+> **On Windows**, stderr only appears in the launching terminal by default. Run the binary from a `cmd` / PowerShell window so you can copy the output. If you launched by double-click, re-launch from a terminal.
+
+**Crash output.** If the port hit a native crash, the crash block is **text on stderr** delimited by a banner like:
+
+```
+========================= NATIVE CRASH =========================
+Reason: ...
+```
+
+Paste that whole block. *(The port does not produce a `.dmp` file — it prints a textual backtrace to stderr and `_Exit`s.)* Screenshot the OS crash dialog if one appeared.
+
+## Triage helpers
+
+**First seen in build.** Which commit / release did this first appear in? If you don't know, leave blank — even a rough guess helps bisect.
+
+**Additional context.** Anything else relevant — other apps running, antivirus, recent driver updates, fresh `git pull` vs long-standing checkout, etc.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,45 @@
+---
+name: Feature request
+about: Propose an enhancement. Check the open issues and epic #26 first — your idea may already be on the roadmap.
+title: "[FEAT] "
+labels: "enhancement"
+assignees: ""
+---
+
+## Problem / motivation
+
+What's missing or annoying? One or two paragraphs. Link any related issues or peer-port references.
+
+## Proposed solution
+
+A sketch of what you want — doesn't have to be code. The clearer this is, the easier it is to scope.
+
+## Alternatives considered *(optional)*
+
+What else did you think about, and why is the proposed solution better?
+
+## Affected area
+
+Pick one. This mirrors the labels the maintainer already uses for triage.
+
+- [ ] Rendering
+- [ ] Audio
+- [ ] Input
+- [ ] Save system
+- [ ] Multiplayer
+- [ ] Build / CI
+- [ ] Documentation
+- [ ] Modding
+- [ ] Other (describe in motivation)
+
+## Priority tier
+
+Pick one. Mirrors the `tier-N` labels. If unsure, leave blank — the maintainer will set it on triage.
+
+- [ ] tier-1 — quick wins, unblock other work
+- [ ] tier-2 — meaningful improvement, near-term roadmap
+- [ ] tier-3 — long-term (mod ecosystem / multiplayer polish)
+
+## Additional context
+
+Screenshots, mockups, links to peer ports that already ship this, references to the relevant section of `docs/HUD.md` or `docs/TEXTURES.md`, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+Replace this header with a 1–3 sentence summary of what the change does.
+-->
+
+## Why?
+
+Closes # <!-- required — issue this PR addresses, or "none — small cleanup" -->
+
+## How was it verified?
+
+- [ ] Built clean with `build.sh` (Linux) / `build.ps1` (Windows) — no manual cmake incantation
+- [ ] Booted smoke-tested: attract → title → menu → race
+- [ ] If visual: screenshot or short clip attached / linked below
+- [ ] If config/schema: defaults preserved when fields absent in `graphics.json`
+- [ ] If new dep patch: mirrored in both `build.sh` AND `build.ps1` AND CI (`build-release.yml`)
+- [ ] If new hook into recompiled code: also mirrored in `scripts/gen_syms_toml.py` (the `PATCH_BLOCKS`-stale trap)
+- [ ] No comments that explain *what* the code does (only *why* — see `CLAUDE.md`)
+- [ ] No "🤖 Generated with Claude Code" footer in commits or PR description
+
+## Screenshots / video
+
+<!-- For visual changes only. Drag into the PR or link to a gist. -->
+
+## Risk / rollback
+
+One sentence: what could break, and how to revert (commit hash, `git revert`, flag to disable, etc.).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to Automobili Lamborghini: Recompiled
+
+Thanks for your interest. This is a single-maintainer port of an N64 game via static
+recompilation — please read this before opening an issue or PR.
+
+## Reporting a bug
+
+Use the **Bug report** issue template. The fields are not bureaucracy — each one
+maps to a layer the maintainer has to peel back to fix anything (ROM, build,
+config, runtime). A save state (F7) + `LAMBO_WARP` recipe + last 30 lines of
+stderr cut triage from hours to minutes. See the template for the full list.
+
+## Proposing a change
+
+Open an issue first. The tracker (epic **#26**) already lists the maintainer's
+roadmap and tiering; check whether your idea is already on it before writing
+code. PRs without a linked issue are likely to be closed with a pointer to the
+tracker.
+
+For very small fixes (typos, dead links, one-line bugs), a direct PR with a
+clear "Closes #N" or "no linked issue — small cleanup" is fine.
+
+## Building & running
+
+See **[BUILDING.md](./BUILDING.md)**. The dependency-patch step (`git apply
+.../0001…`) is the most common cause of "works on my machine" — the local
+`build.sh` / `build.ps1` scripts mirror CI exactly, so use them. If you skip
+them and hand-roll cmake, your build is unsupported.
+
+## Development conventions
+
+See **[CLAUDE.md](./CLAUDE.md)**. The short version:
+
+- Match the existing comment density and idiom. Comments explain **why**, not
+  what — prefer code that doesn't need a comment.
+- Verify empirically (breakpoint, watchpoint, grep for DL constants), not by
+  name or by analogy to other ports.
+- Source is ground truth; session notes are not. Re-read the function before
+  reasoning about it.
+- Decompile, don't invent. Missing behaviour translates what the ROM does;
+  hand-rolled shortcuts are scaffolding, not shipping code.
+
+## Ground-truth reference
+
+[ares](https://ares-emu.org/) is the reference for what the port should
+reproduce. The `ares-debugger` skill drives a locally-installed ares build for
+live-ROM comparison (read/write RDRAM, watchpoints, per-frame DL capture).
+"Port converges to ares" is the success metric — screenshot diffs and
+byte-identical builds are not.
+
+> The committed Python harness lives at `tools/emu_instrumentation/`. The ares
+> binary itself is **not** shipped in this repo (`tools/emulators/` is
+> `.gitignore`d); install ares separately. The scripts default to looking for
+> `tools/emulators/ares-base/ares-v147/ares.exe`; `tools/emu_instrumentation/run_ares_debug.py`
+> also accepts a `--ares-exe <path>` override.
+
+## Legal
+
+This repository contains no ROM content — you must supply your own copy of
+`Automobili Lamborghini (USA).z64` to build. By contributing, you affirm that
+your patch is your own work, GPLv3-compatible, and free of upstream ROM bytes
+or assets.
+
+Code original to this repository is released under the
+[GNU General Public License v3.0](./LICENSE), matching the wider N64Recomp
+port ecosystem. Vendored submodules (`lib/N64ModernRuntime`, `lib/rt64`) and
+patched dependencies retain their own respective licenses.

--- a/build.ps1
+++ b/build.ps1
@@ -80,9 +80,30 @@ try {
     # Order matters: Python's CMake must beat MSYS2's; MinGW bin must beat any
     # cc shim that may sit ahead of gcc on this box. Anything already on PATH
     # is preserved as the suffix.
-    $PythonScripts = 'C:\Users\alond\AppData\Local\Programs\Python\Python313\Scripts'
+    #
+    # The Python-Scripts prefix is needed because MSYS2's cmake 3.25.1 is
+    # buggy on this box (warns "Ignoring extra path from command line: .exe"
+    # and emits Unix paths that Ninja on Windows can't resolve). The fix is
+    # to put Python's bundled cmake ahead of MSYS2's. Either:
+    #   - set $env:LAMBO_PYTHON_SCRIPTS=<path-to-Python's-Scripts-dir>, OR
+    #   - put Python's Scripts dir on PATH yourself, OR
+    #   - rely on the auto-discovery below, which finds a Python-for-Windows
+    #     install under $env:LOCALAPPDATA\Programs\Python\Python*\Scripts.
+    $PythonScripts = $env:LAMBO_PYTHON_SCRIPTS
+    if (-not $PythonScripts -and $env:LOCALAPPDATA) {
+        $pyRoot = Join-Path $env:LOCALAPPDATA 'Programs\Python'
+        if (Test-Path $pyRoot) {
+            # Highest Python version's Scripts dir that contains cmake.exe.
+            $candidate = Get-ChildItem -Path $pyRoot -Directory -Filter 'Python*' -ErrorAction SilentlyContinue |
+                Sort-Object Name -Descending |
+                ForEach-Object { Join-Path $_.FullName 'Scripts' } |
+                Where-Object { Test-Path (Join-Path $_ 'cmake.exe') } |
+                Select-Object -First 1
+            if ($candidate) { $PythonScripts = $candidate }
+        }
+    }
     $MinGW         = 'C:\ProgramData\mingw64\mingw64\bin'
-    $NewPrefix     = @($PythonScripts, $MinGW) | Where-Object { Test-Path $_ }
+    $NewPrefix     = @($PythonScripts, $MinGW) | Where-Object { $_ -and (Test-Path $_) }
     if ($NewPrefix.Count -gt 0) {
         $env:PATH = ($NewPrefix -join ';') + ';' + $env:PATH
         Write-Host ("[path] + {0}" -f ($NewPrefix -join '; ')) -ForegroundColor DarkGray
@@ -93,7 +114,7 @@ try {
     $gcc   = (Get-Command gcc.exe   -ErrorAction SilentlyContinue).Source
     $gxx   = (Get-Command g++.exe   -ErrorAction SilentlyContinue).Source
     $ninja = (Get-Command ninja.exe -ErrorAction SilentlyContinue).Source
-    if (-not $cmake) { throw 'cmake.exe not on PATH. Install CMake or extend $PythonScripts.' }
+    if (-not $cmake) { throw 'cmake.exe not on PATH. Set $env:LAMBO_PYTHON_SCRIPTS to Python''s Scripts dir, add it to PATH manually, or install CMake.' }
     if (-not $gcc)   { throw 'gcc.exe not on PATH. Add MinGW to $env:PATH (see comment in script).' }
     if (-not $gxx)   { throw 'g++.exe not on PATH. Add MinGW to $env:PATH.' }
     if (-not $ninja) { throw 'ninja not on PATH. Install it (pip install ninja) and put on PATH.' }

--- a/tools/emu_instrumentation/ares_session.py
+++ b/tools/emu_instrumentation/ares_session.py
@@ -157,9 +157,12 @@ def _cli():
     p.add_argument("--rom", default=str(DEFAULT_ROM))
     p.add_argument("--port", type=int, default=9150)
     p.add_argument("--boot-wait", type=float, default=2.0)
+    p.add_argument("--ares-exe", default=None,
+                   help="Path to ares executable (default: built-in ares-v147)")
     args = p.parse_args()
     print(f"Launching ares on port {args.port}...")
-    with ares_session(rom=Path(args.rom), port=args.port, boot_wait=args.boot_wait) as c:
+    with ares_session(rom=Path(args.rom), port=args.port, boot_wait=args.boot_wait,
+                      ares_exe=Path(args.ares_exe) if args.ares_exe else ARES_EXE) as c:
         print(f"Connected. VI_CURRENT=0x{c.read32(0xA4400010):08X}")
         print("Ctrl-C to stop ares.")
         try:

--- a/tools/emu_instrumentation/dump_memory.py
+++ b/tools/emu_instrumentation/dump_memory.py
@@ -8,6 +8,7 @@ import os
 import time
 import socket
 import subprocess
+import argparse
 
 sys.path.insert(0, os.path.dirname(__file__))
 from ares_debug_client import AresDebugClient
@@ -44,26 +45,36 @@ def wait_for_port(port, timeout=15.0):
     return False
 
 def main():
+    parser = argparse.ArgumentParser(description="Launch ares and dump memory regions")
+    parser.add_argument("--ares-exe", default=None,
+                        help="Path to ares executable (default: built-in ares-v147)")
+    parser.add_argument("--rom", default=ROM,
+                        help="Path to ROM file (default: <repo>/Automobili Lamborghini (USA).z64)")
+    args = parser.parse_args()
+
+    ares_exe = args.ares_exe or ARES_EXE
+    rom     = args.rom
+
     # Check if ares is already running on port 9150
     if wait_for_port(9150, timeout=2.0):
         print("ares already running on port 9150")
     else:
         print("Launching ares...")
-        if not os.path.exists(ARES_EXE):
-            print(f"ERROR: ares not found at {ARES_EXE}")
+        if not os.path.exists(ares_exe):
+            print(f"ERROR: ares not found at {ares_exe}")
             return
-        if not os.path.exists(ROM):
-            print(f"ERROR: ROM not found at {ROM}")
+        if not os.path.exists(rom):
+            print(f"ERROR: ROM not found at {rom}")
             return
         subprocess.Popen([
-            ARES_EXE,
+            ares_exe,
             '--kiosk', '--no-file-prompt',
             '--setting', 'DebugServer/Enabled=true',
             '--setting', 'DebugServer/Port=9150',
             '--setting', 'DebugServer/UseIPv4=true',
             '--setting', 'Boot/AwaitGDBClient=false',
-            ROM
-        ], cwd=ARES_DIR, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            rom
+        ], cwd=os.path.dirname(ares_exe), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         print("Waiting for ares to start...")
         if not wait_for_port(9150, timeout=15.0):
             print("ERROR: ares failed to start on port 9150")

--- a/tools/emu_instrumentation/dump_memory2.py
+++ b/tools/emu_instrumentation/dump_memory2.py
@@ -8,6 +8,7 @@ import os
 import time
 import socket
 import subprocess
+import argparse
 
 sys.path.insert(0, os.path.dirname(__file__))
 from ares_debug_client import AresDebugClient
@@ -42,23 +43,33 @@ def wait_for_port(port, timeout=15.0):
     return False
 
 def main():
+    parser = argparse.ArgumentParser(description="Capture memory from ares once the game is running")
+    parser.add_argument("--ares-exe", default=None,
+                        help="Path to ares executable (default: built-in ares-v147)")
+    parser.add_argument("--rom", default=ROM,
+                        help="Path to ROM file (default: <repo>/Automobili Lamborghini (USA).z64)")
+    args = parser.parse_args()
+
+    ares_exe = args.ares_exe or ARES_EXE
+    rom     = args.rom
+
     if not wait_for_port(9150, timeout=2.0):
         print("Launching ares...")
-        if not os.path.exists(ARES_EXE):
-            print(f"ERROR: ares not found at {ARES_EXE}")
+        if not os.path.exists(ares_exe):
+            print(f"ERROR: ares not found at {ares_exe}")
             return
-        if not os.path.exists(ROM):
-            print(f"ERROR: ROM not found at {ROM}")
+        if not os.path.exists(rom):
+            print(f"ERROR: ROM not found at {rom}")
             return
         subprocess.Popen([
-            ARES_EXE,
+            ares_exe,
             '--kiosk', '--no-file-prompt',
             '--setting', 'DebugServer/Enabled=true',
             '--setting', 'DebugServer/Port=9150',
             '--setting', 'DebugServer/UseIPv4=true',
             '--setting', 'Boot/AwaitGDBClient=false',
-            ROM
-        ], cwd=ARES_DIR, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            rom
+        ], cwd=os.path.dirname(ares_exe), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         print("Waiting for ares to start...")
         if not wait_for_port(9150, timeout=15.0):
             print("ERROR: ares failed to start")


### PR DESCRIPTION
Adds contributor-facing artefacts AND fixes two pre-existing personal-path smells in committed scripts. All motivated by the contributor-template review: once you ship docs telling people to clone, build, and debug the port, the build + debug infrastructure must not assume the maintainer's specific Windows install.

## What — contributor artefacts

- `CONTRIBUTING.md` (root, 60 lines) — short router to existing docs (`CLAUDE.md`, `BUILDING.md`, issue tracker). Silent on AI assistance by maintainer's choice.
- `.github/ISSUE_TEMPLATE/bug_report.md` (98 lines) — pre-flight (ROM SHA1/CRC32, build commit + dep-patches applied, GPU driver), bug body, artifacts (`.lstate` save-state attachment, `LAMBO_WARP` recipe, screenshots), environment (`graphics.json` keys, multi-player count, audio), logs (stderr paste, crash-banner paste).
- `.github/ISSUE_TEMPLATE/feature_request.md` (44 lines) — problem/solution + affected-area checkbox mirroring repo labels, priority-tier dropdown matching `tier-1`/`tier-2`/`tier-3`.
- `.github/PULL_REQUEST_TEMPLATE.md` (25 lines) — 1-3 sentence summary, `Closes #N` required, verification checklist (clean build via `build.sh`/`build.ps1`, smoke-boot attract→title→menu→race, no "Generated with Claude Code" footer, `PATCH_BLOCKS` trap check, comment density matches `CLAUDE.md`).

## What — personal-path smell fixes

**`build.ps1`** — replaced the hardcoded `C:\Users\alond\AppData\Local\Programs\Python\Python313\Scripts` (Adam's user dir, would silently fail on any other Windows box) with:
- env-var override: `$env:LAMBO_PYTHON_SCRIPTS=<path>`
- best-effort auto-discovery: scans `$env:LOCALAPPDATA\Programs\Python\Python*\Scripts` for `cmake.exe` (highest Python version wins on tie-break)
- updated the cmake-not-found error message to point at the env var

The `$MinGW = 'C:\ProgramData\mingw64\mingw64\bin'` line stays — that's the machine-wide install path documented in `BUILDING.md:94`, not personal.

**`tools/emu_instrumentation/{dump_memory.py,dump_memory2.py,ares_session.py}`** — all three hardcoded `tools/emulators/ares-base/ares-v147/ares.exe` with no override, even though `tools/emulators/` is `.gitignore`d. `run_ares_debug.py` already had `--ares-exe`; the others did not. Added the same `--ares-exe <path>` argparse option (plus `--rom <path>` to the two `dump_memory*` scripts while there, since `ROM` was hardcoded too). Defaults preserve the previous behaviour exactly for anyone who doesn't pass the flag.

## Why these and not the peer N64Recomp templates

Surveyed Zelda64Recomp, Smash64r, BM64Recomp, SnowboardKids2-recomp. Only the first two ship a `bug_report.md`. The peer shape converges on GPU driver version, vanilla-behaviour check, repro/expected/screenshots/desktop info, mods installed.

These templates add 9 project-specific fields the peers don't have: ROM identifier (only USA release supported), build source (`git apply .../0001` drift is the #1 "works on my machine" source), save-state `.lstate` attachment (issue #22), `LAMBO_WARP` recipe, `graphics.json` keys, stderr + crash-banner paste (port writes crash to stderr, no `.dmp` file), window mode + monitor refresh + multi-player count, ares comparison.

## What was NOT done

- No `CODE_OF_CONDUCT.md` / `SECURITY.md` — single-maintainer, no security policy to publish.
- No AI-contribution ban — `Zelda64Recomp/Zelda64Recomp`'s `CONTRIBUTING.md` outright bans AI; this repo is silent (gate is empirical verification per `CLAUDE.md`).
- No separate `port-build-issue.md` — existing tracker convention (e.g. #29) routes build problems through the same form.

## Testing

- `py_compile` clean on the 3 modified `.py` files
- PowerShell parser clean on `build.ps1`
- All 3 modified Python scripts' `--help` shows the new `--ares-exe` option and exits 0
- No behavioural change for users who don't pass `--ares-exe` or set `LAMBO_PYTHON_SCRIPTS`
- YAML frontmatter parses; labels `bug` and `enhancement` exist in the repo
- Cross-references resolve (`BUILDING.md`, `docs/HUD.md`, `docs/TEXTURES.md`, `scripts/gen_syms_toml.py`, `.github/workflows/build-release.yml`)
- Factual claims verified against source: F7/F8 in `src/main.cpp:602-606`, `.lstate` in `src/lambo_savestate.c:88`, crash-banner in `src/lambo_crash.cpp:351`, `kAppFolderName = "LamborghiniRecomp"` in `src/lambo_config.cpp:17`

Docs + governance + small build-script portability fixes — no functional gameplay changes.