### PR TITLE
Detect outdated Intel drivers and surface the fix instead of a silent black screen (#109)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/lambo_flare_widescreen.c  # issue #40: gEXSetRectAspect(STRETCH) bracket around the sun lens-flare ghosts
         src/lambo_fog_widescreen.cpp  # issue #83: widen dense 3P/4P fog to the 1P window/colour (DL rewrite, players>=3)
         src/lambo_sky_widescreen.cpp  # issue #84: draw the 1P/2P sky panorama in 3P/4P (patches.hook branch guard)
+        src/lambo_gpu_advisory.cpp  # issue #109: outdated-Intel-driver detection + user-facing fix advisory
         src/lambo_warp.c       # issue #12: developer warp menu (F1-F6 / LAMBO_WARP race-track warp)
         src/lambo_savestate.c  # issue #22: developer save-state (F7/F8 / LAMBO_STATE_LOAD RDRAM snapshot)
     )

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ N64Recomp ports (Zelda 64: Recompiled et al.):
 | `widescreen_fog_match` | `true`, `false` | `true` | Widens the dense 3P/4P split-screen fog to the open 1P fog window/colour so the extra draw distance shows. Only affects 3+ player races. |
 | `widescreen_sky_match` | `true`, `false` | `true` | Draws the sky panorama in 3P/4P split screen (the original skips it, leaving a flat dark backdrop above the horizon). Only affects 3+ player races. |
 
+## Troubleshooting
+
+**Black screen / `vkQueueSubmit failed` spam on Intel graphics.** Intel drivers
+older than 31.0.101.2115 are known-broken with RT64: the renderer avoids Direct3D 12
+on them, and on newer Intel GPUs (e.g. Iris Xe) stuck on an old driver the Vulkan
+fallback then loses the device. The game detects this at startup and shows a warning.
+The fix is to update the Intel graphics driver (Windows Update or
+[intel.com/download-center](https://www.intel.com/content/www/us/en/download-center/home.html)).
+If you cannot update, set `"api_option": "D3D12"` in `graphics.json` to stay on
+Direct3D 12 instead.
+
 ## Developer warp (race-track warp)
 
 For development it is useful to jump straight into a race without driving the menus

--- a/build.ps1
+++ b/build.ps1
@@ -15,7 +15,7 @@
       3. ROM check (skippable via -RomPath; CI forwards its $env:ROM_FILENAME).
       4. Defensive submodule reset before patching (a half-applied patch from a
          prior run would otherwise break the next apply).
-      5. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0008, 0009, 0005, 0004) with
+      5. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0008, 0009, 0010, 0005, 0004) with
          --ignore-whitespace (CRLF mismatches on Windows git). 0007 adds the
          save-state thread-context registry; without it, src/lambo_savestate.c
          fails to link with "undefined reference to ultramodern_relink_thread_contexts".
