### PR TITLE
no_lod: draw the per-segment scenery layer in 2P-4P races like 1P (#87/#91)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/lambo_flare_widescreen.c  # issue #40: gEXSetRectAspect(STRETCH) bracket around the sun lens-flare ghosts
         src/lambo_fog_widescreen.cpp  # issue #83: widen dense 3P/4P fog to the 1P window/colour (DL rewrite, players>=3)
         src/lambo_sky_widescreen.cpp  # issue #84: draw the 1P/2P sky panorama in 3P/4P (patches.hook branch guard)
+        src/lambo_no_lod.cpp   # issues #87/#91: emit the per-segment scenery layer in 2P-4P like 1P (patches.hook branch guards)
         src/lambo_gpu_advisory.cpp  # issue #109: outdated-Intel-driver detection + user-facing fix advisory
         src/lambo_warp.c       # issue #12: developer warp menu (F1-F6 / LAMBO_WARP race-track warp)
         src/lambo_savestate.c  # issue #22: developer save-state (F7/F8 / LAMBO_STATE_LOAD RDRAM snapshot)

--- a/docs/no_lod_audit.md
+++ b/docs/no_lod_audit.md
@@ -185,6 +185,45 @@ following the same pattern as #83's `widescreen_fog_match`. It does **not** move
 ruling as the fog fix). `no_lod` covers only the *remaining* reductions (tickets above).
 
 ---
