### PR TITLE
Fix pit-stop flicker: guard widescreen HUD bracket resets against label-landing paths

### DIFF
--- a/src/lambo_hud_widescreen.c
+++ b/src/lambo_hud_widescreen.c
@@ -43,6 +43,16 @@ static float lambo_ws_get_hud_shift_scale(void) {
 
 static gpr lambo_ws_bracket_start;
 
+// The reset hooks sit on recompiled branch labels (the instruction after each bracketed
+// jal), and N64Recomp runs label hook text on EVERY incoming path — including game paths
+// that branch over the jal (e.g. the pit-stop screen hides the dial/RANK/LAP draws by
+// jumping straight to the post-jal label). An unpaired reset would pop a scissor that was
+// never pushed and run the matrix walker over a stale [bracket_start, cursor) range,
+// shifting arbitrary scene matrices (issue: pit-stop flicker; cold-start value 0 even
+// walks out of RDRAM and crashes). Every pin arms this flag; every reset no-ops unless
+// armed. Same trap the quad-text section documents below.
+static int s_bracket_open;
+
 static void emit_cmd(uint8_t* rdram, uint32_t w0, uint32_t w1) {
     gpr curp = (gpr)(int32_t)LAMBO_DL_CURSOR;
     gpr cur = MEM_W(0, curp);
@@ -86,6 +96,7 @@ static void pin(uint8_t* rdram, uint32_t origin, int32_t xoff) {
              PARAM(0, 16, 16) | PARAM(0, 16, 0),
              PARAM(0, 16, 16) | PARAM(240 * 4, 16, 0));
     lambo_ws_bracket_start = MEM_W(0, (gpr)(int32_t)LAMBO_DL_CURSOR);
+    s_bracket_open = 1;
 }
 
 void lambo_ws_pin_left(uint8_t* rdram) {
@@ -139,6 +150,10 @@ static void patch_load_mtx_dx(uint8_t* rdram, gpr start, gpr end, float dx_units
 }
 
 void lambo_ws_pin_reset(uint8_t* rdram) {
+    if (!s_bracket_open) {
+        return; /* label-landing path that skipped the pin (e.g. pit stop) */
+    }
+    s_bracket_open = 0;
     patch_load_mtx_dx(rdram, lambo_ws_bracket_start,
                       MEM_W(0, (gpr)(int32_t)LAMBO_DL_CURSOR), LAMBO_WS_NEEDLE_DX);
     emit_cmd(rdram,
@@ -173,6 +188,10 @@ void lambo_ws_minimap_pin(uint8_t* rdram) {
 }
 
 void lambo_ws_minimap_reset(uint8_t* rdram) {
+    if (!s_bracket_open) {
+        return; /* label-landing path that skipped the pin (e.g. pit stop) */
+    }
+    s_bracket_open = 0;
     patch_load_mtx_dx(rdram, lambo_ws_bracket_start,
                       MEM_W(0, (gpr)(int32_t)LAMBO_DL_CURSOR),
                       LAMBO_WS_MINIMAP_ARROW_DX);
@@ -262,6 +281,7 @@ void lambo_ws_quad_text_end(uint8_t* rdram) {
         return; /* reached via the 1P/2P paths that share L_80052C00 */
     }
     s_quad_text_scissor_open = 0;
+    s_bracket_open = 0; /* quad_text_begin armed it via pin_left; no pin_reset runs here */
     emit_cmd(rdram,
              PARAM(RT64_EXTENDED_OPCODE, 8, 24) | PARAM(G_EX_POPSCISSOR_V1, 24, 0),
              0);
@@ -314,9 +334,14 @@ void lambo_ws_quad_panel_bg_reset(uint8_t* rdram) {
 void lambo_ws_quad_panel_pin(uint8_t* rdram) {
     emit_rect_align(rdram, G_EX_ORIGIN_QUARTER_RIGHT, -SCREEN_WIDTH_QP * 3 / 4);
     lambo_ws_bracket_start = MEM_W(0, (gpr)(int32_t)LAMBO_DL_CURSOR);
+    s_bracket_open = 1;
 }
 
 void lambo_ws_quad_panel_reset(uint8_t* rdram) {
+    if (!s_bracket_open) {
+        return; /* label-landing path that skipped the pin */
+    }
+    s_bracket_open = 0;
     patch_load_mtx_dx(rdram, lambo_ws_bracket_start,
                       MEM_W(0, (gpr)(int32_t)LAMBO_DL_CURSOR),
                       LAMBO_WS_QUAD_PANEL_DX);

--- a/src/lambo_hud_widescreen.c
+++ b/src/lambo_hud_widescreen.c
@@ -43,15 +43,28 @@ static float lambo_ws_get_hud_shift_scale(void) {
 
 static gpr lambo_ws_bracket_start;
 
-// The reset hooks sit on recompiled branch labels (the instruction after each bracketed
+// Pin/reset hooks sit on recompiled branch labels (the instruction after each bracketed
 // jal), and N64Recomp runs label hook text on EVERY incoming path — including game paths
 // that branch over the jal (e.g. the pit-stop screen hides the dial/RANK/LAP draws by
 // jumping straight to the post-jal label). An unpaired reset would pop a scissor that was
 // never pushed and run the matrix walker over a stale [bracket_start, cursor) range,
 // shifting arbitrary scene matrices (issue: pit-stop flicker; cold-start value 0 even
-// walks out of RDRAM and crashes). Every pin arms this flag; every reset no-ops unless
-// armed. Same trap the quad-text section documents below.
+// walks out of RDRAM and crashes). The flag models the pairing: pins arm, resets disarm,
+// label-landing-only paths leave it untouched. Quad-text section uses a similar flag for
+// the same merge-label trap.
 static int s_bracket_open;
+
+static void bracket_arm(uint8_t* rdram) {
+    lambo_ws_bracket_start = MEM_W(0, (gpr)(int32_t)LAMBO_DL_CURSOR);
+    s_bracket_open = 1;
+}
+
+// Returns 1 iff a paired reset should run; clears the flag on the way out.
+static int bracket_disarm_if_open(void) {
+    if (!s_bracket_open) return 0;
+    s_bracket_open = 0;
+    return 1;
+}
 
 static void emit_cmd(uint8_t* rdram, uint32_t w0, uint32_t w1) {
     gpr curp = (gpr)(int32_t)LAMBO_DL_CURSOR;
@@ -95,8 +108,7 @@ static void pin(uint8_t* rdram, uint32_t origin, int32_t xoff) {
     emit_cmd(rdram,
              PARAM(0, 16, 16) | PARAM(0, 16, 0),
              PARAM(0, 16, 16) | PARAM(240 * 4, 16, 0));
-    lambo_ws_bracket_start = MEM_W(0, (gpr)(int32_t)LAMBO_DL_CURSOR);
-    s_bracket_open = 1;
+    bracket_arm(rdram);
 }
 
 void lambo_ws_pin_left(uint8_t* rdram) {
@@ -150,10 +162,9 @@ static void patch_load_mtx_dx(uint8_t* rdram, gpr start, gpr end, float dx_units
 }
 
 void lambo_ws_pin_reset(uint8_t* rdram) {
-    if (!s_bracket_open) {
+    if (!bracket_disarm_if_open()) {
         return; /* label-landing path that skipped the pin (e.g. pit stop) */
     }
-    s_bracket_open = 0;
     patch_load_mtx_dx(rdram, lambo_ws_bracket_start,
                       MEM_W(0, (gpr)(int32_t)LAMBO_DL_CURSOR), LAMBO_WS_NEEDLE_DX);
     emit_cmd(rdram,
@@ -188,10 +199,9 @@ void lambo_ws_minimap_pin(uint8_t* rdram) {
 }
 
 void lambo_ws_minimap_reset(uint8_t* rdram) {
-    if (!s_bracket_open) {
+    if (!bracket_disarm_if_open()) {
         return; /* label-landing path that skipped the pin (e.g. pit stop) */
     }
-    s_bracket_open = 0;
     patch_load_mtx_dx(rdram, lambo_ws_bracket_start,
                       MEM_W(0, (gpr)(int32_t)LAMBO_DL_CURSOR),
                       LAMBO_WS_MINIMAP_ARROW_DX);
@@ -281,7 +291,7 @@ void lambo_ws_quad_text_end(uint8_t* rdram) {
         return; /* reached via the 1P/2P paths that share L_80052C00 */
     }
     s_quad_text_scissor_open = 0;
-    s_bracket_open = 0; /* quad_text_begin armed it via pin_left; no pin_reset runs here */
+    (void)bracket_disarm_if_open(); /* quad_text_begin armed via pin_left; no pin_reset runs here */
     emit_cmd(rdram,
              PARAM(RT64_EXTENDED_OPCODE, 8, 24) | PARAM(G_EX_POPSCISSOR_V1, 24, 0),
              0);
@@ -333,12 +343,11 @@ void lambo_ws_quad_panel_bg_reset(uint8_t* rdram) {
 
 void lambo_ws_quad_panel_pin(uint8_t* rdram) {
     emit_rect_align(rdram, G_EX_ORIGIN_QUARTER_RIGHT, -SCREEN_WIDTH_QP * 3 / 4);
-    lambo_ws_bracket_start = MEM_W(0, (gpr)(int32_t)LAMBO_DL_CURSOR);
-    s_bracket_open = 1;
+    bracket_arm(rdram);
 }
 
 void lambo_ws_quad_panel_reset(uint8_t* rdram) {
-    if (!s_bracket_open) {
+    if (!bracket_disarm_if_open()) {
         return; /* label-landing path that skipped the pin */
     }
     s_bracket_open = 0;

--- a/tests/test_hud_bracket_pairing.c
+++ b/tests/test_hud_bracket_pairing.c
@@ -1,0 +1,101 @@
+// Regression spec for widescreen HUD bracket pairing (pit-stop flicker / savestate crash).
+//
+// The reset hooks in func_80050860 sit on recompiled branch labels, so game paths that
+// branch over a bracketed jal (the pit-stop screen hides the dial/RANK/LAP draws this
+// way) run a reset WITHOUT its pin. Unguarded, that walked a stale
+// [bracket_start, cursor) range and shifted arbitrary scene G_MTX matrices (+530 units
+// => per-frame flicker), and on a cold start (bracket_start still 0) walked straight out
+// of RDRAM (savestate-load crash). This locks the guard: unpaired resets are no-ops,
+// paired brackets keep shifting exactly as calibrated.
+//
+// Standalone, no ROM build needed (fake 8 MiB RDRAM):
+//   gcc -Ilib/N64ModernRuntime/N64Recomp/include -Ilib/rt64/include \
+//       tests/test_hud_bracket_pairing.c -lm -o test_hud_bracket_pairing && ./test_hud_bracket_pairing
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static uint8_t* rdram;
+
+// Pull in the real module; the test provides the renderer extern it links against.
+#include "../src/lambo_hud_widescreen.c"
+
+// 16:9 => shift scale is exactly the calibrated baseline (see test_hud_shift_scale.c).
+uint32_t lambo_ws_get_hud_rect_aspect_bits(void) {
+    union { float f; uint32_t u; } a;
+    a.f = 16.0f / 9.0f;
+    return a.u;
+}
+
+#define DL_BASE   0x800BF400u
+#define MTX_A     0x800A6738u /* "needle" matrix inside a legit bracket */
+#define MTX_SCENE 0x800A7000u /* scene matrix emitted on the pit path, outside any bracket */
+
+static void wr32(uint32_t addr, uint32_t v) { MEM_W(0, (gpr)(int32_t)addr) = (int32_t)v; }
+static uint32_t rd32(uint32_t addr) { return (uint32_t)MEM_W(0, (gpr)(int32_t)addr); }
+
+static void emit_gmtx(uint32_t mtx_vaddr) {
+    uint32_t cur = rd32(LAMBO_DL_CURSOR);
+    wr32(cur, 0x01020040u);            /* G_MTX LOAD|MODELVIEW, len 0x40 */
+    wr32(cur + 4, mtx_vaddr & 0x00FFFFFFu);
+    wr32(LAMBO_DL_CURSOR, cur + 8);
+}
+
+static void set_mtx_x(uint32_t mtx, int16_t ip) {
+    MEM_H(24, (gpr)(int32_t)mtx) = ip;          /* translate.x integer part */
+    MEM_HU(24 + 0x20, (gpr)(int32_t)mtx) = 0;   /* fraction */
+}
+
+static int16_t get_mtx_x(uint32_t mtx) { return (int16_t)MEM_H(24, (gpr)(int32_t)mtx); }
+
+int main(void) {
+    rdram = (uint8_t*)calloc(1, 0x800000);
+    assert(rdram != NULL);
+    wr32(LAMBO_DL_CURSOR, DL_BASE);
+
+    // --- cold start: reset with no pin ever run (savestate cold-load shape) ---
+    // bracket_start is still 0; unguarded this walked [0, cursor) out of RDRAM and
+    // crashed. Must be a complete no-op: nothing emitted, cursor untouched.
+    lambo_ws_pin_reset(rdram);
+    assert(rd32(LAMBO_DL_CURSOR) == DL_BASE);
+    lambo_ws_minimap_reset(rdram);
+    assert(rd32(LAMBO_DL_CURSOR) == DL_BASE);
+
+    // --- paired bracket still shifts the needle exactly as calibrated ---
+    set_mtx_x(MTX_A, 100);
+    lambo_ws_pin_right(rdram);
+    emit_gmtx(MTX_A); /* the dial helper's needle matrix */
+    uint32_t cur_before_reset = rd32(LAMBO_DL_CURSOR);
+    lambo_ws_pin_reset(rdram);
+    int32_t shift = (int32_t)(LAMBO_WS_NEEDLE_DX *
+                              lambo_ws_hud_shift_scale_for_aspect(16.0f / 9.0f) * 65536.0f);
+    assert(get_mtx_x(MTX_A) == (int16_t)(((100 << 16) + shift) >> 16));
+    assert(rd32(LAMBO_DL_CURSOR) > cur_before_reset); /* pop + align reset were emitted */
+
+    // --- the pit-stop path: scene draws, then a label-landing reset with NO pin ---
+    // The scene matrix sits in the stale [bracket_start, cursor) span; unguarded the
+    // walker shifted it (+530 => flicker). Must be untouched and nothing emitted.
+    set_mtx_x(MTX_SCENE, 50);
+    emit_gmtx(MTX_SCENE);
+    uint32_t cur = rd32(LAMBO_DL_CURSOR);
+    lambo_ws_pin_reset(rdram);
+    assert(get_mtx_x(MTX_SCENE) == 50);
+    assert(rd32(LAMBO_DL_CURSOR) == cur);
+    lambo_ws_minimap_reset(rdram);   /* later label-landing resets in the same frame */
+    lambo_ws_quad_panel_reset(rdram);
+    assert(get_mtx_x(MTX_SCENE) == 50);
+    assert(rd32(LAMBO_DL_CURSOR) == cur);
+
+    // --- next legit bracket re-arms cleanly after the no-op resets ---
+    set_mtx_x(MTX_A, 200);
+    lambo_ws_pin_right(rdram);
+    emit_gmtx(MTX_A);
+    lambo_ws_pin_reset(rdram);
+    assert(get_mtx_x(MTX_A) == (int16_t)(((200 << 16) + shift) >> 16));
+
+    printf("all HUD bracket-pairing assertions passed\n");
+    return 0;
+}

--- a/tests/test_hud_bracket_pairing.c
+++ b/tests/test_hud_bracket_pairing.c
@@ -20,6 +20,9 @@
 
 static uint8_t* rdram;
 
+void lambo_ws_quad_text_begin(uint8_t* rdram);
+void lambo_ws_quad_text_end(uint8_t* rdram);
+
 // Pull in the real module; the test provides the renderer extern it links against.
 #include "../src/lambo_hud_widescreen.c"
 
@@ -31,22 +34,27 @@ uint32_t lambo_ws_get_hud_rect_aspect_bits(void) {
 }
 
 #define DL_BASE   0x800BF400u
-#define MTX_A     0x800A6738u /* "needle" matrix inside a legit bracket */
-#define MTX_SCENE 0x800A7000u /* scene matrix emitted on the pit path, outside any bracket */
+/* MTX_A: a legitimate in-bracket matrix the walker must shift; if it does, we know the
+ * bracket was correctly armed. MTX_SCENE: a matrix the walker must NOT shift; only ever
+ * reachable when a reset runs without its pin (i.e. our regression case). */
+#define MTX_A     0x800A6738u
+#define MTX_SCENE 0x800A7000u
 
 static void wr32(uint32_t addr, uint32_t v) { MEM_W(0, (gpr)(int32_t)addr) = (int32_t)v; }
 static uint32_t rd32(uint32_t addr) { return (uint32_t)MEM_W(0, (gpr)(int32_t)addr); }
 
 static void emit_gmtx(uint32_t mtx_vaddr) {
     uint32_t cur = rd32(LAMBO_DL_CURSOR);
-    wr32(cur, 0x01020040u);            /* G_MTX LOAD|MODELVIEW, len 0x40 */
+    wr32(cur, 0x01020040u);
     wr32(cur + 4, mtx_vaddr & 0x00FFFFFFu);
     wr32(LAMBO_DL_CURSOR, cur + 8);
 }
 
+/* Mirrors the layout patch_load_mtx_dx walks: translate.x is element 12 of the 4x4
+ * matrix, stored split as int16 integer-part and uint16 fraction-part at +24/+24+0x20. */
 static void set_mtx_x(uint32_t mtx, int16_t ip) {
-    MEM_H(24, (gpr)(int32_t)mtx) = ip;          /* translate.x integer part */
-    MEM_HU(24 + 0x20, (gpr)(int32_t)mtx) = 0;   /* fraction */
+    MEM_H(24, (gpr)(int32_t)mtx) = ip;
+    MEM_HU(24 + 0x20, (gpr)(int32_t)mtx) = 0;
 }
 
 static int16_t get_mtx_x(uint32_t mtx) { return (int16_t)MEM_H(24, (gpr)(int32_t)mtx); }
@@ -95,6 +103,34 @@ int main(void) {
     emit_gmtx(MTX_A);
     lambo_ws_pin_reset(rdram);
     assert(get_mtx_x(MTX_A) == (int16_t)(((200 << 16) + shift) >> 16));
+
+    // --- quad-text section: pin_left arms, end disarms (no per-element pin_reset) ---
+    lambo_ws_quad_text_begin(rdram);
+    /* pin_left armed the bracket flag */
+    lambo_ws_quad_text_end(rdram);  /* label-landing end disarms even if other paths branch to L_80052C00 */
+    /* a subsequent unpaired reset must be a no-op (flag was cleared by end) */
+    uint32_t cur_after_end = rd32(LAMBO_DL_CURSOR);
+    lambo_ws_pin_reset(rdram);
+    assert(rd32(LAMBO_DL_CURSOR) == cur_after_end);
+
+    // --- legit quad_panel bracket arms, shifts, disarms (verifies the only path the
+    //     guard permits on a real 3P frame; pre-fix this would shift the scene matrix) ---
+    set_mtx_x(MTX_SCENE, 999);
+    lambo_ws_quad_panel_pin(rdram);
+    emit_gmtx(MTX_SCENE);
+    lambo_ws_quad_panel_reset(rdram);
+    int32_t quad_shift = (int32_t)(LAMBO_WS_QUAD_PANEL_DX *
+                                   lambo_ws_hud_shift_scale_for_aspect(16.0f / 9.0f) * 65536.0f);
+    assert(get_mtx_x(MTX_SCENE) == (int16_t)(((999 << 16) + quad_shift) >> 16));
+
+    // --- 2P minimap: pin_2p arms via pin_left; the shared minimap_reset disarms ---
+    set_mtx_x(MTX_A, 400);
+    lambo_ws_minimap_pin_2p(rdram);
+    emit_gmtx(MTX_A);
+    lambo_ws_minimap_reset(rdram);
+    int32_t arrow_shift = (int32_t)(LAMBO_WS_MINIMAP_ARROW_DX *
+                                    lambo_ws_hud_shift_scale_for_aspect(16.0f / 9.0f) * 65536.0f);
+    assert(get_mtx_x(MTX_A) == (int16_t)(((400 << 16) + arrow_shift) >> 16));
 
     printf("all HUD bracket-pairing assertions passed\n");
     return 0;


### PR DESCRIPTION
## Problem
Horrendous flickering during pit stops (reported with a savestate paused inside the pit-stop screen). Suspected interpolation — actually display-list corruption by our own widescreen HUD hooks.

## Root cause
The widescreen HUD pin/reset hooks (`lamborghini.us.toml` → `src/lambo_hud_widescreen.c`) bracket each HUD draw `jal` in the 2D dispatcher `func_80050860`. The reset hooks sit on the instruction **after** each jal — which is a recompiled branch label, and N64Recomp runs label hook text on **every** incoming path.

The pit-stop screen hides the speedometer/RANK/LAP by testing a flag (halfword `0x800A5FBC`) and branching straight to those labels (e.g. `bne` at `0x8004FE84` → `L_8004FF68`), skipping the draw *and its pin*. So every pit frame ran unpaired resets, each of which:

1. emitted `G_EX_POPSCISSOR` with no matching push (RT64 scissor-stack corruption), and
2. ran the matrix walker over a stale `[bracket_start, DL cursor)` span, adding the needle/arrow shift (+530 units at 16:9) to **every scene `G_MTX LOAD` matrix** in it — matrices toggling shifted/unshifted per frame is the flicker.

Cold-booting straight into `LAMBO_STATE_LOAD` of the pit savestate is the extreme case: `bracket_start` is still 0, the walk leaves RDRAM, and the game dies with a 100%-reproducible `EXCEPTION_ACCESS_VIOLATION` in `patch_load_mtx_dx` (caught live under gdb: `start=0`). That crash is what exposed the mechanism.

The quad-text section already documents and guards this exact merge-label trap; the 1P/2P brackets never got the same protection because their pairs *look* adjacent in the toml.

## Fix
One module-wide bracket flag: every pin arms it, every reset no-ops unless armed (and disarms). Covers `pin_reset`, `minimap_reset`, `quad_panel_reset`; `quad_text_end` also disarms the flag its `pin_left` armed.

## Tests / verification
- `tests/test_hud_bracket_pairing.c` (standalone, fake RDRAM, includes the real module): cold-start reset no-op, paired needle shift still exactly the calibrated value, pit-path unpaired resets leave scene matrices and cursor untouched. Crashes with the same access violation pre-fix; all assertions pass post-fix.
- `tests/test_hud_shift_scale.c` still green.
- Live: savestate cold-load no longer crashes (was 8/8 crash); pit-stop scene rendered stable for 120 s / 400 frames (median inter-frame delta ~0.2, peaks are rival cars passing); `LAMBO_WARP` race shows needle centered on the dial, LAP/RANK/minimap pinned as shipped.