@@ -156,7 +156,7 @@ try {
     git -C lib/rt64 checkout -- . | Out-Null
     git -C lib/rt64/src/contrib/plume checkout -- . | Out-Null
 
-    # --- 6. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0008, 0009, 0005, 0004) -
+    # --- 6. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0008, 0009, 0010, 0005, 0004) -
     # Mirrors CI's Windows job exactly (workflow lines 210-214). 0001 then 0007
     # both patch N64ModernRuntime with disjoint hunks (verified to apply
     # sequentially on the pinned commit). 0007 adds the save-state thread-
@@ -174,6 +174,7 @@ try {
         @{ Sub = 'lib/rt64';                   Patch = 'patches/0008-rt64-skybox-stretch-parallaxless-backdrop.patch' },
         @{ Sub = 'lib/rt64';                   Patch = 'patches/0005-rt64-mingw-gcc-compat.patch' },
         @{ Sub = 'lib/rt64';                   Patch = 'patches/0009-rt64-widescreen-split-subviewport.patch' },
+        @{ Sub = 'lib/rt64';                   Patch = 'patches/0010-rt64-intel-explicit-d3d12-escape-hatch.patch' },
         @{ Sub = 'lib/rt64/src/contrib/plume'; Patch = 'patches/0004-plume-d3d12-mingw-com-abi-struct-return.patch' }
     )
     foreach ($p in $patches) {

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@
 #   3. Submodule init (recursive; core.longpaths isn't needed on Linux).
 #   4. Defensive submodule reset before patching (half-applied patches from a
 #      prior run would otherwise break the next apply with "patch failed: ...").
-#   5. Apply Lamborghini patches (Linux: 0001, 0007, 0006, 0008, 0009 — no MinGW/D3D12
+#   5. Apply Lamborghini patches (Linux: 0001, 0007, 0006, 0008, 0009, 0010 — no MinGW/D3D12
 #      fixes needed; no plume patch). 0007 adds the save-state thread-context
 #      registry; without it, src/lambo_savestate.c fails to link with
 #      "undefined reference to ultramodern_relink_thread_contexts".
@@ -96,7 +96,7 @@ git -C lib/N64ModernRuntime checkout -- .
 git -C lib/rt64 checkout -- .
 git -C lib/rt64/src/contrib/plume checkout -- . 2>/dev/null || true
 
-# --- 6. Apply Lamborghini patches (Linux: 0001, 0007, 0006, 0008, 0009) ----------------
+# --- 6. Apply Lamborghini patches (Linux: 0001, 0007, 0006, 0008, 0009, 0010) ----------------
 # Mirrors CI's Linux job exactly (workflow lines 93-95). 0001 then 0007 both
 # patch N64ModernRuntime with disjoint hunks (verified to apply sequentially
 # on the pinned commit). 0007 adds the save-state thread-context registry +
@@ -110,6 +110,7 @@ PATCHES=(
     "lib/rt64:0006-rt64-interp-angular-velocity-matching.patch"
     "lib/rt64:0008-rt64-skybox-stretch-parallaxless-backdrop.patch"
     "lib/rt64:0009-rt64-widescreen-split-subviewport.patch"
+    "lib/rt64:0010-rt64-intel-explicit-d3d12-escape-hatch.patch"
 )
 for entry in "${PATCHES[@]}"; do
     sub="${entry%%:*}"

--- a/patches/0010-rt64-intel-explicit-d3d12-escape-hatch.patch
+++ b/patches/0010-rt64-intel-explicit-d3d12-escape-hatch.patch
@@ -1,0 +1,17 @@
+diff --git a/src/hle/rt64_application.cpp b/src/hle/rt64_application.cpp
+index 785de27..204810b 100644
+--- a/src/hle/rt64_application.cpp
++++ b/src/hle/rt64_application.cpp
+@@ -250,8 +250,11 @@ namespace RT64 {
+         else if (deviceDescription.vendor == RenderDeviceVendor::INTEL) {
+             if (chosenGraphicsAPI == UserConfiguration::GraphicsAPI::D3D12) {
+                 // End of life driver for Intel 6th Gen Processor Graphics. D3D12 fails with DXGI_ERROR_DEVICE_REMOVED after running a display list in RT64. Vulkan has been reported to work fine on this driver.
++                // Only applied when the API choice is automatic: on newer Intel GPUs stuck on old drivers
++                // (e.g. Iris Xe on 30.0.101.x) Vulkan is the one that fails (VK_ERROR_DEVICE_LOST), so an
++                // explicit D3D12 selection must win as an escape hatch.
+                 const uint64_t BrokenIntelDriverD3D12 = 0x1F000000650843; // 31.0.101.2115
+-                if (deviceDescription.driverVersion <= BrokenIntelDriverD3D12) {
++                if (automaticGraphicsAPI && (deviceDescription.driverVersion <= BrokenIntelDriverD3D12)) {
+                     forceVulkanForCompatibility = true;
+                 }
+             }

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -146,6 +146,10 @@ std::filesystem::path graphics_json_path() {
 namespace lambo {
 namespace config {
 
+std::filesystem::path graphics_config_path() {
+    return graphics_json_path();
+}
+
 std::filesystem::path app_config_dir() {
     // Portable mode: a portable.txt in the working directory keeps everything local.
     std::error_code ec;

--- a/src/lambo_config.h
+++ b/src/lambo_config.h
@@ -21,6 +21,10 @@ namespace config {
 //   else:    $XDG_CONFIG_HOME/LamborghiniRecomp (or ~/.config/LamborghiniRecomp)
 std::filesystem::path app_config_dir();
 
+// Absolute path of the live graphics.json (honours the LAMBO_GRAPHICS_CONFIG
+// override), for user-facing messages that tell people what file to edit.
+std::filesystem::path graphics_config_path();
+
 // The enhancement-oriented defaults this port ships with (widescreen Expand,
 // display-rate interpolated rendering, window-scaled internal resolution).
 ultramodern::renderer::GraphicsConfig default_graphics_config();

--- a/src/lambo_gpu_advisory.cpp
+++ b/src/lambo_gpu_advisory.cpp
@@ -1,0 +1,82 @@
+#include "lambo_gpu_advisory.h"
+
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+
+// RT64's rt64_application.cpp forces Vulkan on Intel drivers <= this version
+// (31.0.101.2115, an end-of-life driver where D3D12 device-removes). Keep in
+// sync with BrokenIntelDriverD3D12 there; patch 0010 makes an explicit
+// api_option=D3D12 win over that fallback.
+static const uint64_t kBrokenIntelDriverD3D12 = 0x001F000000650843ULL;
+
+void lambo_gpu_format_driver_version(uint64_t v, char* out, size_t out_size) {
+    std::snprintf(out, out_size, "%u.%u.%u.%u",
+                  (unsigned)((v >> 48) & 0xFFFF), (unsigned)((v >> 32) & 0xFFFF),
+                  (unsigned)((v >> 16) & 0xFFFF), (unsigned)(v & 0xFFFF));
+}
+
+int lambo_gpu_intel_driver_predates_fix(uint64_t driver_version) {
+    return driver_version <= kBrokenIntelDriverD3D12 ? 1 : 0;
+}
+
+int lambo_gpu_advisory_severity(uint32_t vendor, uint64_t driver_version, int running_vulkan) {
+    if (vendor != LAMBO_GPU_VENDOR_INTEL || !lambo_gpu_intel_driver_predates_fix(driver_version)) {
+        return LAMBO_GPU_ADVISORY_NONE;
+    }
+    return running_vulkan ? LAMBO_GPU_ADVISORY_SEVERE : LAMBO_GPU_ADVISORY_INFO;
+}
+
+static char g_pending_text[1024];
+static std::atomic<int> g_pending_state{0}; // 0 empty, 1 ready, 2 taken
+
+void lambo_gpu_advisory_set_pending(const char* text) {
+    int expected = 0;
+    if (!g_pending_state.compare_exchange_strong(expected, -1, std::memory_order_acquire)) {
+        return; // already posted or taken; first advisory wins
+    }
+    std::snprintf(g_pending_text, sizeof g_pending_text, "%s", text);
+    g_pending_state.store(1, std::memory_order_release);
+}
+
+const char* lambo_gpu_advisory_take_pending(void) {
+    int expected = 1;
+    if (g_pending_state.compare_exchange_strong(expected, 2, std::memory_order_acquire)) {
+        return g_pending_text;
+    }
+    return nullptr;
+}
+
+void lambo_gpu_advisory_message(int severity, const char* device_name,
+                                uint64_t driver_version, const char* config_path,
+                                char* out, size_t out_size) {
+    char ver[32];
+    lambo_gpu_format_driver_version(driver_version, ver, sizeof ver);
+
+    if (severity == LAMBO_GPU_ADVISORY_SEVERE) {
+        std::snprintf(out, out_size,
+            "Your Intel graphics driver is outdated and known to break this game.\n"
+            "\n"
+            "GPU:    %s\n"
+            "Driver: %s (needs 31.0.101.2115 or newer)\n"
+            "\n"
+            "The renderer fell back to Vulkan on this driver, which typically fails\n"
+            "with a black screen (Vulkan device loss).\n"
+            "\n"
+            "To fix it, update the Intel graphics driver via Windows Update or\n"
+            "intel.com/download-center.\n"
+            "\n"
+            "If you cannot update the driver, try Direct3D 12 instead by setting\n"
+            "    \"api_option\": \"D3D12\"\n"
+            "in %s",
+            device_name, ver, config_path);
+    }
+    else {
+        std::snprintf(out, out_size,
+            "Note: your Intel graphics driver is outdated.\n"
+            "GPU: %s, driver %s (31.0.101.2115 or newer recommended).\n"
+            "If you see rendering problems, update the driver via Windows Update or\n"
+            "intel.com/download-center. Config: %s",
+            device_name, ver, config_path);
+    }
+}

--- a/src/lambo_gpu_advisory.h
+++ b/src/lambo_gpu_advisory.h
@@ -1,0 +1,54 @@
+// GPU driver advisory (issue #109): old Intel drivers trip RT64's
+// force-Vulkan workaround, and on Iris Xe that Vulkan driver loses the device
+// (VK_ERROR_DEVICE_LOST) -> silent black screen. Detect the condition after
+// renderer setup and tell the user what to do about it.
+//
+// Pure logic (no RT64/plume types) so it is host-testable: see
+// tests/test_gpu_advisory.cpp.
+#ifndef LAMBO_GPU_ADVISORY_H
+#define LAMBO_GPU_ADVISORY_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LAMBO_GPU_VENDOR_INTEL 0x8086u
+
+enum {
+    LAMBO_GPU_ADVISORY_NONE = 0,
+    LAMBO_GPU_ADVISORY_INFO = 1,   // affected driver, but not on the failing API path
+    LAMBO_GPU_ADVISORY_SEVERE = 2, // affected driver on Vulkan: expect device loss / black screen
+};
+
+// Render a packed driver version (four 16-bit words, AA.BB.CCC.DDDD) as text.
+void lambo_gpu_format_driver_version(uint64_t driver_version, char* out, size_t out_size);
+
+// Mirrors RT64's BrokenIntelDriverD3D12 gate (rt64_application.cpp): drivers at
+// or below 31.0.101.2115 are forced onto Vulkan when the API choice is automatic.
+int lambo_gpu_intel_driver_predates_fix(uint64_t driver_version);
+
+// Classify the post-setup device state. running_vulkan reflects the API that was
+// actually chosen (after any RT64 fallback), not what the config asked for.
+int lambo_gpu_advisory_severity(uint32_t vendor, uint64_t driver_version, int running_vulkan);
+
+// Build the user-facing advisory text for a non-NONE severity. config_path is the
+// absolute graphics.json path shown to the user for the api_option escape hatch.
+void lambo_gpu_advisory_message(int severity, const char* device_name,
+                                uint64_t driver_version, const char* config_path,
+                                char* out, size_t out_size);
+
+// One-slot cross-thread handoff for the popup: the gfx thread (renderer setup)
+// posts the advisory text; the main thread's event pump takes it exactly once
+// and owns showing the message box (UI must live on the window-owning thread --
+// a detached MessageBox thread races process teardown into heap corruption).
+void lambo_gpu_advisory_set_pending(const char* text);
+const char* lambo_gpu_advisory_take_pending(void); // NULL when nothing pending
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,7 @@
 #include "lambo_audio.h"
 #include "lambo_config.h"
 #include "lambo_crash.h"   // issue #13 / A14
+#include "lambo_gpu_advisory.h"  // issue #109: outdated-driver popup handoff
 // ultramodern's native VI API (events.cpp), used by the promote_vi_context RT64 bridge.
 extern "C" void osViSwapBuffer(uint8_t* rdram, int32_t frameBufPtr);
 extern "C" void osViSetMode(uint8_t* rdram, int32_t mode_);
@@ -427,6 +428,14 @@ static void update_gfx_stub(void* /*gfx_data*/) {
             else if (event.type == SDL_CONTROLLERDEVICEREMOVED) {
                 input_close_controller(event.cdevice.which);  // which = instance id (REMOVED)
             }
+        }
+        // Severe GPU-driver advisory posted by renderer setup (issue #109): the affected
+        // user sees only a black window, so show it as a modal box. Main thread owns all
+        // UI; blocking the pump here is fine -- game threads keep running behind it.
+        if (const char* advisory = lambo_gpu_advisory_take_pending()) {
+            SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING,
+                                     "Lamborghini Recomp - outdated graphics driver",
+                                     advisory, g_sdl_window);
         }
         // SDL_PollEvent pumped events above (implicitly SDL_GameControllerUpdate); sample the
         // fresh keyboard+pad state into the atomic snapshot the game thread reads via get_input.

--- a/src/rt64_renderer.cpp
+++ b/src/rt64_renderer.cpp
@@ -26,6 +26,7 @@
 
 #include "lambo_rt64.h"
 #include "lambo_config.h"
+#include "lambo_gpu_advisory.h"
 #include "lambo_hud_widescreen.h"
 
 extern "C" void lambo_fog_match_1p(uint8_t* rdram, uint32_t dl_addr);  // src/lambo_fog_widescreen.cpp
@@ -166,6 +167,41 @@ ultramodern::renderer::GraphicsApi map_graphics_api(RT64::UserConfiguration::Gra
     return ultramodern::renderer::GraphicsApi::Auto;
 }
 
+// GPU driver advisory (issue #109): an out-of-date Intel driver trips RT64's
+// force-Vulkan workaround, and on Iris Xe that Vulkan driver immediately loses
+// the device (vkQueueSubmit VK_ERROR_DEVICE_LOST) -> a black screen with nothing
+// user-readable anywhere. Detect the condition after setup and say what to do.
+void warn_about_gpu_driver(RT64::Application* app, ultramodern::renderer::GraphicsApi chosen_api) {
+    const auto desc = app->device->getDescription();
+    uint32_t vendor = (uint32_t)desc.vendor;
+    uint64_t driver_version = desc.driverVersion;
+    // Replay a reported machine's device on any box: LAMBO_FAKE_GPU="8086,1e00000065057c"
+    if (const char* fake = std::getenv("LAMBO_FAKE_GPU")) {
+        unsigned v = 0; unsigned long long d = 0;
+        if (std::sscanf(fake, "%x,%llx", &v, &d) == 2) {
+            vendor = v; driver_version = d;
+            std::fprintf(stderr, "[gpu] LAMBO_FAKE_GPU active: vendor=0x%X driver=0x%llX\n", v, d);
+        }
+    }
+    const int severity = lambo_gpu_advisory_severity(
+        vendor, driver_version,
+        chosen_api == ultramodern::renderer::GraphicsApi::Vulkan ? 1 : 0);
+    if (severity == LAMBO_GPU_ADVISORY_NONE) {
+        return;
+    }
+
+    static char text[1024];
+    lambo_gpu_advisory_message(severity, desc.name.c_str(), driver_version,
+                               lambo::config::graphics_config_path().string().c_str(),
+                               text, sizeof text);
+    std::fprintf(stderr, "[gpu] driver advisory:\n%s\n", text);
+    if (severity == LAMBO_GPU_ADVISORY_SEVERE) {
+        // The affected user sees only a black window; a console line is not enough.
+        // Post to the main thread's event pump, which owns showing the message box.
+        lambo_gpu_advisory_set_pending(text);
+    }
+}
+
 class RT64Context final : public ultramodern::renderer::RendererContext {
 public:
     RT64Context(uint8_t* rdram, ultramodern::renderer::WindowHandle window_handle, bool debug) {
@@ -253,6 +289,8 @@ public:
         }
 
         std::fprintf(stderr, "[rt64] RT64 renderer initialised (api=%d)\n", (int)chosen_api);
+
+        warn_about_gpu_driver(app.get(), chosen_api);
 
         // Publish the app pointer for the widescreen HUD rect-aspect helper
         // (lambo_ws_get_hud_rect_aspect_bits reads this on the game-logic thread),

--- a/tests/test_gpu_advisory.cpp
+++ b/tests/test_gpu_advisory.cpp
@@ -1,0 +1,104 @@
+// Host-side spec for issue #109: on the reporter's machine (Intel Iris Xe,
+// driver 30.0.101.1404) RT64's old-Intel-driver workaround forces Vulkan, and
+// that Vulkan driver immediately loses the device (VK_ERROR_DEVICE_LOST) ->
+// black screen with no explanation. The port must recognise the condition and
+// tell the user what is wrong and how to fix it.
+//
+// Pure logic, no ROM or GPU needed. Compile and run from the repo root:
+//   g++ -O0 tests/test_gpu_advisory.cpp src/lambo_gpu_advisory.cpp -o test_gpu_advisory
+//   ./test_gpu_advisory
+
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include "../src/lambo_gpu_advisory.h"
+
+// Driver versions pack four 16-bit words: AA.BB.CCC.DDDD.
+static const uint64_t kReporterDriver = 0x001e00000065057cULL; // 30.0.101.1404 (issue #109)
+static const uint64_t kRT64Threshold  = 0x001F000000650843ULL; // 31.0.101.2115 (rt64_application.cpp)
+static const uint64_t kModernDriver   = 0x0020000000651c86ULL; // 32.0.101.7302
+
+static int failures = 0;
+#define CHECK(cond) do { \
+    if (!(cond)) { std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); failures++; } \
+} while (0)
+
+static bool contains(const char* haystack, const char* needle) {
+    return std::strstr(haystack, needle) != nullptr;
+}
+
+int main() {
+    char buf[32];
+
+    // --- driver version formatting (the packed-word decode) --------------------
+    lambo_gpu_format_driver_version(kReporterDriver, buf, sizeof buf);
+    CHECK(std::strcmp(buf, "30.0.101.1404") == 0);
+    lambo_gpu_format_driver_version(kRT64Threshold, buf, sizeof buf);
+    CHECK(std::strcmp(buf, "31.0.101.2115") == 0);
+
+    // --- the predicate must mirror RT64's <= comparison ------------------------
+    CHECK(lambo_gpu_intel_driver_predates_fix(kReporterDriver) == 1);
+    CHECK(lambo_gpu_intel_driver_predates_fix(kRT64Threshold) == 1);      // <= is inclusive
+    CHECK(lambo_gpu_intel_driver_predates_fix(kRT64Threshold + 1) == 0);
+    CHECK(lambo_gpu_intel_driver_predates_fix(kModernDriver) == 0);
+
+    // --- severity matrix --------------------------------------------------------
+    // Old Intel driver running Vulkan = the exact #109 failure: severe.
+    CHECK(lambo_gpu_advisory_severity(LAMBO_GPU_VENDOR_INTEL, kReporterDriver, /*vulkan*/1)
+          == LAMBO_GPU_ADVISORY_SEVERE);
+    // Old Intel driver on D3D12 (user escape hatch active): still worth a note.
+    CHECK(lambo_gpu_advisory_severity(LAMBO_GPU_VENDOR_INTEL, kReporterDriver, /*vulkan*/0)
+          == LAMBO_GPU_ADVISORY_INFO);
+    // Up-to-date Intel driver: silence.
+    CHECK(lambo_gpu_advisory_severity(LAMBO_GPU_VENDOR_INTEL, kModernDriver, 1)
+          == LAMBO_GPU_ADVISORY_NONE);
+    // Other vendors: not our advisory, even on ancient drivers.
+    CHECK(lambo_gpu_advisory_severity(0x10DEu /*NVIDIA*/, kReporterDriver, 1)
+          == LAMBO_GPU_ADVISORY_NONE);
+
+    // --- the user-facing message ------------------------------------------------
+    char msg[1024];
+    lambo_gpu_advisory_message(LAMBO_GPU_ADVISORY_SEVERE,
+                               "Intel(R) Iris(R) Xe Graphics", kReporterDriver,
+                               "C:\\Users\\cathe\\AppData\\Local\\LamborghiniRecomp\\graphics.json",
+                               msg, sizeof msg);
+    CHECK(contains(msg, "30.0.101.1404"));                 // their driver, decoded
+    CHECK(contains(msg, "Intel(R) Iris(R) Xe Graphics"));  // their GPU
+    CHECK(contains(msg, "black screen"));                  // what they'll see
+    CHECK(contains(msg, "update"));                        // the real fix
+    CHECK(contains(msg, "31.0.101.2115"));                 // how new is new enough
+    CHECK(contains(msg, "api_option"));                    // the escape hatch key...
+    CHECK(contains(msg, "D3D12"));                         // ...and value
+    CHECK(contains(msg, "graphics.json"));                 // where to put it
+    CHECK(contains(msg, "C:\\Users\\cathe\\AppData\\Local\\LamborghiniRecomp\\graphics.json"));
+
+    // INFO variant (already on D3D12) must not threaten a black screen.
+    lambo_gpu_advisory_message(LAMBO_GPU_ADVISORY_INFO,
+                               "Intel(R) Iris(R) Xe Graphics", kReporterDriver,
+                               "graphics.json", msg, sizeof msg);
+    CHECK(contains(msg, "update"));
+    CHECK(!contains(msg, "black screen"));
+
+    // Truncation must stay NUL-terminated and not overrun.
+    char tiny[16];
+    lambo_gpu_advisory_message(LAMBO_GPU_ADVISORY_SEVERE, "GPU", kReporterDriver,
+                               "path", tiny, sizeof tiny);
+    CHECK(std::strlen(tiny) < sizeof tiny);
+
+    // --- popup handoff: take-once semantics --------------------------------------
+    CHECK(lambo_gpu_advisory_take_pending() == nullptr);   // nothing posted yet
+    lambo_gpu_advisory_set_pending("first advisory");
+    lambo_gpu_advisory_set_pending("second must not overwrite");
+    const char* taken = lambo_gpu_advisory_take_pending();
+    CHECK(taken != nullptr && std::strcmp(taken, "first advisory") == 0);
+    CHECK(lambo_gpu_advisory_take_pending() == nullptr);   // consumed exactly once
+
+    if (failures == 0) {
+        std::fprintf(stderr, "PASS: all gpu-advisory checks\n");
+        return 0;
+    }
+    std::fprintf(stderr, "%d check(s) FAILED\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Fixes the user experience behind #109: on Intel Iris Xe with driver 30.0.101.1404 (`0x1e00000065057c` in the report), RT64's old-Intel-driver workaround forces the renderer onto Vulkan, and that Vulkan driver immediately loses the device (`0xFFFFFFFC` = `VK_ERROR_DEVICE_LOST`) — the user gets a silent black screen and a console full of `vkQueueSubmit failed`.

Two-part fix:

**1. Tell the user what's wrong (new `lambo_gpu_advisory`)**
- After renderer setup, the port reads the live device description. An Intel driver at or below RT64's known-broken threshold (31.0.101.2115) running on Vulkan is classified SEVERE: a warning box (SDL, main thread) explains the black screen, names the exact driver version (decoded from the packed value), and gives both fixes — update the driver, or set `"api_option": "D3D12"` in `graphics.json` (full path shown).
- Same driver on D3D12 gets a low-key stderr note instead.
- The logic is pure and host-tested (`tests/test_gpu_advisory.cpp`: version decode, threshold inclusivity, severity matrix, message content, popup take-once handoff).
- `LAMBO_FAKE_GPU="8086,1e00000065057c"` replays a reported machine's device on any box — that's how the SEVERE path was verified end to end here.

**2. Make the escape hatch real (patch 0010)**
- RT64's Intel workaround was unconditional, so even an explicit `api_option: "D3D12"` got overridden onto the broken Vulkan path. The patch gates the workaround on the API choice being automatic (the same pattern RT64 already uses for its NVIDIA and AMD RDNA3 workarounds). Added to both build scripts' patch lists.

Also adds a README troubleshooting entry.

**Verified:** host test green; windowed boot smoke on the default path clean with no advisory (healthy GPU stays silent); fake-Intel + forced-Vulkan smoke shows the popup with the right text while the game keeps running behind it.

**Noted, out of scope:** Vulkan runs on this box intermittently exit with `STATUS_HEAP_CORRUPTION` during the `_Exit` teardown — reproduced ~50% *without* this change (control runs) — tracked separately.
