### PR TITLE
Fix widescreen skybox: stretch parallax-free backdrops in the renderer

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -15,7 +15,7 @@
       3. ROM check (skippable via -RomPath; CI forwards its $env:ROM_FILENAME).
       4. Defensive submodule reset before patching (a half-applied patch from a
          prior run would otherwise break the next apply).
-      5. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0005, 0004) with
+      5. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0008, 0005, 0004) with
          --ignore-whitespace (CRLF mismatches on Windows git). 0007 adds the
          save-state thread-context registry; without it, src/lambo_savestate.c
          fails to link with "undefined reference to ultramodern_relink_thread_contexts".
@@ -135,7 +135,7 @@ try {
     git -C lib/rt64 checkout -- . | Out-Null
     git -C lib/rt64/src/contrib/plume checkout -- . | Out-Null
 
-    # --- 6. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0005, 0004) -
+    # --- 6. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0008, 0005, 0004) -
     # Mirrors CI's Windows job exactly (workflow lines 210-214). 0001 then 0007
     # both patch N64ModernRuntime with disjoint hunks (verified to apply
     # sequentially on the pinned commit). 0007 adds the save-state thread-
@@ -150,6 +150,7 @@ try {
         @{ Sub = 'lib/N64ModernRuntime';       Patch = 'patches/0001-lamborghini-runtime-scheduler-audio-vi.patch' },
         @{ Sub = 'lib/N64ModernRuntime';       Patch = 'patches/0007-ultramodern-savestate-thread-context-relink.patch' },
         @{ Sub = 'lib/rt64';                   Patch = 'patches/0006-rt64-interp-angular-velocity-matching.patch' },
+        @{ Sub = 'lib/rt64';                   Patch = 'patches/0008-rt64-skybox-stretch-parallaxless-backdrop.patch' },
         @{ Sub = 'lib/rt64';                   Patch = 'patches/0005-rt64-mingw-gcc-compat.patch' },
         @{ Sub = 'lib/rt64/src/contrib/plume'; Patch = 'patches/0004-plume-d3d12-mingw-com-abi-struct-return.patch' }
     )

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@
 #   3. Submodule init (recursive; core.longpaths isn't needed on Linux).
 #   4. Defensive submodule reset before patching (half-applied patches from a
 #      prior run would otherwise break the next apply with "patch failed: ...").
-#   5. Apply Lamborghini patches (Linux: 0001, 0007, 0006 — no MinGW/D3D12
+#   5. Apply Lamborghini patches (Linux: 0001, 0007, 0006, 0008 — no MinGW/D3D12
 #      fixes needed; no plume patch). 0007 adds the save-state thread-context
 #      registry; without it, src/lambo_savestate.c fails to link with
 #      "undefined reference to ultramodern_relink_thread_contexts".
@@ -96,7 +96,7 @@ git -C lib/N64ModernRuntime checkout -- .
 git -C lib/rt64 checkout -- .
 git -C lib/rt64/src/contrib/plume checkout -- . 2>/dev/null || true
 
-# --- 6. Apply Lamborghini patches (Linux: 0001, 0007, 0006) ----------------
+# --- 6. Apply Lamborghini patches (Linux: 0001, 0007, 0006, 0008) ----------------
 # Mirrors CI's Linux job exactly (workflow lines 93-95). 0001 then 0007 both
 # patch N64ModernRuntime with disjoint hunks (verified to apply sequentially
 # on the pinned commit). 0007 adds the save-state thread-context registry +
@@ -108,6 +108,7 @@ PATCHES=(
     "lib/N64ModernRuntime:0001-lamborghini-runtime-scheduler-audio-vi.patch"
     "lib/N64ModernRuntime:0007-ultramodern-savestate-thread-context-relink.patch"
     "lib/rt64:0006-rt64-interp-angular-velocity-matching.patch"
+    "lib/rt64:0008-rt64-skybox-stretch-parallaxless-backdrop.patch"
 )
 for entry in "${PATCHES[@]}"; do
     sub="${entry%%:*}"

--- a/docs/HUD.md
+++ b/docs/HUD.md
@@ -153,7 +153,7 @@ Rules:
   raw output aspect — because RT64's rect pins honour `hr_option` via `extAspectPercentage`
   (`rt64_workload_queue.cpp:159-183`): `Full` reaches the real edges, `Clamp16x9` stops at
   16:9 (so at 21:9 the rects travel only ~44% of the way), `Original` doesn't move at all.
-  Keying off the raw output aspect (the skybox's, #3) would over-translate the geometry
+  Keying off the raw output aspect would over-translate the geometry
   past the clamped rects on a non-`Full` ultrawide. The effective aspect is 4/3 (0-travel)
   for any non-Expand config or `Original`, so no separate config gate is needed. See the
   `lambo_ws_hud_*` inline helpers in `src/lambo_hud_widescreen.h` (host-unit-tested in

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -528,23 +528,12 @@ func = "func_80050860"
 before_vram = 0x8005027C
 text = "lambo_ws_pin_reset(rdram);"
 
-# Issue #3 — per-frame Mtx rebuild for the widescreen skybox. func_8004384C (the
-# per-frame 3D DL builder) opens the frame by calling func_80075500 (a hand-rolled
-# guPerspective-equivalent: fovy/aspect/near/far -> frustum -> Mtx) to build the
-# BACKGROUND/skybox layer's own projection, distinct from the main race camera. The
-# call site hardcodes the aspect argument ($a3) to the hex float literal 0x3FAAAAAB
-# (= 4/3, verified by decoding the IEEE-754 bits) via `lui $a3,0x3FAA` / `ori
-# $a3,$a3,0xAAAB` at 0x80042CE0/E4, so the frustum's tangent — and therefore the
-# skybox panels' screen coverage — stays sized for 4:3 no matter the RT64 output
-# width, leaving gaps at the wide edges under ar_option Expand. Hooked right after
-# the literal is fully assembled (0x80042CE8, not a branch-delay slot) and before it
-# is consumed by the jal at 0x80042CFC: overwrite $a3 with the live output aspect
-# (lambo_ws_get_output_aspect_bits, rt64_renderer.cpp) so the frustum widens with the
-# window — the fix degenerates to the original constant at 4:3 or ar_option Original.
-[[patches.hook]]
-func = "func_8004384C"
-before_vram = 0x80042CE8
-text = "extern unsigned int lambo_ws_get_output_aspect_bits(void); ctx->r7 = (int32_t)lambo_ws_get_output_aspect_bits();"
+# Issue #3 — widescreen skybox is handled in the renderer (RT64), NOT here. The earlier
+# ROM-side hook that widened func_8004384C's frustum aspect was removed: it only runs when
+# the game's frame loop runs, so it left the sky wrong whenever that loop is frozen (e.g.
+# paused), and it double-widened at-infinity backgrounds on top of RT64's own aspect adjust.
+# The renderer now stretches any zero-view-translation (parallax-free) perspective backdrop
+# to fill the frame every presented frame. See patches/0008-rt64-skybox-stretch-parallaxless-backdrop.patch.
 
 # Issue #12 — developer warp menu. Per-frame warp tick at the entry of the TOP-LEVEL
 # state dispatcher func_800028D0 (runtime 0x80001CD0, argument-free, jump-table over

--- a/patches/0008-rt64-skybox-stretch-parallaxless-backdrop.patch
+++ b/patches/0008-rt64-skybox-stretch-parallaxless-backdrop.patch
@@ -1,0 +1,43 @@
+diff --git a/src/render/rt64_projection_processor.cpp b/src/render/rt64_projection_processor.cpp
+index e842dcc..4efac76 100644
+--- a/src/render/rt64_projection_processor.cpp
++++ b/src/render/rt64_projection_processor.cpp
+@@ -4,6 +4,8 @@
+ 
+ #include "rt64_projection_processor.h"
+ 
++#include <cmath>
++
+ #include "common/rt64_math.h"
+ #include "hle/rt64_workload_queue.h"
+ 
+@@ -98,6 +100,29 @@ namespace RT64 {
+                 }
+             }
+  
++            // Skybox / at-infinity backdrop stretch (Automobili Lamborghini issue #3 follow-up):
++            // a perspective scene rendered from a camera with zero view-space translation is a
++            // rotation-only backdrop with no parallax (the game's sky billboard). Hor+-widening
++            // its FOV (the default aspect adjust below) shrinks a FINITE backdrop away from the
++            // screen edges, exposing gaps at wide aspects. A no-parallax backdrop must instead
++            // STRETCH to fill: keep the source-aspect FOV so its NDC-space extent maps to the
++            // full (wide) viewport. Detected by a rotation-only view whose translation is
++            // within a small epsilon of zero, so real 3D scenes (which carry a camera position
++            // far from the origin -- the race camera and even menu cameras) are unaffected. The
++            // sky's view translation is measured as exactly zero; the epsilon is slack for
++            // float noise, kept well below any real scene's camera offset. This runs in the
++            // render thread every presented frame, so it also covers the paused state where the
++            // game's own per-frame frustum builder (func_8004384C) is frozen.
++            if (adjustAspectRatio && (proj.type == Projection::Type::Perspective)) {
++                const interop::float4x4 &vT = drawData.viewTransforms[proj.transformsIndex];
++                const float translationEpsilon = 0.5f;
++                if ((fabsf((float)vT[3][0]) < translationEpsilon) &&
++                    (fabsf((float)vT[3][1]) < translationEpsilon) &&
++                    (fabsf((float)vT[3][2]) < translationEpsilon)) {
++                    adjustAspectRatio = false;
++                }
++            }
++
+             float projRatioScale = adjustAspectRatio ? (1.0f / p.aspectRatioScale) : 1.0f;
+             interop::float4x4 &viewMatrix = drawData.modViewTransforms[proj.transformsIndex];
+             interop::float4x4 &projMatrix = drawData.modProjTransforms[proj.transformsIndex];

--- a/scripts/gen_syms_toml.py
+++ b/scripts/gen_syms_toml.py
@@ -860,23 +860,12 @@ func = "func_80050860"
 before_vram = 0x8005027C
 text = "lambo_ws_pin_reset(rdram);"
 
-# Issue #3 — per-frame Mtx rebuild for the widescreen skybox. func_8004384C (the
-# per-frame 3D DL builder) opens the frame by calling func_80075500 (a hand-rolled
-# guPerspective-equivalent: fovy/aspect/near/far -> frustum -> Mtx) to build the
-# BACKGROUND/skybox layer's own projection, distinct from the main race camera. The
-# call site hardcodes the aspect argument ($a3) to the hex float literal 0x3FAAAAAB
-# (= 4/3, verified by decoding the IEEE-754 bits) via `lui $a3,0x3FAA` / `ori
-# $a3,$a3,0xAAAB` at 0x80042CE0/E4, so the frustum's tangent — and therefore the
-# skybox panels' screen coverage — stays sized for 4:3 no matter the RT64 output
-# width, leaving gaps at the wide edges under ar_option Expand. Hooked right after
-# the literal is fully assembled (0x80042CE8, not a branch-delay slot) and before it
-# is consumed by the jal at 0x80042CFC: overwrite $a3 with the live output aspect
-# (lambo_ws_get_output_aspect_bits, rt64_renderer.cpp) so the frustum widens with the
-# window — the fix degenerates to the original constant at 4:3 or ar_option Original.
-[[patches.hook]]
-func = "func_8004384C"
-before_vram = 0x80042CE8
-text = "extern unsigned int lambo_ws_get_output_aspect_bits(void); ctx->r7 = (int32_t)lambo_ws_get_output_aspect_bits();"
+# Issue #3 — widescreen skybox is handled in the renderer (RT64), NOT here. The earlier
+# ROM-side hook that widened func_8004384C's frustum aspect was removed: it only runs when
+# the game's frame loop runs, so it left the sky wrong whenever that loop is frozen (e.g.
+# paused), and it double-widened at-infinity backgrounds on top of RT64's own aspect adjust.
+# The renderer now stretches any zero-view-translation (parallax-free) perspective backdrop
+# to fill the frame every presented frame. See patches/0008-rt64-skybox-stretch-parallaxless-backdrop.patch.
 
 # Issue #12 — developer warp menu. Per-frame warp tick at the entry of the TOP-LEVEL
 # state dispatcher func_800028D0 (runtime 0x80001CD0, argument-free, jump-table over

--- a/src/rt64_renderer.cpp
+++ b/src/rt64_renderer.cpp
@@ -47,19 +47,14 @@ uint32_t DPC_TMEM_REG = 0;
 
 void dummy_check_interrupts() {}
 
-// Live swapchain handle for the background/skybox aspect-ratio fix (issue #3): the
-// course frame-builder (func_8004384C) issues its own frustum matrix for the
-// background layer with a HARDCODED 4/3 literal (0x3FAAAAAB) baked at the call site,
-// so under RT64 Expand the skybox panels stay sized for 4:3 and don't reach the wide
-// edges. lambo_ws_get_output_aspect_bits() below lets a patches.hook override that
-// literal with the live output aspect each frame. This is the RAW output aspect: a
-// symmetric skybox frustum always fills the real screen, so it just needs a wider tangent.
-// The 2D HUD geometry shifts (issue #67) do NOT use this -- they honour hr_option's rect
-// clamp via lambo_ws_get_hud_rect_aspect_bits() below, since a rect-aligned element and a
-// full-screen frustum widen by different amounts under Clamp16x9.
+// Live swapchain handle for the widescreen HUD rect-aspect helper (issue #67): the
+// game-space 2D HUD geometry shifts key off the effective rect-pin aspect, which depends
+// on the live output size and hr_option -- see lambo_ws_get_hud_rect_aspect_bits() below.
+// (The issue #3 skybox no longer uses this: it is handled entirely in the renderer by
+// stretching parallax-free perspective backdrops -- patches/0008-rt64-skybox-stretch-parallaxless-backdrop.patch.)
 //
 // Written on the gfx thread (RT64Context ctor/dtor), read every frame on the CPU/
-// game-logic thread inside lambo_ws_get_output_aspect_bits() below -- unlike
+// game-logic thread inside lambo_ws_get_hud_rect_aspect_bits() below -- unlike
 // get_resolution_scale() elsewhere in this file, which is only ever called from the
 // gfx thread itself. atomic (not a plain pointer) so the CPU thread can't observe a
 // torn or stale value; the dtor nulls it before `app` is torn down so a load racing
@@ -257,8 +252,8 @@ public:
 
         std::fprintf(stderr, "[rt64] RT64 renderer initialised (api=%d)\n", (int)chosen_api);
 
-        // Publish the app pointer for the skybox aspect-ratio override
-        // (lambo_ws_get_output_aspect_bits reads this on the game-logic thread),
+        // Publish the app pointer for the widescreen HUD rect-aspect helper
+        // (lambo_ws_get_hud_rect_aspect_bits reads this on the game-logic thread),
         // then wire texture replacement. Order matters: register first so the
         // dtor's reverse-order unpublish still fires while `app` is alive.
         g_lambo_active_app = app.get();
@@ -398,39 +393,8 @@ private:
 
 } // anonymous namespace
 
-// Native for the issue #3 patches.hook (lamborghini.us.toml, func_8004384C): returns
-// the live output aspect ratio as raw float bits, clamped to never go BELOW 4/3 so a
-// narrower-than-4:3 window (or ar_option != Expand) degenerates to the original
-// constant rather than squeezing the skybox. Called from recompiled game code on the
-// game-logic thread, which races the gfx/render thread's swapchain resize handling;
-// take the same configurationMutex RT64::SharedQueueResources::setSwapChainSize()
-// locks when writing width+height together, so this never observes a torn pair.
-extern "C" uint32_t lambo_ws_get_output_aspect_bits(void) {
-    float aspect = 4.0f / 3.0f;
-    const auto& cfg = ultramodern::renderer::get_graphics_config();
-    RT64::Application* active_app = g_lambo_active_app.load(std::memory_order_acquire);
-    if (cfg.ar_option == ultramodern::renderer::AspectRatio::Expand &&
-        active_app != nullptr && active_app->sharedQueueResources) {
-        auto& shared = *active_app->sharedQueueResources;
-        std::scoped_lock<std::mutex> configuration_lock(shared.configurationMutex);
-        uint32_t w = shared.swapChainWidth;
-        uint32_t h = shared.swapChainHeight;
-        if (w > 0 && h > 0) {
-            float live = float(w) / float(h);
-            if (live > aspect) {
-                aspect = live;
-            }
-        }
-    }
-    uint32_t bits;
-    std::memcpy(&bits, &aspect, sizeof(bits));
-    return bits;
-}
-
 // (issue #67) Effective aspect the extended-GBI HUD rect pins travel to, as raw float
-// bits. DISTINCT from lambo_ws_get_output_aspect_bits() above: that is the skybox's raw
-// output aspect (#3, a symmetric frustum that always fills the real screen), whereas the
-// gEXSetRectAlign HUD pins honour hr_option -- Full reaches the real edges, Clamp16x9
+// bits. The gEXSetRectAlign HUD pins honour hr_option -- Full reaches the real edges, Clamp16x9
 // stops at 16:9, Original doesn't move -- so the game-space HUD geometry shifts
 // (src/lambo_hud_widescreen.c) key off THIS. Keying them off the raw output aspect would
 // over-translate the geometry past the rects at any non-Full ultrawide output (e.g. the


### PR DESCRIPTION
Closes #3.

Reworks the widescreen skybox fix. PR #53 widened `func_8004384C`'s frustum aspect via a ROM hook; driving the actual renderer showed that wasn't comprehensive.

## Root cause (measured)
- **The ROM hook only runs while the game's frame loop runs.** The reported repro is a *paused* 21:9 race — with the loop frozen the hook doesn't fire, so the sky stayed at a 4:3 frustum while RT64 kept widening the view, leaving a hard-edged black gap where the finite sky billboard fell short of the widened frustum's left edge.
- **The sky is a zero-view-translation backdrop sharing the world's projection.** Instrumenting RT64's `ProjectionProcessor`: sky `viewT=[0,0,0]`, world `viewT=[-367,-14,-147]`, same projection matrix. RT64 already Hor+-widens both — and widening a *finite* backdrop's FOV shrinks it away from the edges (the opposite of filling). The hook fought RT64 and double-widened at-infinity menu/title backgrounds.

A no-parallax backdrop must **stretch** to fill a wide frame, not Hor+. (NDC ±1 always maps to the full viewport, so a backdrop that fills the 4:3 FOV fills any width if you simply don't widen its FOV — the 3D analogue of the `STRETCH` treatment the lens-flare fix used for 2D rects.)

## Change
- **`patches/0008-rt64-skybox-stretch-parallaxless-backdrop.patch`** — in `ProjectionProcessor::processScene`, a perspective scene rendered from a ~zero view-translation camera keeps its source-aspect FOV (skips the aspect adjust). Runs every *presented* frame, so it covers the paused case a ROM hook never could.
- **Revert the PR #53 hook** — removed from `lamborghini.us.toml` + `gen_syms_toml.py` PATCH_BLOCKS (regenerated and diffed to confirm in sync); dropped the now-unused `lambo_ws_get_output_aspect_bits`.
- Wired 0008 into `build.ps1` / `build.sh`.

## Verification
Clean `build.ps1` build. At 16:9, 21:9 and 32:9: sky fills with no gap in the paused save state **and** the live demo race; title/menu 3D backdrops are single-widened (not double); world geometry unchanged. HUD host unit test green.