### PR TITLE
Fix #80: crash handler kills boot on benign first-chance exceptions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -99,6 +99,9 @@ jobs:
         run: |
           mkdir -p dist
           cp build/lamborghini_modern dist/
+          # Crash-handler symbol table: probed next to the exe at runtime so
+          # field crash dumps show function names, not raw N64 PCs (issue #80).
+          cp lamborghini.syms.toml dist/
           cd dist && zip -r ../lamborghini-recomp-linux-x64.zip .
 
       - name: Upload artifact
@@ -196,6 +199,9 @@ jobs:
           New-Item -ItemType Directory -Force dist | Out-Null
           Copy-Item build\lamborghini_modern.exe dist\
           Copy-Item build\SDL2.dll, build\dxcompiler.dll, build\dxil.dll dist\ -ErrorAction SilentlyContinue
+          # Crash-handler symbol table: probed next to the exe at runtime so
+          # field crash dumps show function names, not raw N64 PCs (issue #80).
+          Copy-Item lamborghini.syms.toml dist\
           Compress-Archive -Path dist\* -DestinationPath lamborghini-recomp-windows-x64.zip
 
       - name: Upload artifact

--- a/src/lambo_crash.cpp
+++ b/src/lambo_crash.cpp
@@ -342,7 +342,26 @@ void print_native_backtrace(FILE* fp, const void* const* pcs, int n, const char*
             if (si) std::snprintf(vbuf, sizeof(vbuf), "  --> n64 %s+0x%X", si->name, offb);
             else    std::snprintf(vbuf, sizeof(vbuf), "  --> n64 0x%08X", vram);
         }
-        std::fprintf(fp, "    [%2d] native=%p%s\n", i, pc, vbuf);
+        char mbuf[112] = "";
+#if defined(LAMBO_CRASH_WIN32)
+        // Module name per frame: distinguishes "our exe" from ntdll/driver
+        // DLL frames, which is what makes a field dump attributable (#80).
+        HMODULE mod = nullptr;
+        if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                               GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                               (LPCSTR)pc, &mod) && mod != nullptr) {
+            char path[MAX_PATH];
+            DWORD len = GetModuleFileNameA(mod, path, MAX_PATH);
+            if (len > 0) {
+                const char* base = path;
+                for (const char* q = path; *q != '\0'; q++)
+                    if (*q == '\\' || *q == '/') base = q + 1;
+                std::snprintf(mbuf, sizeof(mbuf), "  %s+0x%llX", base,
+                              (unsigned long long)((uintptr_t)pc - (uintptr_t)mod));
+            }
+        }
+#endif
+        std::fprintf(fp, "    [%2d] native=%p%s%s\n", i, pc, mbuf, vbuf);
     }
 }
 
