### PR TITLE
Add release skill: tag, dispatch, verify, and ship notes for new releases

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: release
+description: User-invoked skill for cutting a new release of this project. Walks through tagging the merge commit, dispatching the Build & Release workflow, waiting for the binaries, and replacing the workflow's placeholder notes with the rich release-notes body. Deterministic steps live in scripts/ — Claude fills in the variable parts (the notes body, the headline).
+disable-model-invocation: true
+---
+
+# Release
+
+Cut a new release of **Automobili Lamborghini Recompiled**. The pattern is
+intentionally narrow: this project's releases follow a fixed tag-and-build
+sequence, and the only variable part is the release-notes body. Scripts in
+`scripts/` do everything that's deterministic; Claude fills in the prose.
+
+The expected output is a published GitHub release at
+`https://github.com/alondero/automobililamborghini-recomp/releases/tag/<tag>`
+with `draft: false, prerelease: false` (matching v0.1.0 / v0.3.0 / v0.4.0 /
+v0.4.1 / v0.4.2 — see `references/prior-release-format.md`), the workflow's
+two build artifacts attached, and rich release-notes body replacing the
+`Automated build from commit ...` placeholder.
+
+## When to invoke
+
+The user says something like "create a release", "cut a v0.4.3", "ship what
+we've got", "release 0.5.0", or references this skill by name (`/release`).
+
+## Inputs
+
+- **version** (required) — e.g. `v0.4.3`. Must match `v<MAJOR>.<MINOR>.<PATCH>`.
+- **base tag** (optional, default: previous release tag) — for the diff
+  ("Closed since v0.4.2"). If unspecified, use the most recent tag reachable
+  from HEAD that isn't a release tag.
+
+## Flow
+
+The skill runs five scripts in order. After each, Claude reads the output and
+either proceeds or surfaces a diagnostic. The scripts are designed to be
+re-runnable; if one fails partway, fix the upstream issue and re-run.
+
+### 1. List changes since the base tag
+
+```
+./scripts/list-changes.sh <base-tag>
+```
+
+Prints a structured summary of:
+- merged PRs since `<base-tag>` (number, title, merge date)
+- closed issues since `<base-tag>` (number, title)
+- the merge commit at HEAD (where the new tag will land)
+
+Use this to draft the "Closed since <prev-version>" section of the notes.
+Read each PR's body via `gh pr view <N>` for the prose context.
+
+### 2. Tag the merge commit and dispatch the workflow
+
+```
+./scripts/tag-and-dispatch.sh <version>
+```
+
+Does, in order:
+1. Find the merge commit at HEAD on `main`
+2. `git tag <version> <merge-sha>`
+3. `git push origin <version>`
+4. `gh workflow run "Build & Release" --ref main \
+        -f tag=<version> -f prerelease=false -f draft=false`
+
+The script does NOT take `--prerelease=true --draft=true`. Those flags trigger
+the `untagged-<id>` URL trap documented in `references/gotchas.md` — every
+prior release (v0.1.0 / v0.3.0 / v0.4.0 / v0.4.1 / v0.4.2) was dispatched
+with `--prerelease=false --draft=false`.
+
+Prints the workflow run ID — needed by step 3.
+
+### 3. Wait for the build
+
+```
+./scripts/wait-for-build.sh <run-id>
+```
+
+`gh run watch <run-id> --exit-status --interval 30` — blocks until the run
+finishes. Expected wall time: ~5 min for Linux, ~10-13 min for Windows, ~5 s
+for the `release` job. Exits non-zero on build failure.
+
+### 4. Verify the release is properly bound
+
+```
+./scripts/verify-release.sh <version>
+```
+
+Checks, in order:
+1. Git tag exists on origin (`git ls-remote --tags origin <version>`)
+2. Release accessible via `gh api .../releases/tags/<version>` (not 404)
+3. `html_url` ends with `releases/tag/<version>` (NOT `untagged-<id>`)
+4. `isDraft: false`, `isPrerelease: false`
+5. Both expected assets uploaded (`lamborghini-recomp-{linux,windows}-x64.zip`)
+
+If any check fails, prints a diagnostic and exits non-zero. Common failures:
+- workflow hasn't finished → re-run after a moment
+- URL is `untagged-<id>` → the `--draft` trap; see `references/gotchas.md`
+
+### 5. Update the notes
+
+```
+./scripts/update-notes.sh <version> <path-to-notes.md>
+```
+
+`gh release edit <version> --notes-file <path>` — replaces the workflow's
+placeholder notes with the rich body. The notes file should match the
+template in `references/release-notes-template.md`.
+
+## Variable parts (handled by Claude)
+
+- **Release-notes body** — drafted from `references/release-notes-template.md`,
+  filled in with the PR/issue summary from step 1 and prose from each PR body.
+  Output goes in `<drafts>/<version>-release-notes.md` for the user to review,
+  then handed to step 5.
+- **Headline of the "What's working" section** — pick the single most
+  user-visible change since the base tag. For v0.4.2 this was "Intel Xe/Arc
+  no longer needs a `graphics.json` edit". For a feature release, it's the
+  headline feature.
+- **"What's not done yet" follow-ups** — any open issues referenced in the
+  PRs that ship as known gaps.
+
+## Reference files
+
+Read these when you need them — don't load them all upfront.
+
+- `references/release-notes-template.md` — the skeleton with all required
+  sections and placeholder text.
+- `references/gotchas.md` — the four lessons from the v0.4.1 → v0.4.2
+  release cycle (the `--draft` URL trap, the merge-commit tagging pattern,
+  the actual GitHub flag values vs body copy, the workflow's placeholder
+  notes). Read this before doing anything.
+- `references/prior-release-format.md` — the v0.1.0 / v0.3.0 / v0.4.0 /
+  v0.4.1 / v0.4.2 release bodies side-by-side, so you can match the
+  voice and structure for the new notes.

