### PR TITLE
Keep modern Intel GPUs on D3D12; auto-retry the other backend (#109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,18 @@ N64Recomp ports (Zelda 64: Recompiled et al.):
 ## Troubleshooting
 
 **Black screen / `vkQueueSubmit failed` spam on Intel graphics.** Intel drivers
-older than 31.0.101.2115 are known-broken with RT64: the renderer avoids Direct3D 12
-on them, and on newer Intel GPUs (e.g. Iris Xe) stuck on an old driver the Vulkan
-fallback then loses the device. The game detects this at startup and shows a warning.
-The fix is to update the Intel graphics driver (Windows Update or
+older than 31.0.101.2115 trip an RT64 workaround that avoids Direct3D 12; on the
+6th-gen HD Graphics parts it was written for, D3D12 removes the device, but on newer
+Intel GPUs (Iris Xe, Arc) stuck on an old driver it is the Vulkan fallback that loses
+the device. The game now keeps those modern Intel GPUs on Direct3D 12 automatically,
+so this should no longer happen out of the box — but the real fix is still to update
+the Intel graphics driver (Windows Update or
 [intel.com/download-center](https://www.intel.com/content/www/us/en/download-center/home.html)).
-If you cannot update, set `"api_option": "D3D12"` in `graphics.json` to stay on
-Direct3D 12 instead.
+
+**Still a black screen, or a different GPU?** Force a specific backend by setting
+`"api_option"` in `graphics.json` to `"D3D12"` or `"Vulkan"`. On Windows the game also
+retries the other backend automatically if your chosen one fails to initialise, so a
+bad `api_option` no longer strands you on a black screen.
 
 ## Developer warp (race-track warp)
 

--- a/patches/0010-rt64-intel-explicit-d3d12-escape-hatch.patch
+++ b/patches/0010-rt64-intel-explicit-d3d12-escape-hatch.patch
@@ -2,16 +2,22 @@ diff --git a/src/hle/rt64_application.cpp b/src/hle/rt64_application.cpp
 index 785de27..204810b 100644
 --- a/src/hle/rt64_application.cpp
 +++ b/src/hle/rt64_application.cpp
-@@ -250,8 +250,11 @@ namespace RT64 {
+@@ -250,8 +250,17 @@ namespace RT64 {
          else if (deviceDescription.vendor == RenderDeviceVendor::INTEL) {
              if (chosenGraphicsAPI == UserConfiguration::GraphicsAPI::D3D12) {
                  // End of life driver for Intel 6th Gen Processor Graphics. D3D12 fails with DXGI_ERROR_DEVICE_REMOVED after running a display list in RT64. Vulkan has been reported to work fine on this driver.
 +                // Only applied when the API choice is automatic: on newer Intel GPUs stuck on old drivers
 +                // (e.g. Iris Xe on 30.0.101.x) Vulkan is the one that fails (VK_ERROR_DEVICE_LOST), so an
 +                // explicit D3D12 selection must win as an escape hatch.
++                //
++                // Also skip the fallback for Gen12+ parts (Iris Xe, Arc): they have no D3D12
++                // device-removal bug, so forcing them onto Vulkan on an old driver just moves them
++                // onto the path that device-LOSES (issue #109). Keep them on D3D12 by name.
++                const bool isModernIntel = (deviceDescription.name.find("Xe") != std::string::npos)
++                    || (deviceDescription.name.find("Arc") != std::string::npos);
                  const uint64_t BrokenIntelDriverD3D12 = 0x1F000000650843; // 31.0.101.2115
 -                if (deviceDescription.driverVersion <= BrokenIntelDriverD3D12) {
-+                if (automaticGraphicsAPI && (deviceDescription.driverVersion <= BrokenIntelDriverD3D12)) {
++                if (automaticGraphicsAPI && !isModernIntel && (deviceDescription.driverVersion <= BrokenIntelDriverD3D12)) {
                      forceVulkanForCompatibility = true;
                  }
              }

--- a/src/lambo_gpu_advisory.cpp
+++ b/src/lambo_gpu_advisory.cpp
@@ -20,11 +20,30 @@ int lambo_gpu_intel_driver_predates_fix(uint64_t driver_version) {
     return driver_version <= kBrokenIntelDriverD3D12 ? 1 : 0;
 }
 
-int lambo_gpu_advisory_severity(uint32_t vendor, uint64_t driver_version, int running_vulkan) {
+int lambo_gpu_name_is_modern_intel(const char* device_name) {
+    if (device_name == nullptr) {
+        return 0;
+    }
+    // Gen12+ marketing names: "Intel(R) Iris(R) Xe Graphics", "Intel(R) Arc(TM) ...".
+    // 6th-gen (D3D12-broken) names are "HD Graphics 5xx" / "Iris (Pro) Graphics 5xx"
+    // and contain neither token, so they correctly fall through to RT64's fallback.
+    return (std::strstr(device_name, "Xe") || std::strstr(device_name, "Arc")) ? 1 : 0;
+}
+
+int lambo_gpu_advisory_severity(uint32_t vendor, uint64_t driver_version,
+                                int running_vulkan, const char* device_name) {
     if (vendor != LAMBO_GPU_VENDOR_INTEL || !lambo_gpu_intel_driver_predates_fix(driver_version)) {
         return LAMBO_GPU_ADVISORY_NONE;
     }
-    return running_vulkan ? LAMBO_GPU_ADVISORY_SEVERE : LAMBO_GPU_ADVISORY_INFO;
+    if (!running_vulkan) {
+        return LAMBO_GPU_ADVISORY_INFO; // on D3D12: works, driver merely old.
+    }
+    // On Vulkan with an old driver: only a MODERN Intel part is in trouble here
+    // (device loss -> black screen). A 6th-gen part on Vulkan is RT64 doing the
+    // right thing -- D3D12 would device-remove -- so that is INFO, not SEVERE.
+    return lambo_gpu_name_is_modern_intel(device_name)
+        ? LAMBO_GPU_ADVISORY_SEVERE
+        : LAMBO_GPU_ADVISORY_INFO;
 }
 
 static char g_pending_text[1024];

--- a/src/lambo_gpu_advisory.h
+++ b/src/lambo_gpu_advisory.h
@@ -30,9 +30,21 @@ void lambo_gpu_format_driver_version(uint64_t driver_version, char* out, size_t 
 // or below 31.0.101.2115 are forced onto Vulkan when the API choice is automatic.
 int lambo_gpu_intel_driver_predates_fix(uint64_t driver_version);
 
+// True for Gen12+ Intel iGPUs/dGPUs (Iris Xe, Arc), identified by the "Xe"/"Arc"
+// substring in the device name. These have no D3D12 device-removal bug, so RT64's
+// old-driver force-Vulkan (written for 6th-gen HD Graphics that DO device-remove on
+// D3D12) is wrong for them: it pushes them onto the Vulkan path that device-LOSES
+// (issue #109). patches/0010 uses the same substring test to keep them on D3D12.
+// NULL/empty name -> 0 (unknown, keep RT64's conservative fallback).
+int lambo_gpu_name_is_modern_intel(const char* device_name);
+
 // Classify the post-setup device state. running_vulkan reflects the API that was
 // actually chosen (after any RT64 fallback), not what the config asked for.
-int lambo_gpu_advisory_severity(uint32_t vendor, uint64_t driver_version, int running_vulkan);
+// device_name distinguishes a modern Intel iGPU wrongly on Vulkan (SEVERE: the #109
+// device-loss black screen) from a 6th-gen part correctly on Vulkan (INFO: working,
+// driver merely old). NULL name is treated as not-modern.
+int lambo_gpu_advisory_severity(uint32_t vendor, uint64_t driver_version,
+                                int running_vulkan, const char* device_name);
 
 // Build the user-facing advisory text for a non-NONE severity. config_path is the
 // absolute graphics.json path shown to the user for the api_option escape hatch.

--- a/src/rt64_renderer.cpp
+++ b/src/rt64_renderer.cpp
@@ -185,7 +185,8 @@ void warn_about_gpu_driver(RT64::Application* app, ultramodern::renderer::Graphi
     }
     const int severity = lambo_gpu_advisory_severity(
         vendor, driver_version,
-        chosen_api == ultramodern::renderer::GraphicsApi::Vulkan ? 1 : 0);
+        chosen_api == ultramodern::renderer::GraphicsApi::Vulkan ? 1 : 0,
+        desc.name.c_str());
     if (severity == LAMBO_GPU_ADVISORY_NONE) {
         return;
     }
@@ -258,34 +259,63 @@ public:
         appConfig.appId = "lamborghini-recomp";
         appConfig.useConfigurationFile = false;
 
-        app = std::make_unique<RT64::Application>(appCore, appConfig);
-
         auto& cur_config = ultramodern::renderer::get_graphics_config();
-        set_application_user_config(app.get(), cur_config);
-        app->userConfig.developerMode = debug;
-        // Force gbi depth branches to prevent LODs from kicking in (Zelda64Recomp default).
-        app->enhancementConfig.f3dex.forceBranch = true;
-        // Scale LODs based on the output resolution.
-        app->enhancementConfig.textureLOD.scale = true;
-
-        switch (cur_config.api_option) {
-            case ultramodern::renderer::GraphicsApi::D3D12:  app->userConfig.graphicsAPI = RT64::UserConfiguration::GraphicsAPI::D3D12; break;
-            case ultramodern::renderer::GraphicsApi::Vulkan: app->userConfig.graphicsAPI = RT64::UserConfiguration::GraphicsAPI::Vulkan; break;
-            case ultramodern::renderer::GraphicsApi::Metal:  app->userConfig.graphicsAPI = RT64::UserConfiguration::GraphicsAPI::Metal; break;
-            default:                                         app->userConfig.graphicsAPI = RT64::UserConfiguration::GraphicsAPI::Automatic; break;
-        }
-
         uint32_t thread_id = 0;
 #ifdef _WIN32
         thread_id = window_handle.thread_id;
 #endif
-        setup_result = map_setup_result(app->setup(thread_id));
-        chosen_api = map_graphics_api(app->chosenGraphicsAPI);
-        if (setup_result != ultramodern::renderer::SetupResult::Success) {
-            std::fprintf(stderr, "[rt64] RT64::Application::setup FAILED (SetupResult=%d)\n",
-                         (int)setup_result);
-            app = nullptr;
-            return;
+
+        auto to_rt64_api = [](ultramodern::renderer::GraphicsApi a) {
+            switch (a) {
+                case ultramodern::renderer::GraphicsApi::D3D12:  return RT64::UserConfiguration::GraphicsAPI::D3D12;
+                case ultramodern::renderer::GraphicsApi::Vulkan: return RT64::UserConfiguration::GraphicsAPI::Vulkan;
+                case ultramodern::renderer::GraphicsApi::Metal:  return RT64::UserConfiguration::GraphicsAPI::Metal;
+                default:                                         return RT64::UserConfiguration::GraphicsAPI::Automatic;
+            }
+        };
+
+        // (Re)create and set up the RT64 application under a specific backend. Split
+        // out so we can retry the other backend below without duplicating the wiring.
+        auto try_setup = [&](RT64::UserConfiguration::GraphicsAPI api) {
+            app = std::make_unique<RT64::Application>(appCore, appConfig);
+            set_application_user_config(app.get(), cur_config);
+            app->userConfig.developerMode = debug;
+            // Force gbi depth branches to prevent LODs from kicking in (Zelda64Recomp default).
+            app->enhancementConfig.f3dex.forceBranch = true;
+            // Scale LODs based on the output resolution.
+            app->enhancementConfig.textureLOD.scale = true;
+            app->userConfig.graphicsAPI = api;
+            setup_result = map_setup_result(app->setup(thread_id));
+            chosen_api = map_graphics_api(app->chosenGraphicsAPI);
+            return setup_result == ultramodern::renderer::SetupResult::Success;
+        };
+
+        if (!try_setup(to_rt64_api(cur_config.api_option))) {
+            std::fprintf(stderr, "[rt64] RT64::Application::setup FAILED (SetupResult=%d, api=%d)\n",
+                         (int)setup_result, (int)cur_config.api_option);
+            // RT64 auto-retries the other backend itself only when the API choice is
+            // Automatic. For an EXPLICIT choice that fails to initialise we flip once
+            // rather than leaving the user on a black screen -- a working game beats an
+            // honoured-but-dead preference. Auto and Metal have no Windows sibling to try.
+            RT64::UserConfiguration::GraphicsAPI fallback = RT64::UserConfiguration::GraphicsAPI::OptionCount;
+#ifdef _WIN32
+            if (cur_config.api_option == ultramodern::renderer::GraphicsApi::D3D12) {
+                fallback = RT64::UserConfiguration::GraphicsAPI::Vulkan;
+            } else if (cur_config.api_option == ultramodern::renderer::GraphicsApi::Vulkan) {
+                fallback = RT64::UserConfiguration::GraphicsAPI::D3D12;
+            }
+#endif
+            if (fallback == RT64::UserConfiguration::GraphicsAPI::OptionCount) {
+                app = nullptr;
+                return;
+            }
+            std::fprintf(stderr, "[rt64] retrying with the other graphics API...\n");
+            if (!try_setup(fallback)) {
+                std::fprintf(stderr, "[rt64] retry also FAILED (SetupResult=%d)\n", (int)setup_result);
+                app = nullptr;
+                return;
+            }
+            std::fprintf(stderr, "[rt64] retry succeeded (api=%d)\n", (int)chosen_api);
         }
 
         std::fprintf(stderr, "[rt64] RT64 renderer initialised (api=%d)\n", (int)chosen_api);

--- a/tests/test_gpu_advisory.cpp
+++ b/tests/test_gpu_advisory.cpp
@@ -44,18 +44,32 @@ int main() {
     CHECK(lambo_gpu_intel_driver_predates_fix(kRT64Threshold + 1) == 0);
     CHECK(lambo_gpu_intel_driver_predates_fix(kModernDriver) == 0);
 
+    // --- modern-Intel discriminator (Xe/Arc keep D3D12; #109 core fix) ----------
+    CHECK(lambo_gpu_name_is_modern_intel("Intel(R) Iris(R) Xe Graphics") == 1);
+    CHECK(lambo_gpu_name_is_modern_intel("Intel(R) Arc(TM) A770 Graphics") == 1);
+    CHECK(lambo_gpu_name_is_modern_intel("Intel(R) HD Graphics 530") == 0);   // 6th-gen
+    CHECK(lambo_gpu_name_is_modern_intel("Intel(R) Iris(R) Pro Graphics 580") == 0);
+    CHECK(lambo_gpu_name_is_modern_intel(nullptr) == 0);
+    CHECK(lambo_gpu_name_is_modern_intel("") == 0);
+
     // --- severity matrix --------------------------------------------------------
-    // Old Intel driver running Vulkan = the exact #109 failure: severe.
-    CHECK(lambo_gpu_advisory_severity(LAMBO_GPU_VENDOR_INTEL, kReporterDriver, /*vulkan*/1)
+    const char* kXe   = "Intel(R) Iris(R) Xe Graphics";
+    const char* k6thGen = "Intel(R) HD Graphics 530";
+    // Modern Intel on Vulkan with an old driver = the exact #109 failure: severe.
+    CHECK(lambo_gpu_advisory_severity(LAMBO_GPU_VENDOR_INTEL, kReporterDriver, /*vulkan*/1, kXe)
           == LAMBO_GPU_ADVISORY_SEVERE);
-    // Old Intel driver on D3D12 (user escape hatch active): still worth a note.
-    CHECK(lambo_gpu_advisory_severity(LAMBO_GPU_VENDOR_INTEL, kReporterDriver, /*vulkan*/0)
+    // Modern Intel on D3D12 (now the default after the narrowing): works, just note it.
+    CHECK(lambo_gpu_advisory_severity(LAMBO_GPU_VENDOR_INTEL, kReporterDriver, /*vulkan*/0, kXe)
           == LAMBO_GPU_ADVISORY_INFO);
-    // Up-to-date Intel driver: silence.
-    CHECK(lambo_gpu_advisory_severity(LAMBO_GPU_VENDOR_INTEL, kModernDriver, 1)
+    // 6th-gen on Vulkan is RT64 doing the RIGHT thing (D3D12 would device-remove):
+    // do NOT scare the user with a black-screen popup -- just a note.
+    CHECK(lambo_gpu_advisory_severity(LAMBO_GPU_VENDOR_INTEL, kReporterDriver, /*vulkan*/1, k6thGen)
+          == LAMBO_GPU_ADVISORY_INFO);
+    // Up-to-date Intel driver: silence, regardless of GPU/API.
+    CHECK(lambo_gpu_advisory_severity(LAMBO_GPU_VENDOR_INTEL, kModernDriver, 1, kXe)
           == LAMBO_GPU_ADVISORY_NONE);
     // Other vendors: not our advisory, even on ancient drivers.
-    CHECK(lambo_gpu_advisory_severity(0x10DEu /*NVIDIA*/, kReporterDriver, 1)
+    CHECK(lambo_gpu_advisory_severity(0x10DEu /*NVIDIA*/, kReporterDriver, 1, kXe)
           == LAMBO_GPU_ADVISORY_NONE);
 
     // --- the user-facing message ------------------------------------------------


### PR DESCRIPTION
Closes #109.

## Problem
RT64 force-switches D3D12→Vulkan for **any** Intel GPU on a driver ≤ 31.0.101.2115. That workaround was written for 6th-gen HD Graphics, which device-*remove* on D3D12 — but it wrongly also catches Gen12 **Iris Xe / Arc**, where D3D12 works and it's *Vulkan* that loses the device (`VK_ERROR_DEVICE_LOST` → silent black screen). #109 shipped a manual escape hatch (edit `graphics.json`) + advisory; two more users hit the wall, so this makes it work by default.

## Changes
- **`patches/0010`** — narrow the Intel force-Vulkan to exclude modern Intel (device name contains `Xe`/`Arc`), so those parts stay on D3D12 **automatically, default config, no JSON edit**. Genuine 6th-gen parts keep today's Vulkan fallback → no regression. (Name-matching mirrors RT64's own idiom, e.g. the AMD branch's `name.find("AMD Radeon RX 7")`.)
- **`rt64_renderer.cpp`** — if an *explicit* `api_option` fails to initialise, retry the other Windows backend once before giving up (RT64 only self-retries for `Auto`).
- **`lambo_gpu_advisory.{h,cpp}`** — advisory severity is now device-name-aware: modern Intel stuck on Vulkan = SEVERE (the #109 black screen); a 6th-gen part correctly on Vulkan = INFO, no scary popup.
- **`README.md`** — troubleshooting reflects the automatic behaviour.

## Verification
- Host unit test (`tests/test_gpu_advisory.cpp`, extended with the 6th-gen-vs-modern matrix + `strstr` discriminator) — **PASS** (`-Wall -Wextra` clean).
- `patches/0010` apply-checked against pristine RT64 — clean.
- Full `build.ps1` — **exit 0**, `lamborghini_modern.exe` links.
- Boot smoke (RT64, 300 VIs) — **exit 0**, D3D12 on RTX 3080, state 0→1→2, clean exit; changes verified inert on the non-Intel path (no advisory, no retry).
- Advisory end-to-end via `LAMBO_FAKE_GPU` — INFO variant fires correctly.

## Known limitation (follow-up)
The retry catches *setup-time* failure only. A user who **explicitly** sets `"api_option":"Vulkan"` on an old-driver Iris Xe still hits runtime device-loss (setup succeeds, then `vkQueueSubmit` fails mid-render). The default path is fully covered by the narrowing, and that explicit-Vulkan combo still gets the **SEVERE advisory popup** rather than a silent black screen. Runtime device-loss recovery would need deeper RT64 present-queue surgery — tracked separately.

Note: I couldn't empirically exercise the Intel force-Vulkan narrowing on this box (no Intel GPU) — it rests on code inspection, the applied patch, and the unit-tested severity logic. A real Iris Xe confirmation from an affected user would close the loop.