@@ -379,16 +398,32 @@ void final_dump_and_die(const char* reason, uint32_t vram_guess,
 
 LONG WINAPI win32_vectored_handler(EXCEPTION_POINTERS* ep) {
     DWORD code = ep->ExceptionRecord->ExceptionCode;
-    // Skip debugger-only codes; let gdb handle those.
-    if (code == EXCEPTION_BREAKPOINT || code == EXCEPTION_SINGLE_STEP)
-        return EXCEPTION_CONTINUE_SEARCH;
+    // Positive fatal list ONLY (issue #80). A VEH sees every exception
+    // FIRST-CHANCE, before any catch/__except runs, so anything a later
+    // handler would swallow is normal control flow here: C++ throws (MinGW
+    // 0x20474343 "GCC ", MSVC 0xE06D7363 -- ultramodern ends guest threads
+    // by throwing thread_terminated THROUGH recompiled frames, so recomp-PC
+    // gating alone cannot save those), thread naming 0x406D1388,
+    // DBG_PRINTEXCEPTION_C, guard-page/invalid-handle probes from driver
+    // DLLs, debugger breakpoints. Act only on codes that are unrecoverable
+    // CPU faults; pass everything else down the chain.
+    switch (code) {
+        case EXCEPTION_ACCESS_VIOLATION:
+        case EXCEPTION_ILLEGAL_INSTRUCTION:
+        case EXCEPTION_PRIV_INSTRUCTION:
+        case EXCEPTION_INT_DIVIDE_BY_ZERO:
+        case EXCEPTION_STACK_OVERFLOW:
+        case EXCEPTION_IN_PAGE_ERROR:
+            break;
+        default:
+            return EXCEPTION_CONTINUE_SEARCH;
+    }
 
-    // Whitelist: only treat as a real crash if recompiled code is on the
-    // call chain, OR the fault address is a guest KSEG0/KSEG1 pointer. Windows
-    // DLLs (D3D12, NVIDIA driver, XInput) raise benign structured exceptions
-    // during init/teardown (EXCEPTION_GUARD_PAGE on heap guard pages,
-    // EXCEPTION_INVALID_HANDLE on CloseHandle, etc.) -- blanket _Exit on those
-    // kills the process during boot. CaptureStackBackTrace is VEH-safe.
+    // Even for fatal codes: only treat as a real crash if recompiled code is
+    // on the call chain, OR the fault address is a guest KSEG0/KSEG1 pointer.
+    // Windows DLLs (D3D12, NVIDIA driver, XInput) can raise-and-handle even
+    // AVs internally during init/teardown -- blanket _Exit on those kills the
+    // process during boot. CaptureStackBackTrace is VEH-safe.
     void* native_pcs[64];
     USHORT n = CaptureStackBackTrace(0, 64, (PVOID*)native_pcs, nullptr);
     bool has_recomp_pc = false;
@@ -419,12 +454,18 @@ LONG WINAPI win32_vectored_handler(EXCEPTION_POINTERS* ep) {
         _resetstkoflw();
         std::fprintf(stderr,
             "\n========================= NATIVE CRASH =========================\n"
-            "Reason: %s\n"
+            "Reason: EXCEPTION_STACK_OVERFLOW (code 0x%08lX at %p)\n"
             "(dump truncated: stack overflow -- no native backtrace recoverable)\n",
-            win32_exception_name(code));
+            (unsigned long)code, ep->ExceptionRecord->ExceptionAddress);
         std::_Exit(EXIT_FAILURE);
     }
-    final_dump_and_die(win32_exception_name(code), vram_guess,
+    // Raw code + faulting address in the banner: a field report with only a
+    // symbolic name ("EXCEPTION_UNKNOWN") is undiagnosable (issue #80).
+    char reason[128];
+    std::snprintf(reason, sizeof(reason), "%s (code 0x%08lX at %p)",
+                  win32_exception_name(code), (unsigned long)code,
+                  ep->ExceptionRecord->ExceptionAddress);
+    final_dump_and_die(reason, vram_guess,
                        (const void* const*)native_pcs, n, "Win32 CaptureStackBackTrace");
     return EXCEPTION_CONTINUE_SEARCH;  // unreachable; final_dump_and_die is [[noreturn]]
 }

--- a/tests/test_crash_whitelist.cpp
+++ b/tests/test_crash_whitelist.cpp
@@ -1,0 +1,103 @@
+// Host-side spec for issue #80: the Win32 vectored exception handler must not
+// kill the process on a benign first-chance exception (a C++ throw is normal
+// control flow -- ultramodern ends guest threads by throwing thread_terminated
+// through recompiled frames), while a genuine CPU fault in recompiled code must
+// still produce the crash banner and exit(1).
+//
+// Windows-only (the VEH is Win32-only). Compile and run from the repo root with
+// the host compiler -- no ROM build needed:
+//   g++ -O0 -Ilib/N64ModernRuntime/ultramodern/include \
+//       -Ilib/N64ModernRuntime/librecomp/include \
+//       -Ilib/N64ModernRuntime/N64Recomp/include \
+//       tests/test_crash_whitelist.cpp src/lambo_crash.cpp \
+//       -o test_crash_whitelist && ./test_crash_whitelist
+//
+// The handler _Exit(1)s on a (perceived) crash, so each scenario runs in a
+// child process: the no-arg driver spawns itself with a mode argument and
+// asserts on the child's exit code.
+
+#if !defined(_WIN32)
+#include <cstdio>
+int main(void) {
+    std::fprintf(stderr, "SKIP: Win32-only test (VEH whitelist)\n");
+    return 0;
+}
+#else
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cstdint>
+#include <stdexcept>
+#include <process.h>
+
+#include "../src/lambo_crash.h"
+#include "librecomp/sections.h"
+
+extern "C" void lambo_crash_register_code_ptrs(
+    uint32_t ram_addr, uint32_t size, FuncEntry* funcs, size_t num_funcs);
+
+// Marked noinline so the registered code pointer really is the frame the
+// exception is raised from (native_pc_to_vram matches PCs at/past it).
+__attribute__((noinline)) static void guest_frame_throw_catch(uint8_t*, recomp_context*) {
+    try {
+        throw std::runtime_error("benign first-chance throw");
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "[test] caught: %s\n", e.what());
+    }
+}
+
+__attribute__((noinline)) static void guest_frame_access_violation(uint8_t*, recomp_context*) {
+    volatile uint32_t* guest_ptr = (volatile uint32_t*)(uintptr_t)0x80001000u;
+    *guest_ptr = 0xDEADBEEFu;  // unmapped on the host: real EXCEPTION_ACCESS_VIOLATION
+}
+
+static void register_as_recomp(recomp_func_t* fn) {
+    static FuncEntry fe;
+    fe.func = fn;
+    fe.offset = 0;
+    fe.rom_size = 0;
+    lambo_crash_register_code_ptrs(0x80001000u, 0x1000u, &fe, 1);
+}
+
+static int run_child(const char* self, const char* mode) {
+    intptr_t rc = _spawnl(_P_WAIT, self, self, mode, nullptr);
+    if (rc == -1) { std::perror("_spawnl"); return -1; }
+    return (int)rc;
+}
+
+int main(int argc, char** argv) {
+    if (argc > 1 && std::strcmp(argv[1], "benign-throw") == 0) {
+        register_as_recomp((recomp_func_t*)guest_frame_throw_catch);
+        lambo::crash::install();
+        guest_frame_throw_catch(nullptr, nullptr);
+        std::fprintf(stderr, "[test] survived benign throw\n");
+        return 0;
+    }
+    if (argc > 1 && std::strcmp(argv[1], "fatal-av") == 0) {
+        register_as_recomp((recomp_func_t*)guest_frame_access_violation);
+        lambo::crash::install();
+        guest_frame_access_violation(nullptr, nullptr);
+        std::fprintf(stderr, "[test] ERROR: survived an access violation\n");
+        return 42;  // must be unreachable: the handler _Exit(1)s
+    }
+
+    int failures = 0;
+
+    // A C++ throw caught normally, with a registered recomp PC on the stack,
+    // must NOT be treated as a crash (issue #80: this killed boot in the field).
+    int rc = run_child(argv[0], "benign-throw");
+    std::fprintf(stderr, "[driver] benign-throw child exit=%d (want 0)\n", rc);
+    if (rc != 0) failures++;
+
+    // A genuine access violation at a guest KSEG0 pointer inside recomp code
+    // must still produce the crash banner and exit(1).
+    rc = run_child(argv[0], "fatal-av");
+    std::fprintf(stderr, "[driver] fatal-av child exit=%d (want 1)\n", rc);
+    if (rc != 1) failures++;
+
+    std::fprintf(stderr, failures ? "FAIL (%d)\n" : "PASS\n", failures);
+    return failures ? 1 : 0;
+}
+
+#endif // _WIN32