--- a/.claude/skills/release/references/gotchas.md
+++ b/.claude/skills/release/references/gotchas.md
@@ -1,0 +1,100 @@
+# Gotchas
+
+Four non-obvious things that have all bitten us in this project's release
+flow. Read this before doing anything; if a `gh` command in the skill
+behaves unexpectedly, the answer is usually here.
+
+## 1. `gh release create --draft` puts the release under `untagged-<id>`
+
+This is the single biggest trap in the release flow.
+
+**Symptom**: After `gh release create <tag> ... --draft --prerelease`, the
+release exists, has the right `tag_name`, has assets, has notes — but:
+
+- `gh api repos/<owner>/<repo>/releases/tags/<tag>` returns **404**.
+- The `html_url` ends in `untagged-<hash>` instead of `<tag>`.
+
+**Root cause**: GitHub stores draft releases under a synthetic `untagged-<id>`
+URL even when the underlying git tag exists on origin. The flag combination
+matters more than the tag's actual presence in the refs.
+
+**Fix**: Do NOT pass `--draft` to `gh release create`. Create the release
+"live" (still as `draft:false, prerelease:false`) and let `verify-release.sh`
+confirm. If you actually want a pre-publish review, create it without
+`--draft`, then use `gh release edit <tag> --draft=true` to flip the flag
+afterward — the URL stays properly bound because the release was created
+without `--draft`.
+
+**Why this matters for this project**: The Build & Release workflow has
+inputs `prerelease` and `draft`, both default `true`. Every prior release
+(v0.1.0 / v0.3.0 / v0.4.0 / v0.4.1 / v0.4.2) was actually dispatched with
+`prerelease=false, draft=false` — see the v0.4.0 workflow log where the
+conditional expansion evaluated to empty. Always dispatch the workflow with
+`-f prerelease=false -f draft=false` to avoid the trap.
+
+## 2. Tag at the merge commit, not the feature commit
+
+Every prior release tag in this repo points at a merge commit on `main`,
+not at the feature commit:
+
+| tag | commit | subject |
+|-----|--------|---------|
+| v0.4.0 | `5e07da1` | Merge pull request #94 from alondero/gh78-widescreen-3p4p-... |
+| v0.4.1 | `1f489fb` | Merge pull request #112 from alondero/inbred-rebellious-sphinx |
+| v0.4.2 | `03e533a` | Merge pull request #113 from alondero/significant-significant-bolt |
+
+The merge commit is the smallest unit that includes the new code AND the
+issue/PR reference in the subject. Feature commits come and go; merge
+commits mark the "this PR landed on main" moment, which is what release
+notes link to.
+
+The `tag-and-dispatch.sh` script enforces this — it refuses to tag if HEAD
+isn't a merge commit.
+
+## 3. The release's `prerelease` flag is `false` — "Pre-release quality" is body copy
+
+This is a contradiction in the project's release naming that's confused
+every new contributor (and me, twice):
+
+- The release notes' opening blockquote says "**Pre-release quality.**"
+- The GitHub release's `prerelease` flag is **false**.
+
+The blockquote is the *project's* self-description (mirror of semver's
+"anything <1.0 is pre-release"). The flag is GitHub's mechanism for showing
+the release with a "Pre-release" badge in the UI. The project has decided
+not to use the badge — confirmed by inspecting the v0.1.0/v0.3.0/v0.4.0
+releases via the GitHub API, all of which have `prerelease: false`.
+
+`verify-release.sh` checks this and will fail loudly if a release gets
+flagged `prerelease: true` — that's a deliberate gate so we don't
+accidentally introduce a different convention.
+
+## 4. The workflow's release-notes placeholder must be replaced after the build
+
+The `Build & Release` workflow's release job runs:
+
+```bash
+gh release create "$tag" <assets> \
+  --notes "Automated build from commit $GITHUB_SHA. ..."
+```
+
+That placeholder is fine for the in-flight workflow but is the user-facing
+release body. Step 5 of the skill (`update-notes.sh`) replaces it with the
+real release notes drafted from `release-notes-template.md`. If you skip
+step 5, users downloading the binary see a useless placeholder.
+
+## Quick diagnostic flow
+
+If a release looks wrong, walk down this list:
+
+1. `git ls-remote --tags origin <tag>` — does the tag exist?
+2. `gh api repos/.../releases/tags/<tag>` — does the API see it?
+   - 404 → workflow hasn't finished OR `--draft` trap (gotcha #1)
+3. `gh release view <tag> --json htmlUrl,isDraft,isPrerelease` — sanity check
+   - `untagged-` in url → `--draft` trap (gotcha #1)
+   - `isDraft: true` → publish via UI or `gh release edit <tag> --draft=false`
+   - `isPrerelease: true` → almost certainly a misconfig (gotcha #3)
+4. `gh release view <tag> --json body --jq '.body' | head -n 3` — placeholder
+   notes? Run `update-notes.sh`.
+
+`verify-release.sh` automates all of this; trust its output.

--- a/.claude/skills/release/references/prior-release-format.md
+++ b/.claude/skills/release/references/prior-release-format.md
@@ -1,0 +1,167 @@
+# Prior release format reference
+
+The shape of v0.1.0 / v0.3.0 / v0.4.0 / v0.4.1 / v0.4.2 release notes,
+side-by-side. Use this to match voice and structure when drafting the next
+release — readers compare releases by scanning these sections in parallel.
+
+## Common header (every release)
+
+Every prior release opens with this exact blockquote:
+
+> **Pre-release quality.** Built from `main` for early testing and feedback.
+> Expect rough edges — crashes, audio glitches, and missing native
+> translations are still the rule, not the exception. Please open issues
+> rather than running off the latest commit silently.
+
+Don't paraphrase. The "Pre-release quality" word "Pre-release" is the
+project's voice; rewriting it dilutes the convention.
+
+The "## ⚠️ You must supply your own ROM" section is also identical across
+releases — same three-step "extract → drop ROM → launch" instructions,
+same save-path note. The wording is stable; copy it verbatim.
+
+## What's working — headline pattern
+
+The first paragraph of "What's working" is the single most important
+sentence in the release. The pattern is:
+
+1. State the high-level capability (game is playable, widescreen works,
+   rumble works).
+2. Name THE one change that's the headline for this release.
+3. Optionally quantify (X fixes, Y new knobs).
+4. End with "There's still glitches so please report issues you find." —
+   this line is in every prior release.
+
+Examples from real releases:
+
+- **v0.4.0**: "The headline of this release is **3- and 4-player
+  split-screen**: the 2×2 quadrant views used to be pillarboxed with dark
+  side bars, and now each quarter fills its slice of a wide monitor —
+  with the per-quadrant HUD text, minimap, fog, and sky all tracking the
+  wide frame."
+- **v0.4.1**: "The headline of this release is **N64 Rumble Pak support**:
+  the ROM's per-frame PWM rumble engine now drives SDL pad rumble at the
+  moments ares rumbles (with the Controller Pak save flow intact in the
+  same session). Two follow-up fixes round out this release — ..."
+- **v0.4.2**: "This is a small follow-up to the v0.4.1 Intel driver
+  advisory (#110): where v0.4.1 shipped a manual escape hatch that
+  required editing `graphics.json`, **v0.4.2 makes the fix automatic for
+  modern Intel** — affected users no longer need to take any action."
+
+Notice the v0.4.2 example explicitly frames itself as a follow-up — that's
+the right move when a release has a single small change.
+
+## Closed since — category names
+
+The "Closed since" list groups by theme, not by PR. Categories that have
+actually been used:
+
+| Category | Used in |
+|----------|---------|
+| Widescreen graphics | v0.3.0 |
+| Widescreen — 3P/4P split screen | v0.4.0 |
+| Widescreen — skybox | v0.4.0 |
+| Rumble | v0.4.1 |
+| Stability | v0.4.0 |
+| Stability / driver compatibility | v0.4.2 |
+| Widescreen / multiplayer | v0.4.1, v0.4.2 |
+| Developer tooling | v0.4.0, v0.4.1 |
+| Developer tooling (now ships in the binary) | v0.3.0 |
+| CI / build | v0.3.0 |
+| Release packaging / CI | v0.4.0 |
+| Project / developer docs | v0.4.0 |
+| Texture tooling (developer-facing) | v0.3.0 |
+
+A single-category release (like v0.4.2) is fine — don't pad. A multi-PR
+release (like v0.4.0) usually gets 3-5 categories.
+
+## Bullet format
+
+Each bullet follows the same shape:
+
+```
+- **#<ISSUE> / PR #<PR>** — <prose>. <mechanism details>. <numbers>. <links>.
+```
+
+Real examples:
+
+- **v0.4.1**: "- **#101 / PR #108** — N64 Rumble Pak now rumbles the SDL
+  controller in a real race. The ROM issues raw SI motor frames through a
+  custom start/stop pair (audit in #102 / PR #107 — the ROM carries a
+  complete per-frame PWM engine with per-channel intensity, every link in
+  the chain is emitted and reachable). The port now forces the
+  rumble-present flag and runs native `osMotorStart` / `osMotorStop`
+  stubs..."
+
+- **v0.4.2**: "- **#109 follow-up / PR #113** — Modern Intel GPUs (Iris Xe
+  / Arc) now stay on D3D12 *automatically* — no `graphics.json` edit
+  needed. v0.4.1's patch 0010 only worked when the user manually set
+  `"api_option": "D3D12"`; two more users hit the silent black-screen
+  wall before finding the workaround, so this makes it the default. The
+  Intel force-Vulkan fallback in RT64 was originally written for 6th-gen
+  HD Graphics (which device-*remove* on D3D12), but it was wrongly
+  catching Gen12 Xe / Arc..."
+
+Lead with the user benefit, then the mechanism. Numbers like "79 motor-start
+/ 2395 motor-stop events" or "5 vs 3-4 segment groups" are great — they
+make the change concrete. Inline code for env vars (`LAMBO_PAK_TRACE`,
+`LAMBO_NO_LOD`).
+
+## What's not done yet
+
+The opening paragraph is fixed:
+
+> This is still pre-1.0 — plenty of `force_stub.txt` still includes real
+> game primitives rather than no-ops. The tracker is the canonical "what's
+> next" list.
+
+Below that, optional follow-up paragraph(s) name specific known gaps with
+issue numbers. v0.4.2 has one — about explicit-Vulkan-on-old-Iris-Xe
+runtime device-loss (tracked in #114). These are good to include because
+they tell users where to report if they hit the edge case.
+
+## How to run
+
+The "How to run" section is identical across every release. Linux: unzip,
+copy ROM, run. Windows: extract, drop ROM, double-click. Don't rewrite —
+copy verbatim.
+
+## Build provenance
+
+```
+- **Commit:** `<SHORT_SHA>` (main, <YYYY-MM-DD>)
+- **Workflow run:** [#<RUN_ID>][run] (Build & Release, dispatch from this SHA)
+- **Toolchain:** Linux build on `ubuntu-latest` with gcc / cmake / ninja /
+  `libsdl2-dev` / `libvulkan-dev`. Windows build on `windows-latest` with
+  MinGW-w64 GCC + Ninja (PowerShell, not MSYS bash) per the project's
+  toolchain notes.
+```
+
+The toolchain note is verbatim across releases — it's a permanent reminder
+about the MSYS bash / PowerShell quirk documented in CLAUDE.md.
+
+## Closing
+
+Always end with:
+
+---
+
+If you'd rather build it yourself from source instead of running a pre-built
+binary, see [BUILDING.md]. For graphics settings, see [README.md].
+
+[BUILDING.md]: https://github.com/alondero/automobililamborghini-recomp/blob/<VERSION>/BUILDING.md
+[README.md]: https://github.com/alondero/automobililamborghini-recomp/blob/<VERSION>/README.md
+[run]: https://github.com/alondero/automobililamborghini-recomp/actions/runs/<RUN_ID>
+
+With any additional `[docs/foo.md]:` link references for documents cited in
+the body (e.g. `[docs/rumble-triggers.md]:`).
+
+## Reference: actual prior-release SHAs
+
+For diffing/quoting:
+
+- **v0.4.2** — `03e533a1425bf8aa895c67affbb78b22986f411c` — workflow #29203966918
+- **v0.4.1** — `1f489fbcc3e6db1c82cd3fcbea27ebaf6ce3c866` — workflow #29198294316
+- **v0.4.0** — `5e07da1759fb8aa484a87b0ee210303d3921950b` — workflow #29082039804
+- **v0.3.0** — `9bef7dcd7df8aef0c2e5d5356f25ec62255611e2` — workflow #28996890290
+- **v0.1.0** — `6f3e7d914ce7b2b2424faec8d4acd56cbd785059` — workflow #28778465982

--- a/.claude/skills/release/references/release-notes-template.md
+++ b/.claude/skills/release/references/release-notes-template.md
@@ -1,0 +1,134 @@
+# Release notes template
+
+Skeleton for the body of a release. Replace `<PLACEHOLDER>` text with real
+content. The required sections, in order, match the shape of v0.1.0 /
+v0.3.0 / v0.4.0 / v0.4.1 / v0.4.2 — keep them in this order so users
+comparing releases can scan them in parallel.
+
+```markdown
+> **Pre-release quality.** Built from `main` for early testing and feedback. Expect rough
+> edges — crashes, audio glitches, and missing native translations are still the rule, not
+> the exception. Please open issues rather than running off the latest commit silently.
+
+## ⚠️ You must supply your own ROM
+
+**This release contains no game assets or code from the original cartridge.** It ships
+only the recompiled executable. To play, you must obtain a legal copy of
+`Automobili Lamborghini (USA).z64` (the North American release is the only one
+supported) and place it next to the executable before launching. See **[BUILDING.md]**
+for the full instructions; in brief:
+
+1. Extract the archive for your platform into its own folder.
+2. Drop `Automobili Lamborghini (USA).z64` into that folder.
+3. Launch the binary.
+
+Game saves go alongside the ROM (or under `%LOCALAPPDATA%\LamborghiniRecomp` on
+Windows / `~/.config/LamborghiniRecomp` elsewhere — see **README.md**).
+
+## What's working
+
+<One-paragraph headline: what is THE big user-facing change since the
+previous release? Match the tone of the v0.4.2 example — "v0.4.1 shipped
+a manual escape hatch that required editing `graphics.json`; v0.4.2 makes
+it automatic for modern Intel." Quantify if possible (number of fixes,
+number of new build knobs, etc). End with "There's still glitches so
+please report issues you find." — this line is in every prior release.>
+
+Closed since <PREV_VERSION>:
+
+<Category 1 — e.g. "Rumble", "Stability / driver compatibility",
+"Widescreen / multiplayer", "Developer tooling">
+
+- **#<ISSUE> / PR #<PR>** — <One sentence: what changed, with the user
+  benefit first. Cite the implementation location if non-obvious
+  (patches/NNNN, src/file.c, docs/foo.md). Link-style references like
+  `[docs/rumble-triggers.md]` should resolve at v<NEW_VERSION>.>
+
+<Category 2>
+
+- ...
+
+## What's not done yet
+
+This is still pre-1.0 — plenty of `force_stub.txt` still includes real game primitives
+rather than no-ops. The tracker is the canonical "what's next" list.
+
+<Optional follow-up paragraph — only if a tracked issue is opened but not
+yet fixed in this release. State the gap, the issue number, and the
+mitigation (e.g. "still gets the SEVERE advisory popup instead of a
+silent black screen").>
+
+If you find a crash, please open an issue with `lamborghini_crash` style notes:
+
+- Output window text (or the `crash-*.txt` dump if the native handler caught it)
+- Commit / build provenance (below)
+- Approximate in-game location (title screen / car-select / race lap 2 / etc.)
+
+## How to run
+
+### Linux
+
+\`\`\`bash
+unzip lamborghini-recomp-linux-x64.zip -d lamborghini-recomp
+cp "Automobili Lamborghini (USA).z64" lamborghini-recomp/
+./lamborghini-recomp/lamborghini_modern
+\`\`\`
+
+Requires `libsdl2-2.0-0` and a Vulkan-capable GPU + driver at runtime. Most
+desktop distros ship these already.
+
+### Windows
+
+Extract `lamborghini-recomp-windows-x64.zip` anywhere, drop your ROM in the same
+folder, and double-click `lamborghini_modern.exe`. The bundled `SDL2.dll`,
+`dxcompiler.dll`, and `dxil.dll` must stay alongside the EXE.
+
+**F11 / Alt+Enter** toggles fullscreen (and remembers the choice next launch).
+
+## Build provenance
+
+- **Commit:** `<SHORT_SHA>` (main, <YYYY-MM-DD>)
+- **Workflow run:** [#<RUN_ID>][run] (Build & Release, dispatch from this SHA)
+- **Toolchain:** Linux build on `ubuntu-latest` with gcc / cmake / ninja /
+  `libsdl2-dev` / `libvulkan-dev`. Windows build on `windows-latest` with
+  MinGW-w64 GCC + Ninja (PowerShell, not MSYS bash) per the project's toolchain
+  notes.
+
+---
+
+If you'd rather build it yourself from source instead of running a pre-built
+binary, see [BUILDING.md]. For graphics settings, see [README.md].
+
+[BUILDING.md]: https://github.com/alondero/automobililamborghini-recomp/blob/<VERSION>/BUILDING.md
+[README.md]: https://github.com/alondero/automobililamborghini-recomp/blob/<VERSION>/README.md
+[run]: https://github.com/alondero/automobililamborghini-recomp/actions/runs/<RUN_ID>
+[<any linked doc>]: https://github.com/alondero/automobililamborghini-recomp/blob/<VERSION>/<path>
+```
+
+## Category names actually used in prior releases
+
+Pick from this list — don't invent new categories without a good reason:
+
+- **Rumble**
+- **Stability / driver compatibility**
+- **Widescreen / multiplayer**
+- **Widescreen — skybox / lens flare**
+- **Widescreen graphics**
+- **Developer tooling (now ships in the binary)**
+- **CI / build**
+- **Project / developer docs**
+- **Release packaging / CI**
+- **Texture tooling (developer-facing)**
+
+If a release has only one category (v0.4.2), don't pad — one is fine.
+
+## Tone notes
+
+- Lead each bullet with the user benefit, then the mechanism.
+- Quantify with concrete numbers (LAMBO_PAK_TRACE logged 79 / 2395 events;
+  5 vs 3-4 segment groups; etc.) — much better than "improved performance".
+- Inline code env vars (`LAMBO_PAK_TRACE`, `LAMBO_NO_LOD`) without prose
+  explanation; experienced users know.
+- Cite issues/PRs as `**#N / PR #N**` — GitHub auto-links both numbers.
+- The "Pre-release quality" blockquote is in every release and is the
+  *body copy* — it is NOT the GitHub `prerelease` flag. See gotchas.md.

--- a/.claude/skills/release/scripts/list-changes.sh
+++ b/.claude/skills/release/scripts/list-changes.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# list-changes.sh — print merged PRs, closed issues, and the merge-commit at HEAD
+# since <base-tag>. Output is structured Markdown for the release-notes draft.
+#
+# Usage: list-changes.sh <base-tag> [head-ref]
+#   base-tag: e.g. v0.4.2
+#   head-ref: defaults to HEAD (use 'origin/main' to read remote state)
+
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <base-tag> [head-ref]" >&2
+  exit 2
+fi
+
+BASE_TAG="$1"
+HEAD_REF="${2:-HEAD}"
+
+# Sanity: base tag must exist
+if ! git rev-parse -q --verify "refs/tags/${BASE_TAG}" >/dev/null; then
+  echo "error: base tag '${BASE_TAG}' does not exist locally" >&2
+  exit 1
+fi
+
+BASE_DATE="$(git log -1 --format='%ai' "${BASE_TAG}")"
+HEAD_SHA="$(git rev-parse "${HEAD_REF}")"
+HEAD_SHORT="$(git rev-parse --short "${HEAD_SHA}")"
+HEAD_SUBJECT="$(git log -1 --format='%s' "${HEAD_REF}")"
+HEAD_DATE="$(git log -1 --format='%ai' "${HEAD_REF}")"
+
+echo "## Change summary: ${BASE_TAG} → ${HEAD_REF}"
+echo
+echo "**Base:** \`${BASE_TAG}\` (${BASE_DATE})"
+echo "**Head:** \`${HEAD_SHORT}\` — ${HEAD_SUBJECT} (${HEAD_DATE})"
+echo
+
+# Commits since base
+echo "### Commits since ${BASE_TAG}"
+echo
+echo '```'
+git log --no-merges --oneline "${BASE_TAG}..${HEAD_REF}" || true
+echo '```'
+echo
+
+# Merged PRs since base (uses gh)
+echo "### Merged PRs since ${BASE_TAG}"
+echo
+PRS="$(gh pr list --state merged --base main --search "merged:>=${BASE_DATE%% *}" \
+       --json number,title,mergedAt,author \
+       --jq '.[] | "- **PR #\(.number)** (\(.mergedAt[:10])) — \(.title) — _@\(.author.login)_"')"
+if [[ -n "${PRS}" ]]; then
+  echo "${PRS}"
+else
+  echo "_None found via `gh pr list` — try `gh pr list --state merged --base main --limit 30` and filter manually._"
+fi
+echo
+
+# Closed issues since base
+echo "### Closed issues since ${BASE_TAG}"
+echo
+ISSUES="$(gh issue list --state closed --search "closed:>=${BASE_DATE%% *}" \
+          --json number,title,closedAt \
+          --jq '.[] | "- **#\(.number)** (\(.closedAt[:10])) — \(.title)"')"
+if [[ -n "${ISSUES}" ]]; then
+  echo "${ISSUES}"
+else
+  echo "_None closed since base tag._"
+fi
+echo
+
+# Tag target recommendation
+echo "### Tag target recommendation"
+echo
+# Find the most recent merge commit on main reachable from HEAD
+TAG_TARGET="$(git log --merges --first-parent -n 1 --format='%H %s' "${HEAD_REF}")"
+echo "Most recent merge commit on \`${HEAD_REF}\`:"
+echo
+echo '```'
+echo "${TAG_TARGET}"
+echo '```'
+echo
+echo "Tag \`<new-version>\` should point at \`$(echo "${TAG_TARGET}" | awk '{print $1}' | cut -c1-7)\`."

--- a/.claude/skills/release/scripts/tag-and-dispatch.sh
+++ b/.claude/skills/release/scripts/tag-and-dispatch.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# tag-and-dispatch.sh — tag the merge commit at HEAD on main, push the tag,
+# and dispatch the Build & Release workflow with --prerelease=false --draft=false
+# (the values that produce a properly-bound release).
+#
+# Usage: tag-and-dispatch.sh <version>
+#   version: e.g. v0.4.3 (must match v<MAJOR>.<MINOR>.<PATCH>)
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <version>" >&2
+  exit 2
+fi
+
+VERSION="$1"
+
+# Validate version shape
+if ! [[ "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+  echo "error: '${VERSION}' does not match v<MAJOR>.<MINOR>.<PATCH>" >&2
+  exit 1
+fi
+
+# Make sure we're on main and HEAD is a merge commit (the convention
+# past releases follow — v0.4.0=5e07da1, v0.4.1=1f489fb, v0.4.2=03e533a).
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "${CURRENT_BRANCH}" != "main" ]]; then
+  echo "error: must be on 'main' (currently on '${CURRENT_BRANCH}')." >&2
+  echo "       Switch with: git checkout main" >&2
+  exit 1
+fi
+
+HEAD_SHA="$(git rev-parse HEAD)"
+if [[ -z "$(git log --merges --first-parent -n 1 --format='%H' HEAD | grep -F "${HEAD_SHA}" || true)" ]]; then
+  echo "warning: HEAD (${HEAD_SHA}) is not a merge commit." >&2
+  echo "         Past releases tag at the merge commit (e.g. v0.4.2 = 03e533a)." >&2
+  echo "         Re-run after a PR lands, or override with:" >&2
+  echo "           git tag ${VERSION} <desired-sha> && git push origin ${VERSION}" >&2
+  exit 1
+fi
+
+# Refuse if tag already exists locally OR on origin
+if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
+  echo "error: tag '${VERSION}' already exists locally." >&2
+  echo "       If you want to re-cut, delete first: git tag -d ${VERSION}" >&2
+  exit 1
+fi
+if git ls-remote --tags origin "${VERSION}" 2>/dev/null | grep -q "${VERSION}"; then
+  echo "error: tag '${VERSION}' already exists on origin." >&2
+  exit 1
+fi
+
+echo "→ Tagging ${VERSION} at ${HEAD_SHA}"
+git tag "${VERSION}" "${HEAD_SHA}"
+
+echo "→ Pushing ${VERSION} to origin"
+git push origin "${VERSION}"
+
+echo "→ Dispatching Build & Release workflow (prerelease=false, draft=false)"
+# Capture the run ID — the dispatch returns immediately and prints nothing
+# useful, so we fetch the most recent in_progress run afterwards.
+gh workflow run "Build & Release" --ref main \
+  -f "tag=${VERSION}" \
+  -f "prerelease=false" \
+  -f "draft=false"
+
+# Brief settle before listing runs (gh workflow run is fire-and-forget)
+sleep 3
+
+RUN_ID="$(gh run list --workflow="Build & Release" --limit 1 --json databaseId,status \
+          --jq '.[] | select(.status=="in_progress" or .status=="queued") | .databaseId' \
+          | head -n 1)"
+
+if [[ -z "${RUN_ID}" ]]; then
+  echo "warning: could not find the dispatched run. List with: gh run list --workflow='Build & Release' --limit 3" >&2
+  exit 0
+fi
+
+echo
+echo "✓ Workflow dispatched."
+echo "  Version:    ${VERSION}"
+echo "  Tag SHA:    ${HEAD_SHA}"
+echo "  Run ID:     ${RUN_ID}"
+echo
+echo "Next: ./scripts/wait-for-build.sh ${RUN_ID}"

--- a/.claude/skills/release/scripts/update-notes.sh
+++ b/.claude/skills/release/scripts/update-notes.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# update-notes.sh — replace the workflow's placeholder notes with the rich body.
+#
+# Usage: update-notes.sh <version> <notes-file>
+#   version:    e.g. v0.4.3
+#   notes-file: path to a Markdown file matching references/release-notes-template.md
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <version> <notes-file>" >&2
+  exit 2
+fi
+
+VERSION="$1"
+NOTES_FILE="$2"
+
+if [[ ! -f "${NOTES_FILE}" ]]; then
+  echo "error: notes file '${NOTES_FILE}' not found" >&2
+  exit 1
+fi
+
+if ! [[ "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+  echo "error: '${VERSION}' does not match v<MAJOR>.<MINOR>.<PATCH>" >&2
+  exit 1
+fi
+
+# Refuse to push notes that look like the workflow placeholder
+if head -n 2 "${NOTES_FILE}" | grep -q "Automated build from commit"; then
+  echo "error: notes file appears to be the workflow placeholder." >&2
+  echo "       Use a body drafted from references/release-notes-template.md." >&2
+  exit 1
+fi
+
+echo "→ Updating ${VERSION} notes from ${NOTES_FILE}"
+gh release edit "${VERSION}" --notes-file "${NOTES_FILE}"
+
+echo
+echo "✓ Notes updated. Verify with:"
+echo "    gh release view ${VERSION} --json body --jq '.body' | head -n 30"

--- a/.claude/skills/release/scripts/verify-release.sh
+++ b/.claude/skills/release/scripts/verify-release.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# verify-release.sh — sanity-check a release is properly bound and complete.
+# Runs five checks and prints pass/fail per check; exits non-zero if any fails.
+#
+# Usage: verify-release.sh <version>
+#   version: e.g. v0.4.3
+
+set -uo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <version>" >&2
+  exit 2
+fi
+
+VERSION="$1"
+EXPECTED_ASSETS=(
+  "lamborghini-recomp-linux-x64.zip"
+  "lamborghini-recomp-windows-x64.zip"
+)
+
+PASS=0
+FAIL=0
+
+note_pass() { echo "  ✓ $1"; PASS=$((PASS+1)); }
+note_fail() { echo "  ✗ $1"; FAIL=$((FAIL+1)); }
+
+echo "Verifying ${VERSION}:"
+echo
+
+# Check 1: git tag on origin
+if git ls-remote --tags origin "${VERSION}" 2>/dev/null | grep -q "${VERSION}"; then
+  TAG_SHA="$(git ls-remote --tags origin "${VERSION}" | awk '{print $1}')"
+  note_pass "tag ${VERSION} exists on origin (${TAG_SHA:0:7})"
+else
+  note_fail "tag ${VERSION} NOT on origin"
+fi
+
+# Check 2: release accessible via tag-keyed API
+RELEASE_JSON="$(gh api "repos/alondero/automobililamborghini-recomp/releases/tags/${VERSION}" 2>&1)" || true
+if echo "${RELEASE_JSON}" | grep -q '"message":"Not Found"'; then
+  note_fail "release not found via /releases/tags/${VERSION} (workflow may not have finished)"
+elif [[ -z "${RELEASE_JSON}" ]]; then
+  note_fail "release API call returned empty"
+else
+  note_pass "release accessible via tag-keyed API"
+fi
+
+# Check 3: html_url is properly tag-bound (not the untagged-<id> synthetic URL)
+HTML_URL="$(echo "${RELEASE_JSON}" | grep -o '"html_url":"[^"]*"' | head -n 1 | cut -d'"' -f4)"
+if [[ "${HTML_URL}" == *"releases/tag/${VERSION}" ]]; then
+  note_pass "html_url is properly tag-bound: ${HTML_URL}"
+elif [[ "${HTML_URL}" == *"untagged-"* ]]; then
+  note_fail "html_url is the synthetic 'untagged-<id>' pattern — the --draft trap"
+  note_fail "  url: ${HTML_URL}"
+  echo "         See references/gotchas.md — release was created as a draft."
+else
+  note_fail "html_url unexpected: ${HTML_URL:-<empty>}"
+fi
+
+# Check 4: draft and prerelease flags
+IS_DRAFT="$(echo "${RELEASE_JSON}" | grep -o '"draft":[a-z]*' | head -n 1 | cut -d: -f2)"
+IS_PRERELEASE="$(echo "${RELEASE_JSON}" | grep -o '"prerelease":[a-z]*' | head -n 1 | cut -d: -f2)"
+if [[ "${IS_DRAFT}" == "false" ]]; then
+  note_pass "draft: false"
+else
+  note_fail "draft: ${IS_DRAFT:-<unset>} (expected false to match prior releases)"
+fi
+if [[ "${IS_PRERELEASE}" == "false" ]]; then
+  note_pass "prerelease: false"
+else
+  note_fail "prerelease: ${IS_PRERELEASE:-<unset>} (expected false — 'Pre-release quality' is body copy only)"
+fi
+
+# Check 5: assets uploaded — use a fresh gh call that returns parseable JSON
+ASSETS_JSON="$(gh api "repos/alondero/automobililamborghini-recomp/releases/tags/${VERSION}" \
+               --jq '.assets // []' 2>/dev/null || echo '[]')"
+for expected in "${EXPECTED_ASSETS[@]}"; do
+  ASSET_LINE="$(echo "${ASSETS_JSON}" \
+                | grep -o "\"name\":\"${expected}\"[^}]*\"size\":[0-9]*" \
+                | head -n 1 || true)"
+  if [[ -n "${ASSET_LINE}" ]]; then
+    SIZE="$(echo "${ASSET_LINE}" | grep -o '"size":[0-9]*' | cut -d: -f2)"
+    SIZE_MB="$(awk "BEGIN { printf \"%.0f\", ${SIZE:-0}/1024/1024 }")"
+    note_pass "asset uploaded: ${expected} (${SIZE_MB} MB)"
+  else
+    note_fail "asset missing: ${expected}"
+  fi
+done
+
+echo
+echo "Result: ${PASS} passed, ${FAIL} failed"
+
+if [[ ${FAIL} -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/.claude/skills/release/scripts/wait-for-build.sh
+++ b/.claude/skills/release/scripts/wait-for-build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# wait-for-build.sh — block until a Build & Release workflow run finishes.
+# Exits 0 on success, non-zero on failure/cancellation.
+#
+# Usage: wait-for-build.sh <run-id>
+#   run-id: the GitHub Actions database ID (e.g. 29203966918)
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <run-id>" >&2
+  exit 2
+fi
+
+RUN_ID="$1"
+
+if ! [[ "${RUN_ID}" =~ ^[0-9]+$ ]]; then
+  echo "error: '${RUN_ID}' does not look like a run ID (digits only)." >&2
+  exit 1
+fi
+
+echo "→ Watching run ${RUN_ID} (Ctrl-C to detach; the run will keep going)"
+echo
+
+# --exit-status makes gh return non-zero on any job failure, which is what
+# we want — it propagates a failed build as a script failure.
+gh run watch "${RUN_ID}" --exit-status --interval 30
+
+# After a successful run, print a one-liner summary so the caller can verify
+# which commit/SHA actually got built (workflows run on whatever HEAD was at
+# dispatch time, which may differ from a tag you created earlier).
+echo
+echo "✓ Run ${RUN_ID} succeeded."
+echo
+gh run view "${RUN_ID}" --json headSha,headBranch,conclusion \
+   --jq '"  HEAD:      \(.headSha)\n  Branch:    \(.headBranch)\n  Conclusion: \(.conclusion)"'


### PR DESCRIPTION
Adds a `.claude/skills/release/` user-invocable slash command that captures the v0.4.0 → v0.4.2 release flow. Five deterministic bash scripts under `scripts/` handle the parts that don't benefit from prose (list changes, tag-and-dispatch, wait-for-build, verify-release, update-notes); three reference docs (`release-notes-template.md`, `gotchas.md`, `prior-release-format.md`) give the body-drafting step the skeleton and voice to match. `disable-model-invocation: true` in the SKILL.md frontmatter keeps the agent from auto-invoking it — releases are deliberate, never auto-triggered.

## Why?

The release flow has accumulated four non-obvious gotchas (the `gh release create --draft` URL trap, the merge-commit tagging convention, the `prerelease=false + draft=false` dispatch values, the workflow's placeholder notes) and the body-drafting step keeps re-deriving the same skeleton. Bundling both into a slash command makes the next cut deterministic and gives the next session a starting point that doesn't require re-deriving the lessons. None of the existing issues track this — it's a tooling addition that pays for itself the next time a release ships.

Closes # none — small cleanup

## How was it verified?

- [x] No recompiled/built code changes — scripts and reference docs only
- [x] `list-changes.sh v0.4.1 origin/main` returns the expected PR/commit summary and recommends `03e533a` as the tag target
- [x] `verify-release.sh v0.4.2` passes all 7 checks (tag on origin, API accessible, html_url tag-bound, draft:false, prerelease:false, both assets uploaded at 7 MB / 19 MB)
- [x] `verify-release.sh v99.99.99` fails all 7 checks cleanly with non-zero exit and per-check diagnostics
- [x] `tag-and-dispatch.sh`, `wait-for-build.sh`, `update-notes.sh` re-runnable; exit non-zero on bad input (validate version format, refuse workflow placeholder, require merge-commit HEAD)
- [x] No comments that explain *what* the code does — scripts inline the *why* (gotcha callouts, exit-on-bad-input rationale)
- [x] No "🤖 Generated with Claude Code" footer in commits or PR description

## Screenshots / video

N/A — no visual change.

## Risk / rollback

No runtime change; the skill only takes effect when a user invokes `/release`. Revert with `git revert 305fbf9`, or just delete `.claude/skills/release/`.