### PR TITLE
no_lod: lift the per-circuit draw-distance cull (city-track distance pop-in)

### DIFF
--- a/docs/no_lod_audit.md
+++ b/docs/no_lod_audit.md
@@ -224,6 +224,45 @@ report's conclusions:
   `LAMBO_STATE_LOAD` to diff the frames around a pop deterministically.
 
 ---
+
+## 8. Addendum (2026-07-18): per-circuit draw-distance radii (the within-mode pop-in)
+
+A user report of residual distance pop-in — worst on the city track — led back into the
+scene builder `func_8000A6C0` and falsified the last of this report's "no mechanism
+remains" claims, this time *within* a mode rather than between modes:
+
+- **The builder distance-culls every segment it could draw.** Each frame it walks the
+  camera segment's precomputed visibility list (up to 10 entries, 20-byte rows, `-1`
+  terminated; table pointer `0x800CE678`, loaded from the track asset header
+  `*(0x800A2238)+0x4`) and per entry computes `dist = sqrt(dx²+dz²)` from the camera.
+  The entry is drawn only if `dist <` a radius fetched from a **float[6][5] table at
+  `0x80088FD0`, indexed `[circuit (0x800CE794)][player-count (0x800CE6A4)]`** — a coarse
+  test at `0x8000D370` (AND-ed with a 0.886 forward-cone on the view direction, double at
+  `0x8008D8C0`), falling back to a fine test (`0x8000D568`) of up to 16 sub-points of the
+  segment against the same radius plus a front-half-plane check.
+- **The radii are authored per circuit for N64 fill-rate**, 1P column: 55000 / 50000 /
+  40000 / 45000 / 35000 / 35000 (multiplayer columns drop to 20000–27500). The city
+  circuits sit at the bottom — exactly the track where whole building blocks visibly pop
+  at the radius edge. This is why "draw distance measured intact" (§1 Axis B) held on the
+  circuit measured in #83 yet pop-in persisted elsewhere: the cull is per-circuit *data*,
+  not per-mode code.
+- **Why every scan missed it:** the compare is an FP `c.lt.s`, but against a *table load*,
+  not an immediate — `scan_lod_patterns.py` classified func_8000A6C0's compares as
+  "normalisation math" (§1) because the threshold never appears as a constant in code.
+  The table has exactly two readers, both in this cull (whole-RecompiledFuncs scan for
+  the `-0x7030(0x8009)` address pattern; the third hit is a `G_DL` word at `0x801F8FD0`,
+  a false positive).
+- **Fix (shipped under the existing `no_lod` key):** a `[[patches.hook]]` at
+  `0x8000CD3C` (world-draw path, before the first table read) rewrites the 30 radii to
+  1e9 each frame via `lambo_no_lod_draw_distance` (src/lambo_no_lod.cpp). Per frame, not
+  once at load, because a savestate restore (#22) brings the ROM values back. The
+  forward-cone and half-plane tests are untouched and the authored 10-entry visibility
+  lists still bound what exists to draw, so no geometry is synthesised — segments the
+  game already streamed simply stop being hidden. Residual pop beyond this is
+  visibility-list-bound (an entry missing from the row entirely), a separate, larger
+  change if it ever proves visible.
+
+---
 *Method note: MIPS classification used `tools/scan_lod_patterns.py` output cross-read
 against the recompiled C (per-instruction VRAM comments) rather than raw disassembly;
 extraction script preserved in the session scratchpad. ROM scans were byte-pattern

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -629,6 +629,23 @@ func = "func_8000A6C0"
 before_vram = 0x8000D838
 text = "{ extern uint32_t lambo_no_lod_scenery_guard(uint8_t*, uint32_t); ctx->r1 = lambo_no_lod_scenery_guard(rdram, (uint32_t)ctx->r1); }"
 
+# no_lod follow-up -- distance pop-in inside a mode (worst on the city circuits). The same
+# scene builder walks the camera segment's 10-slot visibility list (table ptr 0x800CE678,
+# 20-byte rows, -1 terminated) and culls each entry against a per-circuit, per-player-count
+# radius from a float[6][5] table at 0x80088FD0 (coarse test 0x8000D370 with a 0.886
+# forward-cone; fine 16-sub-point half-plane test 0x8000D568; circuit index 0x800CE794,
+# players 0x800CE6A4). The radii are N64 fill-rate budgets -- circuits 5/6 are authored at
+# 35000 vs 55000 for circuit 1 -- so whole city blocks pop in at the radius edge. The hook
+# sits on the world-draw path (0x8000CD3C, after the 0x200 state gate, before the first
+# table read) and rewrites the radii to 1e9 when no_lod(): per frame, not once at load,
+# because a savestate restore brings the ROM values back. Cone/half-plane tests and the
+# authored visibility lists are untouched, so nothing is synthesised -- the game just stops
+# hiding segments it already streamed. Native in src/lambo_no_lod.cpp.
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000CD3C
+text = "{ extern void lambo_no_lod_draw_distance(uint8_t*); lambo_no_lod_draw_distance(rdram); }"
+
 # Issue #78 — 3P/4P per-quadrant HUD text pinning. The quad section (L_800517A8) draws
 # each player's RANK (x=0x20/0x110), speed readout (x=0x14-0x46 / 0xEB-0x11D), lap-notify
 # glyph (x=0x19/0x118) and the inline per-player tag texrects in the outer columns, plus

--- a/scripts/gen_syms_toml.py
+++ b/scripts/gen_syms_toml.py
@@ -993,6 +993,23 @@ func = "func_8000A6C0"
 before_vram = 0x8000D838
 text = "{ extern uint32_t lambo_no_lod_scenery_guard(uint8_t*, uint32_t); ctx->r1 = lambo_no_lod_scenery_guard(rdram, (uint32_t)ctx->r1); }"
 
+# no_lod follow-up -- distance pop-in inside a mode (worst on the city circuits). The same
+# scene builder walks the camera segment's 10-slot visibility list (table ptr 0x800CE678,
+# 20-byte rows, -1 terminated) and culls each entry against a per-circuit, per-player-count
+# radius from a float[6][5] table at 0x80088FD0 (coarse test 0x8000D370 with a 0.886
+# forward-cone; fine 16-sub-point half-plane test 0x8000D568; circuit index 0x800CE794,
+# players 0x800CE6A4). The radii are N64 fill-rate budgets -- circuits 5/6 are authored at
+# 35000 vs 55000 for circuit 1 -- so whole city blocks pop in at the radius edge. The hook
+# sits on the world-draw path (0x8000CD3C, after the 0x200 state gate, before the first
+# table read) and rewrites the radii to 1e9 when no_lod(): per frame, not once at load,
+# because a savestate restore brings the ROM values back. Cone/half-plane tests and the
+# authored visibility lists are untouched, so nothing is synthesised -- the game just stops
+# hiding segments it already streamed. Native in src/lambo_no_lod.cpp.
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000CD3C
+text = "{ extern void lambo_no_lod_draw_distance(uint8_t*); lambo_no_lod_draw_distance(rdram); }"
+
 # Issue #78 — 3P/4P per-quadrant HUD text pinning. The quad section (L_800517A8) draws
 # each player's RANK (x=0x20/0x110), speed readout (x=0x14-0x46 / 0xEB-0x11D), lap-notify
 # glyph (x=0x19/0x118) and the inline per-player tag texrects in the outer columns, plus

--- a/src/lambo_no_lod.cpp
+++ b/src/lambo_no_lod.cpp
@@ -13,9 +13,31 @@
 
 #include <cstdint>
 
+#include "recomp.h"
+
 #include "lambo_config.h"
 
 extern "C" uint32_t lambo_no_lod_scenery_guard(uint8_t* rdram, uint32_t at) {
     (void)rdram;
     return lambo::config::no_lod() ? 1u : at;
+}
+
+// Distance pop-in (the other half of the same builder): each entry of a segment's
+// 10-slot visibility list is culled against a per-circuit, per-player-count radius
+// from a float[6][5] table at 0x80088FD0 (coarse test 0x8000D370, fine 16-sub-point
+// test 0x8000D568). The radii are N64 fill-rate budgets -- the city circuits are
+// authored shortest (35000 vs 55000 on circuit 1), so whole blocks pop in at the
+// radius edge. Hooked per frame on the world-draw path (0x8000CD3C, before the first
+// table read) rather than once at load because a savestate restore brings the ROM
+// values back. Only the radius is lifted: the forward-cone/half-plane tests and the
+// authored per-segment visibility lists still decide what is drawn.
+extern "C" void lambo_no_lod_draw_distance(uint8_t* rdram) {
+    if (!lambo::config::no_lod()) {
+        return;
+    }
+    constexpr uint32_t kTableAddr = 0x80088FD0u;  // float[6][5]: [circuit][player-count]
+    constexpr int32_t kFarBits = 0x4E6E6B28;      // 1e9f, beyond any on-track distance
+    for (uint32_t i = 0; i < 6 * 5; i++) {
+        MEM_W(i * 4, (gpr)(int32_t)kTableAddr) = kFarBits;
+    }
 }

--- a/tools/pvs_distance_audit.py
+++ b/tools/pvs_distance_audit.py
@@ -1,0 +1,95 @@
+"""Audit the scene builder's per-circuit draw-distance cull from a race RDRAM snapshot.
+
+The frame builder (func_8000A6C0) draws the camera segment's precomputed visibility
+list (up to 10 entries, table ptr 0x800CE678) but culls each entry against a radius
+from the float[6][5] table at 0x80088FD0, indexed [circuit (0x800CE794)][players
+(0x800CE6A4)] -- see docs/no_lod_audit.md section 8. This script replays that test
+offline for every segment of the loaded track: for each segment k (camera stood at
+k's own test point) and each entry e of k's row, it computes the builder's distance
+(0x8000D094-0x8000D374: rec16[rec64[e]+0x20] + rec64[e]+{0x10,0x12} vs the camera
+point, XZ plane) and reports which entries the circuit's radius would hide. Culled
+entries are exactly the "world pops in at a distance" events the no_lod
+draw-distance lift (src/lambo_no_lod.cpp) removes.
+
+Usage:
+    LAMBO_HEADLESS=1 LAMBO_WARP=<circuit> LAMBO_RACE_DL_DUMP=<base> \
+        LAMBO_RACE_DL_DUMP_AT=300 LAMBO_MODERN_MAX_VIS=1500 build/lamborghini_modern
+    python tools/pvs_distance_audit.py <base>-300.bin
+
+Example result (CIRCUIT 5, the city track, radius 35000): segments 28-30 hide
+segment 31 at ~51k units -- a whole block popping in down a long street.
+"""
+import struct
+import sys
+
+
+def main(path):
+    with open(path, 'rb') as f:
+        d = f.read()
+
+    def gh(a):
+        """Guest (big-endian) signed halfword; recomp RDRAM stores native LE words."""
+        off = (a - 0x80000000) & ~3
+        w = struct.unpack_from('<I', d, off)[0]
+        v = (w >> 16) if (a & 3) == 0 else (w & 0xFFFF)
+        return v - 0x10000 if v >= 0x8000 else v
+
+    def gw(a):
+        return struct.unpack_from('<I', d, a - 0x80000000)[0]
+
+    pvs = gw(0x800CE678)      # 20-byte rows of 10 s16 entries, -1 terminated
+    rec64 = gw(0x800BF1D0)    # viewport-0 segment record list (64-byte stride)
+    rec16 = gw(0x800BF1C0)    # 16-byte test-point records
+    circuit = gh(0x800CE794)
+    players = gh(0x800CE6A4)
+    radius = struct.unpack_from('<f', d, 0x88FD0 + (circuit * 5 + players) * 4)[0]
+    print(f'pvs=0x{pvs:08X} rec64=0x{rec64:08X} rec16=0x{rec16:08X} '
+          f'circuit={circuit} players={players} radius={radius:.0f}')
+    if not (0x80000000 <= rec64 < 0x80800000):
+        sys.exit('segment record base is null -- snapshot not taken in a race?')
+
+    def point(seg):
+        idx = gh(rec64 + seg * 64 + 0x20)
+        x = gh(rec16 + idx * 16 + 0x0) + gh(rec64 + seg * 64 + 0x10)
+        z = gh(rec16 + idx * 16 + 0x2) + gh(rec64 + seg * 64 + 0x12)
+        return x, z
+
+    # Segment count: PVS rows are only sane for real segments; stop at the first
+    # row whose entries leave plausible range.
+    rows = []
+    k = 0
+    while k < 200:
+        raw = [gh(pvs + k * 20 + i * 2) for i in range(10)]
+        ents = []
+        for v in raw:
+            if v < 0:
+                break
+            ents.append(v)
+        if (not ents and k > 0) or any(v > 4096 for v in ents):
+            break
+        rows.append(ents)
+        k += 1
+
+    n = len(rows)
+    total = 0
+    worst = []
+    for k, ents in enumerate(rows):
+        cx, cz = point(k)
+        for e in ents:
+            if e >= n:
+                continue
+            x, z = point(e)
+            dist = ((x - cx) ** 2 + (z - cz) ** 2) ** 0.5
+            total += 1
+            if dist >= radius:
+                worst.append((dist, k, e))
+    worst.sort(reverse=True)
+    print(f'segments={n} entries={total} culled at radius {radius:.0f}: {len(worst)}')
+    for dist, k, e in worst:
+        print(f'  camera in seg {k:3d} hides entry {e:3d} at dist {dist:9.0f}')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        sys.exit(__doc__)
+    main(sys.argv[1])


### PR DESCRIPTION
Residual distance pop-in — worst on CIRCUIT 5 (the city track) — traced to a mechanism the #88 audit missed: the scene builder `func_8000A6C0` distance-culls every entry of the camera segment's precomputed 10-slot visibility list against a **per-circuit, per-player-count radius table** (`float[6][5]` at `0x80088FD0`). The radii are N64 fill-rate budgets; the city circuits are authored shortest:

| circuit (1P column) | radius |
|---|---|
| 1 | 55000 |
| 2 | 50000 |
| 3 | 40000 |
| 4 | 45000 |
| **5 / 6 (city)** | **35000** |

(multiplayer columns drop to 20000–27500)

On CIRCUIT 5 the new `tools/pvs_distance_audit.py` (replays the builder's exact test arithmetic offline from a `LAMBO_RACE_DL_DUMP` RDRAM snapshot) shows 4 of 124 visibility entries culled stock — segments 28–30 hide segment 31 sitting ~51k units down a long street, i.e. a whole city block popping in at the 35000 edge. With the lift: 0 culled.

**Fix** (under the existing `no_lod` key): a per-frame `[[patches.hook]]` on the world-draw path (`0x8000CD3C`, before the first table read) rewrites the 30 radii to 1e9 via `lambo_no_lod_draw_distance` — per frame rather than once at load because a savestate restore (#22) brings the ROM values back. The forward-cone/half-plane tests and the authored visibility lists are untouched, so nothing is synthesised — segments the game already streamed just stop being hidden. Residual pop beyond this would be visibility-list-bound (entry absent from the row), not observed on the verification data.

**Why every earlier pass missed it:** the compare is `c.lt.s` against a *table load*, not an immediate — `scan_lod_patterns.py` classified the builder's compares as "normalisation math", and #83's "draw distance measured intact" was measured on a long-radius circuit. Falsifies §1 Axis B for within-mode pop; documented as `docs/no_lod_audit.md` §8.

**Verified:** full build green; headless CIRCUIT 5 runs (`LAMBO_WARP=5`) with `LAMBO_NO_LOD=0/1` — table verifiably rewritten in the RDRAM dump, walked DLs byte-identical at frames where the cull was not binding (no unintended change), boot/race smoke clean. `gen_syms_toml.py` PATCH_BLOCKS synced with the toml (regen is byte-clean).