### PR DESCRIPTION
Fixes #80.

## What
The Win32 vectored exception handler (VEH) sees every exception first-chance, before any `catch` runs. ultramodern deliberately throws `thread_terminated` **through recompiled frames** to end guest threads, so the existing "recomp PC on the stack" whitelist gate always passed for those benign MinGW C++ throws (SEH code `0x20474343`) and the process was killed with an `EXCEPTION_UNKNOWN` banner — the exact field failure in #80 (dies right after `[probe] calling start_game`, machine-specific).

## Changes
- **`src/lambo_crash.cpp`**: invert default-deny to default-allow — the VEH acts only on a positive list of unrecoverable CPU faults (`ACCESS_VIOLATION`, `ILLEGAL_INSTRUCTION`, `PRIV_INSTRUCTION`, `INT_DIVIDE_BY_ZERO`, `STACK_OVERFLOW`, `IN_PAGE_ERROR`) and returns `EXCEPTION_CONTINUE_SEARCH` on everything else. The recomp-PC / guest-KSEG0-pointer gating is retained for the codes that remain fatal.
- **Diagnosability**: the banner now prints the raw exception code in hex + the faulting address, and every backtrace frame carries its module name (`exe+0x1234`, `ntdll.dll+0x...`) — the #80 field report was undiagnosable without these.
- **Packaging**: both release zips now ship `lamborghini.syms.toml` next to the binary (the handler already probes the exe dir), so field dumps show function names instead of raw N64 PCs.

## Test-first
`tests/test_crash_whitelist.cpp` (standalone host test, same pattern as `test_hud_shift_scale.c`; self-spawning children since the handler `_Exit(1)`s):
- **benign-throw**: registered recomp PC on the stack + caught C++ throw → must survive. Red before the fix (died with the exact `EXCEPTION_UNKNOWN` banner from the field report), green after.
- **fatal-av**: real access violation at a guest KSEG0 pointer in "recomp" code → still banners and exits 1. Green before and after.

## Verification
- Test red → green.
- Full Windows build + RT64 boot smoke green: `exit=0`, `boot summary; threads=7 vis=300 first_vi=1 max_state=4 swaps=121`, no crash banner.
- `LAMBO_CRASH_TEST` deliberate-crash path still dumps with symbolized trace ring.
