### PR TITLE
Trace motor start/stop in native rumble stubs (#106 verification)

### DIFF
--- a/src/libultra_stubs.c
+++ b/src/libultra_stubs.c
@@ -503,6 +503,7 @@ void func_8007AC78(uint8_t* rdram, recomp_context* ctx) {
      * Natively bypasses the uninitialized pfs->queue and pfs->channel (which remain zero/uninitialized
      * since osMotorInit is skipped when a Controller Pak is detected) and directly drives the motor. */
     int channel = ((int32_t)ctx->r4 - 0x80110D68) / 40;
+    if (lambo_pak_trace()) fprintf(stderr, "[pak] MOTOR START ch=%d\n", channel);
     if (channel == 0) {
         lambo_pak_set_rumble(1);
     }
@@ -512,6 +513,7 @@ void func_8007AC78(uint8_t* rdram, recomp_context* ctx) {
 void func_8007AB10(uint8_t* rdram, recomp_context* ctx) {
     /* osMotorStop: VRAM 0x80079f10 */
     int channel = ((int32_t)ctx->r4 - 0x80110D68) / 40;
+    if (lambo_pak_trace()) fprintf(stderr, "[pak] MOTOR STOP ch=%d\n", channel);
     if (channel == 0) {
         lambo_pak_set_rumble(0);
     }


### PR DESCRIPTION
Adds `LAMBO_PAK_TRACE=1`-gated `[pak] MOTOR START/STOP ch=N` lines to the native `osMotorStart`/`osMotorStop` stubs, so a headless run can prove ROM-driven rumble.

Used to verify #106 end-to-end: a real 1P arcade race logged 79 MOTOR START / 2395 MOTOR STOP events on ch0 (the ROM's PWM duty-cycle engine), while cpak saving stayed intact in the same session (26 image-region WRITE frames, 32 KB .mpk flushed). Part of wayfinder map #101.