### PR TITLE
debug: gate first-party logs behind --lambo-debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/lambo_gpu_advisory.cpp  # issue #109: outdated-Intel-driver detection + user-facing fix advisory
         src/lambo_warp.c       # issue #12: developer warp menu (F1-F6 / LAMBO_WARP race-track warp)
         src/lambo_savestate.c  # issue #22: developer save-state (F7/F8 / LAMBO_STATE_LOAD RDRAM snapshot)
+        src/lambo_log.cpp      # first-party debug-logging gate (--lambo-debug CLI flag)
     )
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/aspMain.cpp)
         list(APPEND LAMBO_SOURCES src/aspMain.cpp)

--- a/src/lambo_audio.cpp
+++ b/src/lambo_audio.cpp
@@ -21,6 +21,8 @@
 
 #include "lambo_audio.h"
 
+#include "lambo_log.h"
+
 #include <SDL.h>
 #include <ultramodern/ultramodern.hpp>
 #include "recomp.h" // recomp_context + MEM_W for the func_80079720 native override below
@@ -63,8 +65,7 @@ std::mutex g_state_mtx;
 void log_opened_once() {
     bool expected = false;
     if (g_init_logged.compare_exchange_strong(expected, true)) {
-        std::fprintf(stderr,
-                     "[probe] audio: opened SDL2 device freq=%u fmt=%d ch=%u samples=%u\n",
+        LAMBO_LOG("probe", "audio: opened SDL2 device freq=%u fmt=%d ch=%u samples=%u\n",
                      (unsigned)g_obtained.freq, (int)g_obtained.format,
                      (unsigned)g_obtained.channels, (unsigned)g_obtained.samples);
     }
@@ -84,8 +85,7 @@ void submit(const int16_t* pcm, size_t sample_count) {
             if (pcm[i] != 0) {
                 bool exp2 = false;
                 if (g_first_nonsilent_logged.compare_exchange_strong(exp2, true)) {
-                    std::fprintf(stderr,
-                                 "[probe] audio: first NON-SILENT buffer (sample[%zu]=%d of %zu)\n",
+                    LAMBO_LOG("probe", "audio: first NON-SILENT buffer (sample[%zu]=%d of %zu)\n",
                                  i, (int)pcm[i], sample_count);
                 }
                 break;
@@ -106,7 +106,7 @@ void submit(const int16_t* pcm, size_t sample_count) {
         static std::atomic<bool> s_oversize_logged{false};
         bool exp = false;
         if (s_oversize_logged.compare_exchange_strong(exp, true)) {
-            std::fprintf(stderr, "[probe] audio: dropped oversize submit (%zu samples > AI max)\n",
+            LAMBO_LOG("probe", "audio: dropped oversize submit (%zu samples > AI max)\n",
                          sample_count);
         }
         return;
@@ -140,7 +140,7 @@ void submit(const int16_t* pcm, size_t sample_count) {
     const bool native_chan  = g_obtained.channels == 2;
     if (native_rate && native_fmt && native_chan) {
         if (SDL_QueueAudio(g_dev, swapped.data(), byte_count) != 0) {
-            std::fprintf(stderr, "[probe] audio: SDL_QueueAudio failed: %s\n", SDL_GetError());
+            LAMBO_LOG("probe", "audio: SDL_QueueAudio failed: %s\n", SDL_GetError());
         }
     } else {
         // Convert via a PERSISTENT SDL_AudioStream (stateful resampler — see the note at
@@ -154,20 +154,20 @@ void submit(const int16_t* pcm, size_t sample_count) {
                                           g_obtained.freq);
             g_stream_src_rate = g_desired_rate;
             if (g_stream == nullptr) {
-                std::fprintf(stderr, "[probe] audio: SDL_NewAudioStream failed: %s\n",
+                LAMBO_LOG("probe", "audio: SDL_NewAudioStream failed: %s\n",
                              SDL_GetError());
             }
         }
         if (g_stream == nullptr) {
             // Degraded fallback: queue unconverted (wrong rate beats silence).
             if (SDL_QueueAudio(g_dev, swapped.data(), byte_count) != 0) {
-                std::fprintf(stderr, "[probe] audio: SDL_QueueAudio (fallback) failed: %s\n",
+                LAMBO_LOG("probe", "audio: SDL_QueueAudio (fallback) failed: %s\n",
                              SDL_GetError());
             }
             return;
         }
         if (SDL_AudioStreamPut(g_stream, swapped.data(), (int)byte_count) != 0) {
-            std::fprintf(stderr, "[probe] audio: SDL_AudioStreamPut failed: %s\n", SDL_GetError());
+            LAMBO_LOG("probe", "audio: SDL_AudioStreamPut failed: %s\n", SDL_GetError());
             return;
         }
         const int avail = SDL_AudioStreamAvailable(g_stream);
@@ -177,7 +177,7 @@ void submit(const int16_t* pcm, size_t sample_count) {
             const int got = SDL_AudioStreamGet(g_stream, out.data(), avail);
             if (got > 0) {
                 if (SDL_QueueAudio(g_dev, out.data(), (Uint32)got) != 0) {
-                    std::fprintf(stderr, "[probe] audio: SDL_QueueAudio (stream) failed: %s\n",
+                    LAMBO_LOG("probe", "audio: SDL_QueueAudio (stream) failed: %s\n",
                                  SDL_GetError());
                 }
             }
@@ -187,8 +187,7 @@ void submit(const int16_t* pcm, size_t sample_count) {
     bool expected = false;
     if (g_first_hit_logged.compare_exchange_strong(expected, true)) {
         const uint32_t frames = (uint32_t)(sample_count / 2);
-        std::fprintf(stderr,
-                     "[probe] audio: first osAiSetNextBuffer routed (%u samples, %u frames)\n",
+        LAMBO_LOG("probe", "audio: first osAiSetNextBuffer routed (%u samples, %u frames)\n",
                      (unsigned)sample_count, (unsigned)frames);
     }
 }
@@ -237,7 +236,7 @@ size_t get_frames_remaining() {
 void set_frequency(uint32_t freq) {
     std::lock_guard<std::mutex> lock(g_state_mtx);
     if (freq != g_desired_rate) {
-        std::fprintf(stderr, "[probe] audio: set_frequency %u -> %u\n", g_desired_rate, freq);
+        LAMBO_LOG("probe", "audio: set_frequency %u -> %u\n", g_desired_rate, freq);
     }
     g_desired_rate = freq;
     // We do not reopen the device on every set_frequency. SDL honours the
@@ -268,7 +267,7 @@ void init(uint32_t desired_sample_rate) {
     {
         const char* headless = std::getenv("LAMBO_HEADLESS");
         if (headless && headless[0] && headless[0] != '0') {
-            std::fprintf(stderr, "[probe] audio: headless -- no SDL device (ideal-drain sink)\n");
+            LAMBO_LOG("probe", "audio: headless -- no SDL device (ideal-drain sink)\n");
             return;
         }
     }
@@ -281,7 +280,7 @@ void init(uint32_t desired_sample_rate) {
 #endif
 
     if (SDL_InitSubSystem(SDL_INIT_AUDIO) != 0) {
-        std::fprintf(stderr, "[probe] audio: SDL_InitSubSystem(SDL_INIT_AUDIO) failed: %s\n",
+        LAMBO_LOG("probe", "audio: SDL_InitSubSystem(SDL_INIT_AUDIO) failed: %s\n",
                      SDL_GetError());
         return;
     }
@@ -299,7 +298,7 @@ void init(uint32_t desired_sample_rate) {
                                 &want, &g_obtained,
                                 SDL_AUDIO_ALLOW_ANY_CHANGE);
     if (g_dev == 0) {
-        std::fprintf(stderr, "[probe] audio: SDL_OpenAudioDevice failed: %s\n", SDL_GetError());
+        LAMBO_LOG("probe", "audio: SDL_OpenAudioDevice failed: %s\n", SDL_GetError());
         return;
     }
     SDL_PauseAudioDevice(g_dev, 0);  // start playback immediately

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -10,6 +10,8 @@
 #include <cstdlib>
 #include <fstream>
 
+#include "lambo_log.h"
+
 #include "json/json.hpp"
 
 namespace {
@@ -58,13 +60,13 @@ void from_or_default(const nlohmann::json& j, const char* key, T& out) {
     try {
         T parsed = it->get<T>();
         if (nlohmann::json(parsed) != *it) {
-            std::fprintf(stderr, "[config] %s: invalid value %s -- keeping default\n",
+            LAMBO_LOG("config", "%s: invalid value %s -- keeping default\n",
                          key, it->dump().c_str());
             return;
         }
         out = parsed;
     } catch (const nlohmann::json::exception&) {
-        std::fprintf(stderr, "[config] %s: wrong type -- keeping default\n", key);
+        LAMBO_LOG("config", "%s: wrong type -- keeping default\n", key);
     }
 }
 
@@ -115,7 +117,7 @@ void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c
     // permanently headless, so reset to defaults instead.
     if (g_window_size.width < 320 || g_window_size.width > 7680 ||
         g_window_size.height < 240 || g_window_size.height > 4320) {
-        std::fprintf(stderr, "[config] window %dx%d out of range -- using %dx%d\n",
+        LAMBO_LOG("config", "window %dx%d out of range -- using %dx%d\n",
                      g_window_size.width, g_window_size.height,
                      kDefaultWindowWidth, kDefaultWindowHeight);
         g_window_size = {kDefaultWindowWidth, kDefaultWindowHeight};
@@ -135,7 +137,7 @@ ReadResult read_graphics_file(const std::filesystem::path& path,
         from_json(j, cfg);
         return ReadResult::Ok;
     } catch (const nlohmann::json::exception& e) {
-        std::fprintf(stderr, "[config] %s unparseable (%s); using defaults IN MEMORY"
+        LAMBO_LOG("config", "%s unparseable (%s); using defaults IN MEMORY"
                      " -- file left untouched, fix or delete it\n",
                      path.string().c_str(), e.what());
         return ReadResult::Unparseable;
@@ -221,7 +223,7 @@ ultramodern::renderer::GraphicsConfig load_and_apply_graphics() {
     if (r != ReadResult::Unparseable) {
         save_graphics(cfg);
     }
-    std::fprintf(stderr, "[config] graphics config: %s\n", path.string().c_str());
+    LAMBO_LOG("config", "graphics config: %s\n", path.string().c_str());
     return cfg;
 }
 
@@ -244,13 +246,13 @@ void save_graphics(const ultramodern::renderer::GraphicsConfig& cfg) {
     std::filesystem::create_directories(path.parent_path(), ec);
     std::ofstream out{path};
     if (!out.good()) {
-        std::fprintf(stderr, "[config] cannot write %s\n", path.string().c_str());
+        LAMBO_LOG("config", "cannot write %s\n", path.string().c_str());
         return;
     }
     out << to_json(cfg).dump(4) << "\n";
     out.flush();
     if (!out.good()) {
-        std::fprintf(stderr, "[config] write to %s FAILED (disk full / permissions?)"
+        LAMBO_LOG("config", "write to %s FAILED (disk full / permissions?)"
                      " -- settings may not persist\n", path.string().c_str());
     }
 }

--- a/src/lambo_log.cpp
+++ b/src/lambo_log.cpp
@@ -1,0 +1,14 @@
+#include "lambo_log.h"
+
+#include <cstring>
+
+bool lambo_log_enabled = false;
+
+void lambo_log_parse_flag(int argc, char** argv) {
+    for (int i = 1; i < argc; ++i) {
+        if (argv[i] && std::strcmp(argv[i], "--lambo-debug") == 0) {
+            lambo_log_enabled = true;
+            return;
+        }
+    }
+}

--- a/src/lambo_log.h
+++ b/src/lambo_log.h
@@ -1,0 +1,37 @@
+// First-party debug-logging gate (--lambo-debug). C/C++ portable; routed from
+// C TUs via plain C-linkage symbols (no namespace gymnastics).
+//
+// C-linkage chosen so C TUs (lambo_savestate.c, lambo_warp.c, libultra_stubs.c)
+// can use the same gate as C++ without a wrapper. lambo_crash.cpp and the
+// opt-in env-var features (LAMBO_PAK_TRACE, LAMBO_DL_INSPECT, ...) are NOT
+// routed through this header.
+
+#ifndef LAMBO_LOG_H
+#define LAMBO_LOG_H
+
+#include <stdbool.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern bool lambo_log_enabled;
+void lambo_log_parse_flag(int argc, char** argv);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+// `tag` MUST be a string literal -- concatenation happens here, not via printf
+// format. Args are NOT evaluated when the gate is closed (they live inside an
+// untaken if branch).
+#define LAMBO_LOG(tag, ...) \
+    do { if (lambo_log_enabled) fprintf(stderr, "[" tag "] " __VA_ARGS__); } while (0)
+
+// Crash dumps and fatal early-init errors only -- never gate a line behind
+// this for convenience.
+#define LAMBO_LOG_ALWAYS(tag, ...) \
+    fprintf(stderr, "[" tag "] " __VA_ARGS__)
+
+#endif // LAMBO_LOG_H

--- a/src/lambo_savestate.c
+++ b/src/lambo_savestate.c
@@ -57,6 +57,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "lambo_log.h"
+
 #include "recomp.h"
 
 // After a wholesale RDRAM restore, guest RAM's OSThread.context fields hold the SAVE process's
@@ -102,12 +104,12 @@ static const char* slot_path(void) {
 static void do_save(uint8_t* rdram, const char* path) {
     char tmp[1100];
     if ((size_t)snprintf(tmp, sizeof(tmp), "%s.tmp", path) >= sizeof(tmp)) {
-        fprintf(stderr, "[state] save: path too long: %s\n", path);
+        LAMBO_LOG("state", "save: path too long: %s\n", path);
         return;
     }
     FILE* f = fopen(tmp, "wb");
     if (f == NULL) {
-        fprintf(stderr, "[state] save: cannot open %s for write\n", tmp);
+        LAMBO_LOG("state", "save: cannot open %s for write\n", tmp);
         return;
     }
     state_header_t h;
@@ -122,7 +124,7 @@ static void do_save(uint8_t* rdram, const char* path) {
     ok = ok && (fflush(f) == 0);
     fclose(f);
     if (!ok) {
-        fprintf(stderr, "[state] save: write failed for %s\n", path);
+        LAMBO_LOG("state", "save: write failed for %s\n", path);
         remove(tmp);
         return;
     }
@@ -134,11 +136,11 @@ static void do_save(uint8_t* rdram, const char* path) {
     if (rename(tmp, path) != 0) {
         remove(path);
         if (rename(tmp, path) != 0) {
-            fprintf(stderr, "[state] save: could not publish %s; snapshot kept at %s\n", path, tmp);
+            LAMBO_LOG("state", "save: could not publish %s; snapshot kept at %s\n", path, tmp);
             return;
         }
     }
-    fprintf(stderr, "[state] saved %u bytes to %s (state=%u)\n",
+    LAMBO_LOG("state", "saved %u bytes to %s (state=%u)\n",
             RDRAM_SNAP_SIZE, path, h.state);
 }
 
@@ -148,32 +150,32 @@ static void do_save(uint8_t* rdram, const char* path) {
 static void do_load(uint8_t* rdram, const char* path) {
     FILE* f = fopen(path, "rb");
     if (f == NULL) {
-        fprintf(stderr, "[state] load: cannot open %s\n", path);
+        LAMBO_LOG("state", "load: cannot open %s\n", path);
         return;
     }
     state_header_t h;
     if (fread(&h, 1, sizeof(h), f) != sizeof(h) ||
         memcmp(h.magic, STATE_MAGIC, 8) != 0) {
-        fprintf(stderr, "[state] load: %s is not a save-state (bad magic)\n", path);
+        LAMBO_LOG("state", "load: %s is not a save-state (bad magic)\n", path);
         fclose(f);
         return;
     }
     if (h.version != STATE_VERSION || h.rdram_size != RDRAM_SNAP_SIZE) {
-        fprintf(stderr, "[state] load: %s version/size mismatch (v%u size %u)\n",
+        LAMBO_LOG("state", "load: %s version/size mismatch (v%u size %u)\n",
                 path, h.version, h.rdram_size);
         fclose(f);
         return;
     }
     uint8_t* buf = (uint8_t*)malloc(RDRAM_SNAP_SIZE);
     if (buf == NULL) {
-        fprintf(stderr, "[state] load: out of memory\n");
+        LAMBO_LOG("state", "load: out of memory\n");
         fclose(f);
         return;
     }
     size_t got = fread(buf, 1, RDRAM_SNAP_SIZE, f);
     fclose(f);
     if (got != RDRAM_SNAP_SIZE) {
-        fprintf(stderr, "[state] load: %s truncated (%zu/%u bytes)\n",
+        LAMBO_LOG("state", "load: %s truncated (%zu/%u bytes)\n",
                 path, got, RDRAM_SNAP_SIZE);
         free(buf);
         return;
@@ -183,7 +185,7 @@ static void do_load(uint8_t* rdram, const char* path) {
     // Repair the native OSThread.context pointers the memcpy just clobbered with the save
     // process's addresses; without this the scheduler dereferences garbage on the next tick.
     ultramodern_relink_thread_contexts(rdram);
-    fprintf(stderr, "[state] loaded %u bytes from %s (state=%u)\n",
+    LAMBO_LOG("state", "loaded %u bytes from %s (state=%u)\n",
             RDRAM_SNAP_SIZE, path, h.state);
 }
 

--- a/src/lambo_warp.c
+++ b/src/lambo_warp.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "lambo_log.h"
 #include "recomp.h"
 
 // Audio quiesce pair the ROM runs before every state->7 write (menu RACE action,
@@ -84,7 +85,7 @@ static void parse_env_request(void) {
         if (p != NULL) p++;
     }
     if (v[0] < 1 || v[0] > 6) {
-        fprintf(stderr, "[warp] LAMBO_WARP=%s invalid: circuit must be 1-6\n", env);
+        LAMBO_LOG("warp", "LAMBO_WARP=%s invalid: circuit must be 1-6\n", env);
         return;
     }
     atomic_store_explicit(&g_warp_request, pack_request(v[0] - 1, v[1], v[2], v[3]),
@@ -146,6 +147,6 @@ void lambo_warp_tick(uint8_t* rdram, recomp_context* ctx) {
     func_80008ECC(rdram, ctx);
     MEM_H(0, (gpr)(int32_t)WARP_STATE) = 7;
 
-    fprintf(stderr, "[warp] %s: single race, %d lap(s), car %d, %d player(s) (from state %d)\n",
+    LAMBO_LOG("warp", "%s: single race, %d lap(s), car %d, %d player(s) (from state %d)\n",
             lambo_scene_table[circuit0], laps, car, players, state);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #include "lambo_config.h"
 #include "lambo_crash.h"   // issue #13 / A14
 #include "lambo_gpu_advisory.h"  // issue #109: outdated-driver popup handoff
+#include "lambo_log.h"   
 // ultramodern's native VI API (events.cpp), used by the promote_vi_context RT64 bridge.
 extern "C" void osViSwapBuffer(uint8_t* rdram, int32_t frameBufPtr);
 extern "C" void osViSetMode(uint8_t* rdram, int32_t mode_);
@@ -88,12 +89,12 @@ static int watchdog_seconds() {
 }
 
 static void on_init_cb(uint8_t*, recomp_context*) {
-    std::fprintf(stderr, "[probe] init complete; entering recomp_entrypoint @ 0x80000400\n");
+    LAMBO_LOG("probe", "init complete; entering recomp_entrypoint @ 0x80000400\n");
 }
 
 static void thread_create_cb(uint8_t*, recomp_context*) {
     int n = ++g_threads;
-    if (n <= 12) std::fprintf(stderr, "[probe] game thread #%d started (osCreateThread)\n", n);
+    if (n <= 12) LAMBO_LOG("probe", "game thread #%d started (osCreateThread)\n", n);
 }
 
 // Print the one-line boot summary the runtime guard (tests/pivot/test_boot_smoke.py) parses,
@@ -105,7 +106,7 @@ static void thread_create_cb(uint8_t*, recomp_context*) {
 // quitting anyway, so skip the unwind and let process exit tear the game threads down.
 // (Graceful game-thread shutdown is RT64-integration work, #58.)
 [[noreturn]] static void boot_summary_and_exit() {
-    std::fprintf(stderr, "[probe] boot summary; threads=%d vis=%d first_vi=%d max_state=%d swaps=%d\n",
+    LAMBO_LOG("probe", "boot summary; threads=%d vis=%d first_vi=%d max_state=%d swaps=%d\n",
                  g_threads.load(), g_vis.load(), (int)g_first_vi.load(), g_max_state.load(),
                  g_swaps.load());
     std::fflush(nullptr);
@@ -195,7 +196,7 @@ static void state_probe() {
     if (state > g_max_state.load()) g_max_state.store(state);
     static int s_last = -1;
     if (state != s_last) {
-        std::fprintf(stderr, "[state] vi=%d  state=%d (was %d)\n", g_vis.load(), state, s_last);
+        LAMBO_LOG("state", "vi=%d  state=%d (was %d)\n", g_vis.load(), state, s_last);
         s_last = state;
     }
 }
@@ -216,7 +217,7 @@ static void menu_probe() {
     int sub = (int)(int16_t)h(0x80098560);
     static int s_scr = -9999, s_sub = -9999;
     if (scr != s_scr || sub != s_sub) {
-        std::fprintf(stderr, "[menu] vi=%d  screen=%d sub=%d (was %d/%d)\n",
+        LAMBO_LOG("menu", "vi=%d  screen=%d sub=%d (was %d/%d)\n",
                      g_vis.load(), scr, sub, s_scr, s_sub);
         s_scr = scr; s_sub = sub;
     }
@@ -239,7 +240,7 @@ static void pace_probe(int vi_n) {
     if ((vi_n % 600) == 0) {
         static int s_prev_total = 0;
         int total = g_swaps.load();
-        std::fprintf(stderr, "[pace] vi=%d swaps_last_600vi=%d (~%.1f fps)\n",
+        LAMBO_LOG("pace", "vi=%d swaps_last_600vi=%d (~%.1f fps)\n",
                      vi_n, total - s_prev_total, (total - s_prev_total) / 10.0);
         s_prev_total = total;
     }
@@ -253,9 +254,9 @@ static void vi_cb() {
     int n = ++g_vis;
     pace_probe(n);
     if ((n % 50) == 0) lambo_thread_trace_dump(n); // THROWAWAY: per-thread recv/send snapshot to find the frozen thread
-    if (!g_first_vi.exchange(true)) std::fprintf(stderr, "[probe] FIRST VI retrace\n");
+    if (!g_first_vi.exchange(true)) LAMBO_LOG("probe", "FIRST VI retrace\n");
     if (n == kQuitAfterVis) {
-        std::fprintf(stderr, "[probe] reached %d VIs; quitting\n", n);
+        LAMBO_LOG("probe", "reached %d VIs; quitting\n", n);
         boot_summary_and_exit();
     }
 }
@@ -276,7 +277,7 @@ static void vi_cb() {
 static RspExitReason audio_ucode_noop(uint8_t* /*rdram*/, uint32_t /*ucode_addr*/) {
     static std::atomic<bool> logged{false};
     if (!logged.exchange(true))
-        std::fprintf(stderr, "[probe] audio_ucode_noop: first M_AUDTASK (type 2) -> Broke (no PCM; #53)\n");
+        LAMBO_LOG("probe", "audio_ucode_noop: first M_AUDTASK (type 2) -> Broke (no PCM; #53)\n");
     return RspExitReason::Broke;
 }
 
@@ -291,13 +292,13 @@ static RspUcodeFunc* get_rsp_microcode_stub(const OSTask* task) {
     if (task->t.type == 2) return aspMain; // M_AUDTASK: RSPRecomp'd real synthesis (#53)
     static std::atomic<bool> logged{false};
     if (!logged.exchange(true))
-        std::fprintf(stderr, "[probe] get_rsp_microcode: unhandled task type %u -> nullptr\n",
+        LAMBO_LOG("probe", "get_rsp_microcode: unhandled task type %u -> nullptr\n",
                      (unsigned)task->t.type);
     return nullptr;
 }
 
 static void message_box_stub(const char* msg) {
-    std::fprintf(stderr, "[probe] message_box: %s\n", msg);
+    LAMBO_LOG("probe", "message_box: %s\n", msg);
 }
 
 // Input (#68) — defined below in the input section; used by the window/pump callbacks above them.
@@ -324,13 +325,13 @@ static void toggle_fullscreen() {
     bool to_fullscreen = (SDL_GetWindowFlags(g_sdl_window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0;
     if (SDL_SetWindowFullscreen(g_sdl_window,
                                 to_fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0) != 0) {
-        std::fprintf(stderr, "[config] fullscreen toggle FAILED: %s\n", SDL_GetError());
+        LAMBO_LOG("config", "fullscreen toggle FAILED: %s\n", SDL_GetError());
         return; // window unchanged -> persist nothing, config and reality stay agreed
     }
     lambo::config::update_saved_window_mode(
         to_fullscreen ? ultramodern::renderer::WindowMode::Fullscreen
                       : ultramodern::renderer::WindowMode::Windowed);
-    std::fprintf(stderr, "[config] fullscreen %s (F11 / Alt+Enter)\n", to_fullscreen ? "ON" : "OFF");
+    LAMBO_LOG("config", "fullscreen %s (F11 / Alt+Enter)\n", to_fullscreen ? "ON" : "OFF");
 }
 
 static ultramodern::renderer::WindowHandle create_window_stub(void* /*gfx_data*/) {
@@ -348,7 +349,7 @@ static ultramodern::renderer::WindowHandle create_window_stub(void* /*gfx_data*/
         SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
         // GAMECONTROLLER pulls in JOYSTICK + enables CONTROLLERDEVICEADDED/REMOVED events (#68).
         if (SDL_InitSubSystem(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER) != 0) {
-            std::fprintf(stderr, "[rt64] SDL_InitSubSystem(VIDEO|GAMECONTROLLER) failed: %s -- staying headless\n",
+            LAMBO_LOG("rt64", "SDL_InitSubSystem(VIDEO|GAMECONTROLLER) failed: %s -- staying headless\n",
                          SDL_GetError());
             return ultramodern::renderer::WindowHandle{};
         }
@@ -371,13 +372,13 @@ static ultramodern::renderer::WindowHandle create_window_stub(void* /*gfx_data*/
                                               SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
                                               win_size.width, win_size.height, flags);
         if (window == nullptr) {
-            std::fprintf(stderr, "[rt64] SDL_CreateWindow failed: %s -- staying headless\n",
+            LAMBO_LOG("rt64", "SDL_CreateWindow failed: %s -- staying headless\n",
                          SDL_GetError());
             return ultramodern::renderer::WindowHandle{};
         }
         g_sdl_window = window;
 #if defined(__linux__)
-        std::fprintf(stderr, "[rt64] SDL window created (%dx%d, Vulkan surface)\n",
+        LAMBO_LOG("rt64", "SDL window created (%dx%d, Vulkan surface)\n",
                      win_size.width, win_size.height);
         return ultramodern::renderer::WindowHandle{window};
 #elif defined(_WIN32)
@@ -387,16 +388,16 @@ static ultramodern::renderer::WindowHandle create_window_stub(void* /*gfx_data*/
         SDL_SysWMinfo wmInfo;
         SDL_VERSION(&wmInfo.version);
         if (SDL_GetWindowWMInfo(window, &wmInfo) != SDL_TRUE) {
-            std::fprintf(stderr, "[rt64] SDL_GetWindowWMInfo failed: %s -- staying headless\n",
+            LAMBO_LOG("rt64", "SDL_GetWindowWMInfo failed: %s -- staying headless\n",
                          SDL_GetError());
             SDL_DestroyWindow(window);
             return ultramodern::renderer::WindowHandle{};
         }
-        std::fprintf(stderr, "[rt64] SDL window created (%dx%d, Win32 HWND -> D3D12)\n",
+        LAMBO_LOG("rt64", "SDL window created (%dx%d, Win32 HWND -> D3D12)\n",
                      win_size.width, win_size.height);
         return ultramodern::renderer::WindowHandle{wmInfo.info.win.window, GetCurrentThreadId()};
 #else
-        std::fprintf(stderr, "[rt64] window handle wiring not implemented on this platform\n");
+        LAMBO_LOG("rt64", "window handle wiring not implemented on this platform\n");
         SDL_DestroyWindow(window);
         return ultramodern::renderer::WindowHandle{};
 #endif
@@ -414,7 +415,7 @@ static void update_gfx_stub(void* /*gfx_data*/) {
             // process exit; see boot_summary_and_exit's rationale).
             if (event.type == SDL_QUIT ||
                 (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE)) {
-                std::fprintf(stderr, "[probe] window closed; quitting\n");
+                LAMBO_LOG("probe", "window closed; quitting\n");
                 boot_summary_and_exit();
             }
             else if (event.type == SDL_KEYDOWN && !event.key.repeat &&
@@ -630,7 +631,7 @@ static void input_open_controller(int joystick_index) {
     if (!SDL_IsGameController(joystick_index)) return;
     g_pad = SDL_GameControllerOpen(joystick_index);
     if (g_pad != nullptr)
-        std::fprintf(stderr, "[input] controller connected: %s\n",
+        LAMBO_LOG("input", "controller connected: %s\n",
                      SDL_GameControllerName(g_pad) ? SDL_GameControllerName(g_pad) : "(unknown)");
 }
 static void input_close_controller(SDL_JoystickID which) {
@@ -639,7 +640,7 @@ static void input_close_controller(SDL_JoystickID which) {
     if (js != nullptr && SDL_JoystickInstanceID(js) == which) {
         SDL_GameControllerClose(g_pad);
         g_pad = nullptr;
-        std::fprintf(stderr, "[input] controller disconnected\n");
+        LAMBO_LOG("input", "controller disconnected\n");
     }
 }
 
@@ -677,8 +678,20 @@ int main(int argc, char** argv) {
     if (std::getenv("LAMBO_LIGHTING_SELFTEST")) {
         return headless::run_lighting_selftest();
     }
-    const char* rom_path = (argc > 1) ? argv[1] : "Automobili Lamborghini (USA).z64";
-    std::fprintf(stderr, "[probe] ROM: %s\n", rom_path);
+    // Parse --lambo-debug BEFORE anything else that might print a [probe] line.
+    // The flag is read by every LAMBO_LOG() site via the lambo_log_enabled bool.
+    lambo_log_parse_flag(argc, argv);
+    // The ROM path is the first non-flag positional arg; skip argv entries that
+    // start with "--" so e.g. `lamborghini_modern --lambo-debug` still finds the
+    // bundled ROM at argv[2] (or falls back to the default when no path given).
+    const char* rom_path = "Automobili Lamborghini (USA).z64";
+    for (int i = 1; i < argc; ++i) {
+        if (argv[i] && argv[i][0] != '-' && argv[i][0] != '\0') {
+            rom_path = argv[i];
+            break;
+        }
+    }
+    LAMBO_LOG("probe", "ROM: %s\n", rom_path);
 
     register_overlays();
     // After register_overlays so the native-ptr -> vram map is already wired.
@@ -688,7 +701,7 @@ int main(int argc, char** argv) {
     // sleep then a deliberate crash so the dump format can be verified in
     // CI / field testing without waiting for a real bug.
     if (const char* ct = std::getenv("LAMBO_CRASH_TEST")) {
-        std::fprintf(stderr, "[probe] LAMBO_CRASH_TEST=%s; injecting deliberate crash in 2s\n", ct);
+        LAMBO_LOG("probe", "LAMBO_CRASH_TEST=%s; injecting deliberate crash in 2s\n", ct);
         std::thread([](const char* reason){
             std::this_thread::sleep_for(std::chrono::seconds(2));
             lambo::crash::record_recent(0x80001CD0u, 0x800024F8u);  // func_800028D0 entry, $ra into menu driver
@@ -724,16 +737,16 @@ int main(int argc, char** argv) {
     std::u8string game_id = u8"lamborghini.us";
     recomp::RomValidationError verr = recomp::select_rom(rom_path, game_id);
     if (verr != recomp::RomValidationError::Good) {
-        std::fprintf(stderr, "[probe] select_rom FAILED (RomValidationError=%d)\n", (int)verr);
+        LAMBO_LOG("probe", "select_rom FAILED (RomValidationError=%d)\n", (int)verr);
         return 1;
     }
-    std::fprintf(stderr, "[probe] ROM validated; rom_hash matches\n");
+    LAMBO_LOG("probe", "ROM validated; rom_hash matches\n");
 
     // recomp::start() blocks the calling thread until ultramodern::quit(), so
     // kick the game off from a side thread once the runtime has set up.
     std::thread starter([game_id]() {
         std::this_thread::sleep_for(std::chrono::milliseconds(150));
-        std::fprintf(stderr, "[probe] calling start_game\n");
+        LAMBO_LOG("probe", "calling start_game\n");
         std::u8string gid = game_id;
         recomp::start_game(gid);
     });
@@ -743,7 +756,7 @@ int main(int argc, char** argv) {
     const int wd_sec = watchdog_seconds();
     std::thread watchdog([wd_sec]() {
         std::this_thread::sleep_for(std::chrono::seconds(wd_sec));
-        std::fprintf(stderr, "[probe] WATCHDOG %ds: threads=%d vis=%d first_vi=%d\n",
+        LAMBO_LOG("probe", "WATCHDOG %ds: threads=%d vis=%d first_vi=%d\n",
                      wd_sec, g_threads.load(), g_vis.load(), (int)g_first_vi.load());
         // Exit deterministically (same as the VI-cap path) rather than ultramodern::quit(),
         // whose teardown munmaps RDRAM out from under the live game threads (SIGSEGV race).
@@ -790,13 +803,13 @@ int main(int argc, char** argv) {
         if (end && *end == ':') g_pulse_duty   = (int)std::strtol(end + 1, &end, 10);
         if (end && *end == ':') g_pulse_start  = (int)std::strtol(end + 1, &end, 10);
         if (end && *end == ':') g_pulse_count  = (int)std::strtol(end + 1, nullptr, 10);
-        std::fprintf(stderr, "[probe] input pulse: btn=%04x period=%d duty=%d start=%d count=%d\n",
+        LAMBO_LOG("probe", "input pulse: btn=%04x period=%d duty=%d start=%d count=%d\n",
                      g_pulse_buttons, g_pulse_period, g_pulse_duty, g_pulse_start, g_pulse_count);
     }
     cfg.input_callbacks.poll_input = input_poll_stub;
     cfg.input_callbacks.get_input = input_get_input;
     cfg.input_callbacks.get_connected_device_info = input_device_info;
-    std::fprintf(stderr, "[probe] input: controller0 connected (default), buttons=%04x\n", g_held_buttons);
+    LAMBO_LOG("probe", "input: controller0 connected (default), buttons=%04x\n", g_held_buttons);
 
     // Audio epic #53 (PR 1 of 3): populate the host audio sink. ultramodern
     // reads cfg.audio_callbacks inside recomp::start (recomp.cpp:743), before
@@ -807,9 +820,9 @@ int main(int argc, char** argv) {
     // into SDL via ultramodern's shim.
     lambo::audio::init(48000);
     lambo::audio::get_callbacks(&cfg.audio_callbacks);
-    std::fprintf(stderr, "[probe] audio: callbacks wired (queue_samples/get_frames_remaining/set_frequency)\n");
+    LAMBO_LOG("probe", "audio: callbacks wired (queue_samples/get_frames_remaining/set_frequency)\n");
 
-    std::fprintf(stderr, "[probe] calling recomp::start\n");
+    LAMBO_LOG("probe", "calling recomp::start\n");
     recomp::start(cfg);
     // Reached only via the watchdog quit path (a boot stall before the VI cap): the VI-cap
     // path exits from vi_cb via boot_summary_and_exit() and never returns here.

--- a/src/rt64_renderer.cpp
+++ b/src/rt64_renderer.cpp
@@ -16,6 +16,8 @@
 #include <memory>
 #include <mutex>
 
+#include "lambo_log.h"
+
 #include "hle/rt64_application.h"
 #include "hle/rt64_state.h"
 #include "render/rt64_texture_cache.h"
@@ -180,7 +182,7 @@ void warn_about_gpu_driver(RT64::Application* app, ultramodern::renderer::Graphi
         unsigned v = 0; unsigned long long d = 0;
         if (std::sscanf(fake, "%x,%llx", &v, &d) == 2) {
             vendor = v; driver_version = d;
-            std::fprintf(stderr, "[gpu] LAMBO_FAKE_GPU active: vendor=0x%X driver=0x%llX\n", v, d);
+            LAMBO_LOG("gpu", "LAMBO_FAKE_GPU active: vendor=0x%X driver=0x%llX\n", v, d);
         }
     }
     const int severity = lambo_gpu_advisory_severity(
@@ -195,7 +197,7 @@ void warn_about_gpu_driver(RT64::Application* app, ultramodern::renderer::Graphi
     lambo_gpu_advisory_message(severity, desc.name.c_str(), driver_version,
                                lambo::config::graphics_config_path().string().c_str(),
                                text, sizeof text);
-    std::fprintf(stderr, "[gpu] driver advisory:\n%s\n", text);
+    LAMBO_LOG("gpu", "driver advisory:\n%s\n", text);
     if (severity == LAMBO_GPU_ADVISORY_SEVERE) {
         // The affected user sees only a black window; a console line is not enough.
         // Post to the main thread's event pump, which owns showing the message box.
@@ -291,7 +293,7 @@ public:
         };
 
         if (!try_setup(to_rt64_api(cur_config.api_option))) {
-            std::fprintf(stderr, "[rt64] RT64::Application::setup FAILED (SetupResult=%d, api=%d)\n",
+            LAMBO_LOG("rt64", "RT64::Application::setup FAILED (SetupResult=%d, api=%d)\n",
                          (int)setup_result, (int)cur_config.api_option);
             // RT64 auto-retries the other backend itself only when the API choice is
             // Automatic. For an EXPLICIT choice that fails to initialise we flip once
@@ -309,16 +311,16 @@ public:
                 app = nullptr;
                 return;
             }
-            std::fprintf(stderr, "[rt64] retrying with the other graphics API...\n");
+            LAMBO_LOG("rt64", "retrying with the other graphics API...\n");
             if (!try_setup(fallback)) {
-                std::fprintf(stderr, "[rt64] retry also FAILED (SetupResult=%d)\n", (int)setup_result);
+                LAMBO_LOG("rt64", "retry also FAILED (SetupResult=%d)\n", (int)setup_result);
                 app = nullptr;
                 return;
             }
-            std::fprintf(stderr, "[rt64] retry succeeded (api=%d)\n", (int)chosen_api);
+            LAMBO_LOG("rt64", "retry succeeded (api=%d)\n", (int)chosen_api);
         }
 
-        std::fprintf(stderr, "[rt64] RT64 renderer initialised (api=%d)\n", (int)chosen_api);
+        LAMBO_LOG("rt64", "RT64 renderer initialised (api=%d)\n", (int)chosen_api);
 
         warn_about_gpu_driver(app.get(), chosen_api);
 
@@ -337,14 +339,14 @@ public:
             // Setting this non-empty makes TextureManager::dumpTexture write every
             // uploaded texture (raw TMEM + RDRAM + tile JSON) to the directory.
             app->state->dumpingTexturesDirectory = std::filesystem::path(dump_dir);
-            std::fprintf(stderr, "[rt64] texture dump enabled -> %s\n", dump_dir.c_str());
+            LAMBO_LOG("rt64", "texture dump enabled -> %s\n", dump_dir.c_str());
         }
 
         const std::string pack = lambo::config::texture_pack_path();
         if (!pack.empty()) {
             const bool ok = app->textureCache->loadReplacementDirectory(
                 RT64::ReplacementDirectory(std::filesystem::path(pack)));
-            std::fprintf(stderr, "[rt64] texture pack %s: %s\n",
+            LAMBO_LOG("rt64", "texture pack %s: %s\n",
                          ok ? "loaded" : "FAILED to load", pack.c_str());
         }
     }
@@ -381,8 +383,7 @@ public:
     void send_dl(const OSTask* task) override {
         static int count = 0;
         if (++count == 1) {
-            std::fprintf(stderr,
-                         "[rt64] first send_dl: ucode=0x%08x ucode_data=0x%08x dl=0x%08x\n",
+            LAMBO_LOG("rt64", "first send_dl: ucode=0x%08x ucode_data=0x%08x dl=0x%08x\n",
                          (uint32_t)task->t.ucode, (uint32_t)task->t.ucode_data,
                          (uint32_t)task->t.data_ptr);
         }
@@ -397,7 +398,9 @@ public:
         // comparable against headless logs. VI_ORIGIN/STATUS prove the present path is
         // scanning out the game's REAL framebuffer (via the promote_vi_context bridge),
         // not the pre-game dummy at 0x80700000 / a blanked STATUS of 0.
-        if (count % 30 == 0) {
+        // The lambo_log_enabled check short-circuits the WHOLE block (VI-reg read +
+        // interpolatedMutex lock) on a default boot, not just the inner fprintf.
+        if (lambo_log_enabled && (count % 30 == 0)) {
             const ultramodern::renderer::ViRegs* vr = ultramodern::renderer::get_vi_regs();
             // Interpolation health (#1 display-rate rendering): viOriginalRate is the game's
             // detected update rate (30 for this title), targetRate the present pace RT64 aims
@@ -423,8 +426,7 @@ public:
                 interp_count = fc.count;
                 interp_presented = fc.presented;
             }
-            std::fprintf(stderr,
-                         "[rt64] send_dl count=%d VI_ORIGIN=0x%08x VI_STATUS=0x%04x VI_WIDTH=%u"
+            LAMBO_LOG("rt64", "send_dl count=%d VI_ORIGIN=0x%08x VI_STATUS=0x%04x VI_WIDTH=%u"
                          " | viRate=%u targetRate=%u swapHz=%u interp count=%u presented=%u\n",
                          count, vr->VI_ORIGIN_REG, vr->VI_STATUS_REG, vr->VI_WIDTH_REG,
                          vi_rate, target_rate, swap_hz, interp_count, interp_presented);

--- a/src/stub_renderer.cpp
+++ b/src/stub_renderer.cpp
@@ -14,6 +14,8 @@
 #include <algorithm>
 #include <vector>
 
+#include "lambo_log.h"
+
 #include "ultramodern/renderer_context.hpp"
 
 #include "lambo_rt64.h" // RT64 default presenter (#58); LAMBO_HEADLESS=1 keeps swrender
@@ -242,13 +244,13 @@ static const char* opname(uint8_t op) {
 static void dump_raw(const uint8_t* rdram, uint32_t dl_addr, uint32_t byte_len, int max_cmds) {
     uint32_t off;
     uint32_t noseg[16] = {0};
-    if (!resolve(dl_addr, noseg, &off)) { std::fprintf(stderr, "[dl-inspect]   (unresolvable)\n"); return; }
+    if (!resolve(dl_addr, noseg, &off)) { LAMBO_LOG("dl-inspect", "  (unresolvable)\n"); return; }
     uint32_t end = off + byte_len;
     int n = 0;
     for (uint32_t o = off; o + 8 <= end && o + 8 <= 0x00800000 && n < max_cmds; o += 8, ++n) {
         uint32_t w0 = *(const uint32_t*)(rdram + o);
         uint32_t w1 = *(const uint32_t*)(rdram + o + 4);
-        std::fprintf(stderr, "[dl-inspect]   %3d  %08X %08X  %s\n", n, w0, w1, opname((w0 >> 24) & 0xFF));
+        LAMBO_LOG("dl-inspect", "  %3d  %08X %08X  %s\n", n, w0, w1, opname((w0 >> 24) & 0xFF));
     }
 }
 
@@ -256,12 +258,11 @@ static void dump_summary(const uint8_t* rdram, const OSTask* t) {
     uint32_t seg[16] = {0};
     Stats st;
     uint32_t dl_addr = (uint32_t)(int32_t)t->t.data_ptr;
-    std::fprintf(stderr, "[dl-inspect] --- raw first commands (bounded by data_size) ---\n");
+    LAMBO_LOG("dl-inspect", "--- raw first commands (bounded by data_size) ---\n");
     dump_raw(rdram, dl_addr, (uint32_t)t->t.data_size, 64);
-    std::fprintf(stderr, "[dl-inspect] --- unbounded walk aggregate (may overrun if no in-buffer ENDDL) ---\n");
+    LAMBO_LOG("dl-inspect", "--- unbounded walk aggregate (may overrun if no in-buffer ENDDL) ---\n");
     walk(rdram, dl_addr, seg, st, 0);
-    std::fprintf(stderr,
-        "[dl-inspect] state-gated one-shot DL @ 0x%08X (size=%u)\n"
+    LAMBO_LOG("dl-inspect", "state-gated one-shot DL @ 0x%08X (size=%u)\n"
         "  cmds=%u  vtx_loads=%u vtx_total=%u  tris=%u\n"
         "  mtx=%u popmtx=%u moveword=%u movemem=%u texture=%u geommode=%u\n"
         "  settimg=%u settile=%u loadblock=%u loadtile=%u settilesize=%u  texrect=%u fillrect=%u\n"
@@ -271,10 +272,10 @@ static void dump_summary(const uint8_t* rdram, const OSTask* t) {
         st.mtx, st.popmtx, st.moveword, st.movemem, st.texture, st.geommode,
         st.settimg, st.settile, st.loadblock, st.loadtile, st.settilesize, st.texrect, st.fillrect,
         st.dl_calls, st.enddl, st.unknown, st.max_depth, st.first_timg);
-    std::fprintf(stderr, "[dl-inspect] texture working-set: %d distinct (first %d shown)\n",
+    LAMBO_LOG("dl-inspect", "texture working-set: %d distinct (first %d shown)\n",
                  st.tex_count, st.tex_count);
     for (int i = 0; i < st.tex_count; ++i)
-        std::fprintf(stderr, "[dl-inspect]   tex[%2d] addr=0x%08X  fmt=%s siz=%s\n",
+        LAMBO_LOG("dl-inspect", "  tex[%2d] addr=0x%08X  fmt=%s siz=%s\n",
                      i, st.tex_addr[i], fmt_name(st.tex_fmt[i]), siz_name(st.tex_siz[i]));
 }
 
@@ -325,8 +326,7 @@ static void sprite_scan(const uint8_t* rdram, uint32_t start_addr, uint32_t seg[
                     n1w0 = *(const uint32_t*)(rdram + off + 16);
                     n1w1 = *(const uint32_t*)(rdram + off + 20);
                 }
-                std::fprintf(stderr,
-                    "[menudl]   #%u @off=0x%06X  base=%08X %08X  next=%08X %08X | %08X %08X\n",
+                LAMBO_LOG("menudl", "  #%u @off=0x%06X  base=%08X %08X  next=%08X %08X | %08X %08X\n",
                     sc.count, off, w0, w1, n0w0, n0w1, n1w0, n1w1);
                 uint32_t soff;
                 if (resolve(w1, seg, &soff) && soff + 24 <= 0x00800000) {
@@ -339,8 +339,7 @@ static void sprite_scan(const uint8_t* rdram, uint32_t start_addr, uint32_t seg[
                     auto rd16x = [&](int o) { int a = o ^ 2; return (int16_t)((s[a + 1] << 8) | s[a]); };
                     auto rd8x  = [&](int o) { return s[o ^ 3]; };
                     (void)rd16;
-                    std::fprintf(stderr,
-                        "[menudl]     uSprite@%08X img=%08X tlut=%08X stride=%d w=%d h=%d "
+                    LAMBO_LOG("menudl", "    uSprite@%08X img=%08X tlut=%08X stride=%d w=%d h=%d "
                         "fmt=%u siz=%u offS=%d offT=%d\n",
                         w1, rd32(0), rd32(4), rd16x(8), rd16x(10), rd16x(12),
                         rd8x(14), rd8x(15), rd16x(16), rd16x(18));
@@ -1345,7 +1344,7 @@ public:
             lambo_fog_match_1p(g_lambo_rdram, (uint32_t)(int32_t)t->t.data_ptr);
         }
         if (count == 1) {
-            std::fprintf(stderr, "[gfx] first OSTask submitted to renderer (send_dl); task type=%u\n",
+            LAMBO_LOG("gfx", "first OSTask submitted to renderer (send_dl); task type=%u\n",
                          t ? (unsigned)t->t.type : 0u);
         }
         // Renderer-seam DL introspection (LAMBO_DL_INSPECT=1). One-shot at a target state
@@ -1361,7 +1360,7 @@ public:
                 uint32_t w = *(const uint32_t*)(g_lambo_rdram + (0x800CE6AC - 0x80000000u));
                 int state = (int)((w >> 16) & 0xFFFF);
                 if (state >= target) {
-                    std::fprintf(stderr, "[dl-inspect] state=%d (>= target %d), send_dl #%d\n",
+                    LAMBO_LOG("dl-inspect", "state=%d (>= target %d), send_dl #%d\n",
                                  state, target, count);
                     dlinspect::dump_summary(g_lambo_rdram, t);
                     s_done = true;
@@ -1408,7 +1407,7 @@ public:
                             std::fwrite(g_lambo_rdram, 1, 0x800000, rf);
                             std::fclose(rf);
                         }
-                        std::fprintf(stderr, "[racedl] dumped DL @0x%08X at send_dl=%d\n",
+                        LAMBO_LOG("racedl", "dumped DL @0x%08X at send_dl=%d\n",
                                      dl_addr, count);
                     }
                 }
@@ -1427,7 +1426,7 @@ public:
                         std::fwrite(g_lambo_rdram, 1, 0x800000, rf);
                         std::fclose(rf);
                     }
-                    std::fprintf(stderr, "[racedl] dumped DL @0x%08X + RDRAM to %s.{txt,bin}\n",
+                    LAMBO_LOG("racedl", "dumped DL @0x%08X + RDRAM to %s.{txt,bin}\n",
                                  dl_addr, s_race_dump);
                     s_done = true;
                 }
@@ -1448,7 +1447,7 @@ public:
             static uint32_t s_cmds = 0;
             if (scr != s_scr || sc.count != s_count || sc.cmds != s_cmds) {
                 s_cmds = sc.cmds;
-                std::fprintf(stderr, "[menudl] send_dl #%d screen=%d sprite2d_count=%u cmds=%u texrects=%u (was scr=%d n=%u)\n",
+                LAMBO_LOG("menudl", "send_dl #%d screen=%d sprite2d_count=%u cmds=%u texrects=%u (was scr=%d n=%u)\n",
                              count, scr, sc.count, sc.cmds, sc.texrects, s_scr, s_count);
                 if (sc.count > 0) {   // re-walk verbosely to dump the sequences
                     uint32_t seg2[16] = {0};
@@ -1472,13 +1471,13 @@ public:
                     uint32_t seg3[16] = {0};
                     dlinspect::dump_walk(g_lambo_rdram, dl_addr, seg3, f, 0);
                     std::fclose(f);
-                    std::fprintf(stderr, "[menudl] dumped DL @0x%08X to %s\n", dl_addr, path);
+                    LAMBO_LOG("menudl", "dumped DL @0x%08X to %s\n", dl_addr, path);
                     char rpath[128];
                     std::snprintf(rpath, sizeof(rpath), "rdram_screen%d.bin", scr);
                     if (std::FILE* rf = std::fopen(rpath, "wb")) {
                         std::fwrite(g_lambo_rdram, 1, 0x800000, rf);
                         std::fclose(rf);
-                        std::fprintf(stderr, "[menudl] dumped RDRAM to %s\n", rpath);
+                        LAMBO_LOG("menudl", "dumped RDRAM to %s\n", rpath);
                     }
                     s_dumped = true;
                 }
@@ -1520,8 +1519,7 @@ public:
                     // "horizon gap" that was two DIFFERENT demos compared frame-to-frame.
                     uint32_t dw = *(const uint32_t*)(g_lambo_rdram + (0x800CE774 - 0x80000000u));
                     int demo_idx = (int)((dw >> 16) & 0xFFFF);
-                    std::fprintf(stderr,
-                        "[dl-render] captured state=%d demo_idx=%d frame (send_dl #%d) -> %s (%s)\n"
+                    LAMBO_LOG("dl-render", "captured state=%d demo_idx=%d frame (send_dl #%d) -> %s (%s)\n"
                         "[dl-render]   verts_loaded=%u tris_in=%u drawn=%u clipped=%u pixels=%u tex_pixels=%u  viewport=%s\n"
                         "[dl-render]   fog: pixels=%u mul=%d off=%d color=(%u,%u,%u)\n",
                         state, demo_idx, count, path, ok ? "written" : "WRITE FAILED",
@@ -1534,8 +1532,11 @@ public:
         }
         // Periodic heartbeat: a SUSTAINED gfx pipeline (not the #58 1-task stall). Before the
         // __osViCurr/__osViNext retrace-promotion fix (vi_cb in main.cpp), this stuck at 1 forever.
-        if (count % 30 == 0) {
-            std::fprintf(stderr, "[gfx] send_dl count=%d (pipeline sustained)\n", count);
+        // lambo_log_enabled short-circuits the WHOLE block on a default boot (the rt64 sibling
+        // also wraps so its VI-reg read + mutex lock are skipped -- here the block is just the
+        // LAMBO_LOG, but the modulo is skipped for symmetry).
+        if (lambo_log_enabled && (count % 30 == 0)) {
+            LAMBO_LOG("gfx", "send_dl count=%d (pipeline sustained)\n", count);
         }
     }
     void update_screen() override {}
@@ -1562,10 +1563,10 @@ create_render_context(uint8_t* rdram, ultramodern::renderer::WindowHandle window
     if (lambo_rt64::enabled()) {
         auto rt64_ctx = lambo_rt64::create_render_context(rdram, window_handle, developer_mode);
         if (rt64_ctx) {
-            std::fprintf(stderr, "[rt64] RT64 renderer ACTIVE (default presenter)\n");
+            LAMBO_LOG("rt64", "RT64 renderer ACTIVE (default presenter)\n");
             return rt64_ctx;
         }
-        std::fprintf(stderr, "[rt64] RT64 setup failed -- falling back to headless swrender\n");
+        LAMBO_LOG("rt64", "RT64 setup failed -- falling back to headless swrender\n");
     }
     (void)window_handle;
     (void)developer_mode;


### PR DESCRIPTION
## Summary

Default boot is silent; the same lines that used to print one per VI heartbeat (and several on each transition) now only emit when the binary is started with `--lambo-debug`. The recurring heartbeats in `stub_renderer.cpp` and `rt64_renderer.cpp` were the worst offenders — roughly one line per second on every default launch.

Crash dumps (the `[crash]` tag inside `lambo_crash.cpp`) and the opt-in env-var features (`LAMBO_PAK_TRACE`, `LAMBO_DL_INSPECT`, ...) are NOT routed through this gate — they were already opt-in via env var, or they only fire on actual signal/SEH.

## What changed

- **New `src/lambo_log.h` + `src/lambo_log.cpp`** — C-linkage `lambo_log_enabled` bool (default false) + `LAMBO_LOG(tag, ...)` macro that prints `[tag] ...` when enabled. C/C++ portable so the C TUs (`lambo_savestate.c`, `lambo_warp.c`) can use the same gate.
- **99 fprintf sites converted** across 7 files: `main.cpp`, `lambo_audio.cpp`, `lambo_config.cpp`, `lambo_savestate.c`, `lambo_warp.c`, `stub_renderer.cpp`, `rt64_renderer.cpp`.
- **Perf win in `rt64_renderer.cpp`**: the `[rt64] send_dl count=` heartbeat's whole `if (count % 30 == 0) { ... }` block is wrapped in `if (lambo_log_enabled && ...)` so the VI-reg read + `interpolatedMutex` lock also short-circuit on a default boot, not just the inner `fprintf`. `stub_renderer.cpp`'s `[gfx]` heartbeat gets the same wrap for symmetry.
- **`main.cpp` now skips argv entries that start with `-`** when finding the ROM path, so `lamborghini_modern --lambo-debug` still finds the bundled ROM (or a path supplied after the flag) without the flag being misread as `argv[1]`.
- **`CMakeLists.txt`**: `src/lambo_log.cpp` added to the `lamborghini_modern` source list.

## What was NOT changed (intentional)

- `lambo_crash.cpp` — every `[crash]` line stays as raw `fprintf`; only fires on actual signal/SEH, gating it would defeat the dump.
- `libultra_stubs.c:492` `[input]` site and the `[paktrc]` / `[pak]` sites — already gated by `LAMBO_INPUT_PROBE` / `LAMBO_PAK_TRACE` env vars; wrapping twice would be redundant.
- `stub_renderer.cpp` `[light-selftest]` lines — `std::printf` to stdout in a self-test path that exits before main parses the flag.
- `patches/` — submodule patches (`[ttrace]`, `[match]`) are out of scope; their existing env-var gates still work.

## How to test

```
# Default boot (silent)
.\build\lamborghini_modern.exe

# Full debug output
.\build\lamborghini_modern.exe --lambo-debug

# Flag + ROM path coexist
.\build\lamborghini_modern.exe --lambo-debug path/to/rom.z64
```

In a 1800-VI headless run:
- Default: 2 lines (only the always-on `[crash]` init).
- `--lambo-debug`: 69 lines (29 `[gfx]`, 20 `[probe]`, 9 `[state]`, 3 `[pace]`, 3 `[dl-render]`, 2 `[crash]`, 2 `[menu]`, 1 `[config]`).
- `LAMBO_CRASH_TEST=smoke` (no flag): the deliberate crash 2 s after boot still produces the full `=== NATIVE CRASH ===` banner + native backtrace.

## Notes

- Diff is intentionally small (180 insertions / 108 deletions after the LF fix) — the 4120/4102 figures from the first pass were the diff churn from a Windows-side `pathlib.write_text()` introducing CRLF, since corrected.
- No `LAMBO_DEBUG` compile-time flag was added — runtime flag was the ask, and a build-time switch wouldn't match "unless a flag is provided at start up".