+
+## 7. Addendum (2026-07-11): the audit missed the per-segment scenery layer
+
+A 3P save-state investigation (paused just before visible pop-in) falsified two of this
+report's conclusions:
+
+- **"Per-mode draw distance is measured intact" was wrong for scenery.** The scene DL
+  builder `func_8000A6C0` draws each track segment as up to three sub-DLs from its
+  64-byte segment record (+0x4 road, +0x8 walls, +0xC far scenery: distant canyon
+  relief, trees, trackside structures) — and gates the scenery emit on
+  `slti $at, players, 0x2` + `beq $at, $zero` (0x8000CFA0/0x8000CFA4 in the segment
+  loop; 0x8000D834/0x8000D838 for the camera's own segment). **2P, 3P and 4P races
+  never draw the scenery layer at all**, which reads as short draw distance and pop-in;
+  #83's fog widening unmasked it (the near-black variant-2 fog used to hide the gap).
+  Fixed by the `no_lod` graphics.json key (default true): `[[patches.hook]]`s route
+  `$at` through `lambo_no_lod_scenery_guard` (src/lambo_no_lod.cpp), so every mode
+  takes the branch the way 1P does. The emit still self-gates on record+0xC being
+  non-null, and the scenery DLs are streamed in all modes (verified from a 3P save
+  state), so nothing is synthesised. Verified: 3P/4P scenery present and stable,
+  `LAMBO_NO_LOD=0` frame pixel-identical to the pre-patch binary, 1P unchanged.
+- **Why the scan missed it:** `tools/scan_lod_patterns.py` fingerprints
+  *single-precision FP compares* only. This gate is an integer `slti` on the player
+  count — a whole class (integer/per-mode branch gates inside DL emitters) the scan
+  cannot see. Double-precision compares (`c.lt.d`, ~200 sites) were also outside the
+  scan; the one guarding func_80060464's pair loop is a 0.01 epsilon, not a cull.
+- **Misleading role classifications:** `func_8000A6C0` ("ratio/range/normalisation
+  math") is actually the per-frame scene DL builder, and `func_80032450` ("camera
+  math") also maintains the per-viewport segment machinery. Their Axis-A FP-compare
+  verdicts stand; the role labels shouldn't be reused for navigation.
+- **Residual (unmeasured impact):** at the same track spot the 1P frame emits 5
+  segment groups ahead vs 3–4 per 3P viewport. With the scenery layer restored the
+  horizon is filled and no chunk pop was visible in the verification captures; if a
+  residual far-road pop shows up in play, the next probe is the per-viewport segment
+  list builder (func_80032450 / the list consumed at 0x8000CD5C via 0x800A2F28).
+- New diagnostic: `LAMBO_RACE_DL_DUMP_AT="n1,n2,..."` (with `LAMBO_RACE_DL_DUMP=<base>`)
+  dumps the walked frame DL + RDRAM at exact send_dl counts — pairs with
+  `LAMBO_STATE_LOAD` to diff the frames around a pop deterministically.
+
+---
 *Method note: MIPS classification used `tools/scan_lod_patterns.py` output cross-read
 against the recompiled C (per-instruction VRAM comments) rather than raw disassembly;
 extraction script preserved in the session scratchpad. ROM scans were byte-pattern

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -614,6 +614,24 @@ func = "func_800030F8"
 before_vram = 0x80004E94
 text = "{ extern uint32_t lambo_sky_match_1p_guard(uint8_t*, uint32_t); ctx->r1 = lambo_sky_match_1p_guard(rdram, (uint32_t)ctx->r1); }"
 
+# Issues #87/#91 -- no_lod: emit the per-segment scenery layer in 2P-4P like 1P. The scene
+# builder func_8000A6C0 draws each track segment as up to three sub-DLs from the 64-byte
+# segment record (+0x4 road, +0x8 walls, +0xC far scenery) but gates the scenery emit on
+# `slti $at, players, 0x2` + `beq $at, $zero`: 0x8000CFA0/0x8000CFA4 in the segment loop
+# (which also checks record+0xC != 0 first) and 0x8000D834/0x8000D838 for the camera's own
+# segment. Routing $at through the native makes every mode take the branch the way 1P does;
+# the scenery DLs are streamed in all modes (verified from a 3P save state), only the emit
+# was skipped. Native in src/lambo_no_lod.cpp; graphics.json key "no_lod".
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000CFA4
+text = "{ extern uint32_t lambo_no_lod_scenery_guard(uint8_t*, uint32_t); ctx->r1 = lambo_no_lod_scenery_guard(rdram, (uint32_t)ctx->r1); }"
+
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000D838
+text = "{ extern uint32_t lambo_no_lod_scenery_guard(uint8_t*, uint32_t); ctx->r1 = lambo_no_lod_scenery_guard(rdram, (uint32_t)ctx->r1); }"
+
 # Issue #78 — 3P/4P per-quadrant HUD text pinning. The quad section (L_800517A8) draws
 # each player's RANK (x=0x20/0x110), speed readout (x=0x14-0x46 / 0xEB-0x11D), lap-notify
 # glyph (x=0x19/0x118) and the inline per-player tag texrects in the outer columns, plus

--- a/scripts/gen_syms_toml.py
+++ b/scripts/gen_syms_toml.py
@@ -943,6 +943,24 @@ text = "lambo_ws_split_wide_end(rdram);"
 func = "func_800030F8"
 before_vram = 0x80004E94
 text = "{ extern uint32_t lambo_sky_match_1p_guard(uint8_t*, uint32_t); ctx->r1 = lambo_sky_match_1p_guard(rdram, (uint32_t)ctx->r1); }"
+
+# Issues #87/#91 -- no_lod: emit the per-segment scenery layer in 2P-4P like 1P. The scene
+# builder func_8000A6C0 draws each track segment as up to three sub-DLs from the 64-byte
+# segment record (+0x4 road, +0x8 walls, +0xC far scenery) but gates the scenery emit on
+# `slti $at, players, 0x2` + `beq $at, $zero`: 0x8000CFA0/0x8000CFA4 in the segment loop
+# (which also checks record+0xC != 0 first) and 0x8000D834/0x8000D838 for the camera's own
+# segment. Routing $at through the native makes every mode take the branch the way 1P does;
+# the scenery DLs are streamed in all modes (verified from a 3P save state), only the emit
+# was skipped. Native in src/lambo_no_lod.cpp; graphics.json key "no_lod".
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000CFA4
+text = "{ extern uint32_t lambo_no_lod_scenery_guard(uint8_t*, uint32_t); ctx->r1 = lambo_no_lod_scenery_guard(rdram, (uint32_t)ctx->r1); }"
+
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000D838
+text = "{ extern uint32_t lambo_no_lod_scenery_guard(uint8_t*, uint32_t); ctx->r1 = lambo_no_lod_scenery_guard(rdram, (uint32_t)ctx->r1); }"
 """
 
 UNSTUB = [

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -38,6 +38,13 @@ bool g_widescreen_fog_match = true;
 // enhancement family as the fog match; 1P/2P take the sky path natively anyway.
 bool g_widescreen_sky_match = true;
 
+// Remove the ROM's per-mode LOD reductions (issues #87/#91): the scene builder
+// func_8000A6C0 emits each track segment's scenery layer (record+0xC sub-DL: the
+// distant canyon walls / roadside relief) only when players < 2, so 2P-4P races
+// lose the far scenery entirely. Default-on; the emit still self-gates on the
+// record pointer being non-null, so segments without a scenery DL are unaffected.
+bool g_no_lod = true;
+
 // Read a key into `out`, keeping the existing (default) value when the key is
 // missing or invalid. NLOHMANN_JSON_SERIALIZE_ENUM does NOT throw on an
 // unrecognised string -- it silently maps it to the FIRST enumerator, which for
@@ -80,6 +87,7 @@ nlohmann::json to_json(const ultramodern::renderer::GraphicsConfig& c) {
         {"texture_dump", g_texture_dump},
         {"widescreen_fog_match", g_widescreen_fog_match},
         {"widescreen_sky_match", g_widescreen_sky_match},
+        {"no_lod", g_no_lod},
     };
 }
 
@@ -101,6 +109,7 @@ void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c
     from_or_default(j, "texture_dump", g_texture_dump);
     from_or_default(j, "widescreen_fog_match", g_widescreen_fog_match);
     from_or_default(j, "widescreen_sky_match", g_widescreen_sky_match);
+    from_or_default(j, "no_lod", g_no_lod);
     // Sanity-bound the window size: below the N64 framebuffer is useless, above 8K
     // is a typo -- either way SDL_CreateWindow would fail and the port would run
     // permanently headless, so reset to defaults instead.
@@ -281,6 +290,14 @@ bool widescreen_sky_match() {
         return v[0] == '1';
     }
     return g_widescreen_sky_match;
+}
+
+// LAMBO_NO_LOD=1/0 overrides the JSON key for headless capture/testing.
+bool no_lod() {
+    if (const char* v = std::getenv("LAMBO_NO_LOD")) {
+        return v[0] == '1';
+    }
+    return g_no_lod;
 }
 
 } // namespace config

--- a/src/lambo_config.h
+++ b/src/lambo_config.h
@@ -67,6 +67,11 @@ bool widescreen_fog_match();
 // LAMBO_SKY_MATCH_1P=1/0. Only flips a branch that 1P/2P already take.
 bool widescreen_sky_match();
 
+// Remove the ROM's per-mode LOD reductions (issues #87/#91): emit each track
+// segment's scenery layer in 2P-4P races like 1P does. graphics.json key
+// "no_lod" (default true), overridable by LAMBO_NO_LOD=1/0.
+bool no_lod();
+
 } // namespace config
 } // namespace lambo
 

--- a/src/lambo_no_lod.cpp
+++ b/src/lambo_no_lod.cpp
@@ -1,0 +1,21 @@
+// #87/#91: remove the ROM's per-mode LOD reductions. The scene builder
+// func_8000A6C0 draws each track segment as up to three sub-DLs from the
+// segment record (+0x4 road, +0x8 walls, +0xC far scenery) but emits the
+// scenery layer only when the player count at 0x800CE6A4 is < 2
+// (`slti $at, players, 2` / `beq $at, $zero` at 0x8000CFA0/0x8000CFA4 in the
+// segment loop and 0x8000D834/0x8000D838 for the camera's own segment), so
+// 2P-4P races lose the distant canyon walls entirely -- seen as "short draw
+// distance" and pop-in. [[patches.hook]]s before each beq route $at through
+// here: returning 1 makes every mode take the branch the way 1P takes it.
+// The emit still self-gates on the record's scenery pointer being non-null,
+// and the scenery DLs are streamed in all modes (verified from a 3P save
+// state: record+0xC pointers populated), so no geometry is synthesised here.
+
+#include <cstdint>
+
+#include "lambo_config.h"
+
+extern "C" uint32_t lambo_no_lod_scenery_guard(uint8_t* rdram, uint32_t at) {
+    (void)rdram;
+    return lambo::config::no_lod() ? 1u : at;
+}

--- a/src/stub_renderer.cpp
+++ b/src/stub_renderer.cpp
@@ -1377,7 +1377,42 @@ public:
             static int s_settle = 0;
             uint32_t w = *(const uint32_t*)(g_lambo_rdram + (0x800CE6AC - 0x80000000u));
             int state = (int)((w >> 16) & 0xFFFF);
-            if (!s_done && state >= 8 && ++s_settle >= 400) {
+            // LAMBO_RACE_DL_DUMP_AT="n1,n2,..." dumps at exact send_dl counts instead of the
+            // one-shot 400-frame settle -- lets a state-load run diff the frames around a
+            // pop-in without racing the settle timer. Each dump goes to <basename>-<n>.txt
+            // (+ .bin RDRAM snapshot per dump).
+            static const char* s_dump_at = std::getenv("LAMBO_RACE_DL_DUMP_AT");
+            if (s_dump_at) {
+                bool hit = false;
+                {   // parse the list each hit-check; counts are small and this is a debug knob
+                    const char* p = s_dump_at;
+                    while (*p) {
+                        long n = std::strtol(p, (char**)&p, 10);
+                        if (n == count) { hit = true; break; }
+                        while (*p && *p != ',') ++p;
+                        if (*p == ',') ++p;
+                    }
+                }
+                if (hit) {
+                    char path[512];
+                    std::snprintf(path, sizeof(path), "%s-%d.txt", s_race_dump, count);
+                    uint32_t dl_addr = (uint32_t)(int32_t)t->t.data_ptr;
+                    if (std::FILE* f = std::fopen(path, "w")) {
+                        std::fprintf(f, "# race DL dump send_dl=%d dl_addr=0x%08X state=%d\n",
+                                     count, dl_addr, state);
+                        uint32_t seg[16] = {0};
+                        dlinspect::dump_walk(g_lambo_rdram, dl_addr, seg, f, 0);
+                        std::fclose(f);
+                        std::snprintf(path, sizeof(path), "%s-%d.bin", s_race_dump, count);
+                        if (std::FILE* rf = std::fopen(path, "wb")) {
+                            std::fwrite(g_lambo_rdram, 1, 0x800000, rf);
+                            std::fclose(rf);
+                        }
+                        std::fprintf(stderr, "[racedl] dumped DL @0x%08X at send_dl=%d\n",
+                                     dl_addr, count);
+                    }
+                }
+            } else if (!s_done && state >= 8 && ++s_settle >= 400) {
                 char path[512];
                 std::snprintf(path, sizeof(path), "%s.txt", s_race_dump);
                 uint32_t dl_addr = (uint32_t)(int32_t)t->t.data_ptr;


### PR DESCRIPTION
Fixes the pop-in / short draw distance Adam reported in 3P multiplayer (save-state repro), part of the `no_lod` epic #87 and the config-key half of #91.

## Root cause

The scene DL builder `func_8000A6C0` draws each track segment as up to three sub-DLs from its 64-byte segment record: `+0x4` road, `+0x8` walls, `+0xC` far scenery (distant canyon relief, trees, trackside structures like the clifftop castle). The scenery emit is gated on `slti $at, players, 0x2` + `beq $at, $zero` at `0x8000CFA0/0x8000CFA4` (segment loop, after a `record+0xC != 0` check) and `0x8000D834/0x8000D838` (the camera's own segment). **2P, 3P and 4P races never draw the scenery layer at all.** With #83's fog match (the near-black variant-2 fog used to hide the gap), the missing distance became visible as pop-in.

Found by diffing per-frame DL dumps around the pop (new `LAMBO_RACE_DL_DUMP_AT` knob) + a gdb hardware watchpoint on the frame-DL slot: 1P emits segment groups as layer triples, 3P as pairs with the `0x8028xxxx` scenery DLs never called — while the scenery data is streamed and resident in all modes (verified from the 3P save state's RDRAM: `record+0xC` pointers populated).

## Fix

- `graphics.json` key **`no_lod`** (default true, `LAMBO_NO_LOD=1/0` env override), the #91 template.
- Two `[[patches.hook]]` branch guards (same mechanism as #84's sky guard, carried in both `lamborghini.us.toml` and `gen_syms_toml.py` PATCH_BLOCKS) route `$at` through `lambo_no_lod_scenery_guard` so every mode takes the branch the way 1P does. The per-record null check still applies; no geometry is synthesised.

## Verification

- From the reporter's 3P save state: scenery present in all three viewports from the paused frame on, no chunk pop across the unpause sequence (before: bare grey gap, castle/trees/hills absent).
- `LAMBO_NO_LOD=0` produces a frame **pixel-identical** to the pre-patch binary (clean off-switch, and proves the hook is the only behavioural change).
- 1P warp race unchanged; 4P warp race shows scenery in all quadrants, no DL corruption (frame DL 6091 -> 7000 walked commands, ENDDL reached).
- Host tests pass (`test_hud_shift_scale`, `test_gpu_advisory`, `test_crash_whitelist`).

## Also in this PR

- `LAMBO_RACE_DL_DUMP_AT="n1,n2,..."` — dump the walked frame DL + RDRAM at exact send_dl counts (pairs with `LAMBO_STATE_LOAD` for deterministic around-the-pop diffs).
- `docs/no_lod_audit.md` addendum: corrects the audit's "per-mode draw distance measured intact" conclusion, documents the scanner's FP-compare-only blind spot (this gate is an integer `slti`), and records the residual open question (1P emits 5 segment groups vs 3-4 per 3P viewport at the same spot — not visibly popping now that scenery fills the horizon).
