### PR TITLE
no_lod: full-track visibility walk; fog_scale density control

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ N64Recomp ports (Zelda 64: Recompiled et al.):
 | `api_option` | `Auto`, `D3D12`, `Vulkan`, `Metal` | `Auto` | Graphics API. |
 | `widescreen_fog_match` | `true`, `false` | `true` | Widens the dense 3P/4P split-screen fog to the open 1P fog window/colour so the extra draw distance shows. Only affects 3+ player races. |
 | `widescreen_sky_match` | `true`, `false` | `true` | Draws the sky panorama in 3P/4P split screen (the original skips it, leaving a flat dark backdrop above the horizon). Only affects 3+ player races. |
+| `no_lod` | `true`, `false` | `true` | Removes the ROM's draw-distance reductions: the per-mode scenery-layer skip, the per-circuit distance culls, and the trimmed per-segment visibility lists (the whole track is drawn subject only to normal view culling). Eliminates world pop-in; `false` restores the N64-authored behaviour. |
+| `fog_scale` | `0.0`–`8.0` | `1.0` | Fog density multiplier. `1.0` = authored fog, `0.0` = no fog; values in between thin the fog uniformly without moving where it starts. |
+| `fog_scale_circuit` | array of 6 numbers | `[1,1,1,1,1,1]` | Per-circuit fog multipliers (multiplied with `fog_scale`), e.g. clear a single hazy track by lowering its entry. |
 
 ## Troubleshooting
 

--- a/docs/no_lod_audit.md
+++ b/docs/no_lod_audit.md
@@ -262,6 +262,44 @@ remains" claims, this time *within* a mode rather than between modes:
   visibility-list-bound (an entry missing from the row entirely), a separate, larger
   change if it ever proves visible.
 
+## 9. Addendum (2026-07-18): the visibility lists themselves (full-track walk)
+
+The §8 residual proved visible the same day: a city-track savestate showed the camera
+in segment 21 with **segment 54 only 1,027 units away and absent from the authored
+row** — a parallel street (chimney and all) that block-pops the moment the camera's
+row changes. Corrections to §8's data model, from re-reading the loop and the track
+header rather than the row scan:
+
+- **PVS rows are 10 fixed slots with `-1` holes, NOT `-1`-terminated.** The loop at
+  `L_8000D028` always runs to its `slti 0xA` cap and `bltz`-skips negative slots
+  (the skip branches to the increment, not out). `tools/pvs_distance_audit.py`'s
+  original terminator-based parse silently dropped every entry after the first hole.
+- **The segment count is not stored anywhere** — it is the PVS block size:
+  `(header+0x8 − header+0x4) / 20` with the header pointer at `0x80098238`
+  (`*(header)+0x0` is the 64-byte record list, `+0x10` the 16-byte test points).
+  Circuit 5 has **55 segments** (1100/20), not the 42 a terminator-parse suggests;
+  record 55 is all-null (a natural sentinel).
+- **Every segment's road/wall/scenery sub-DLs stay resident for the whole race**
+  (verified: all 55 records' three pointers valid in a mid-race savestate), so the
+  authored rows are the only thing bounding reach.
+
+**Fix (shipped under `no_lod`):** three natives in src/lambo_no_lod.cpp bend the
+existing walk — `lambo_no_lod_pvs_entry` (hook after the row fetch `lh` at
+`0x8000D058`) replaces each fetched entry with one from a synthesized all-segments
+row (authored entries first, camera segment excluded, null-record segments skipped);
+`lambo_no_lod_pvs_more` (hook over the `slti` result at `0x8000D904`) widens the
+10-iteration cap to the synthesized length; `lambo_no_lod_seg_list_clamp` (hooks at
+`0x8000D8D0`/`0x8000D920`) clamps the per-frame drawn-segment-list index to slot 20 —
+the list at `0x800B6758` has **21 slots** (`0x800B6782` is the next global) and
+accumulates across viewports without reset, so the widened walk can exceed it in
+split screen; excess appends collapse onto the last slot and the `-1` terminator
+lands on top. The per-entry forward-cone tests are untouched: they are frame-coherent
+view culling, so segments now emerge at the horizon/screen edge instead of popping on
+row-membership changes. Verified on the reporting savestate: stock walk draws
+`[21,22,23,24]`; widened walk draws `[21,22,23,24,25,48,49,50]` (+645 triangles into
+the pipeline), `LAMBO_NO_LOD=0` restores the stock list bit-for-bit, and a 4P race
+smokes clean with the list clamp holding.
+
 ---
 *Method note: MIPS classification used `tools/scan_lod_patterns.py` output cross-read
 against the recompiled C (per-instruction VRAM comments) rather than raw disassembly;

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -646,6 +646,39 @@ func = "func_8000A6C0"
 before_vram = 0x8000CD3C
 text = "{ extern void lambo_no_lod_draw_distance(uint8_t*); lambo_no_lod_draw_distance(rdram); }"
 
+# no_lod full-track walk -- the remaining pop-in axis after the radius lift. The builder
+# only draws segments listed in the camera segment's authored PVS row (10 fixed slots
+# with -1 holes, NOT -1 terminated: the loop always runs its cap and skips negatives),
+# and the city circuits' rows are trimmed for N64 fill rate -- on circuit 5 the row can
+# omit a parallel street 1k units away, which pops in on the next segment boundary. All
+# segment sub-DLs stay resident for the whole race, so the fix is to widen the walk:
+# override the fetched row entry (after the lh at 0x8000D058) with a native synthesized
+# all-segments row (authored entries first, camera segment excluded) and stretch the
+# 10-iteration cap (slti at 0x8000D904) to its length. The per-frame drawn-segment list
+# at 0x800B6758 holds 21 slots (0x800B6782 is the next global), so both list-index
+# computations are clamped to slot 20 -- excess appends collapse there and the -1
+# terminator lands on top, keeping the stock-shaped prefix for the list's consumers.
+# The per-entry forward-cone tests still run untouched. Native in src/lambo_no_lod.cpp.
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000D05C
+text = "{ extern uint32_t lambo_no_lod_pvs_entry(uint8_t*, uint32_t, uint32_t); ctx->r11 = (gpr)(int32_t)lambo_no_lod_pvs_entry(rdram, (uint32_t)ctx->r11, (uint32_t)ctx->r12); }"
+
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000D908
+text = "{ extern uint32_t lambo_no_lod_pvs_more(uint8_t*, uint32_t, uint32_t); ctx->r1 = lambo_no_lod_pvs_more(rdram, (uint32_t)ctx->r1, (uint32_t)ctx->r12); }"
+
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000D8D0
+text = "{ extern uint32_t lambo_no_lod_seg_list_clamp(uint8_t*, uint32_t); ctx->r25 = lambo_no_lod_seg_list_clamp(rdram, (uint32_t)ctx->r25); }"
+
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000D920
+text = "{ extern uint32_t lambo_no_lod_seg_list_clamp(uint8_t*, uint32_t); ctx->r25 = lambo_no_lod_seg_list_clamp(rdram, (uint32_t)ctx->r25); }"
+
 # Issue #78 — 3P/4P per-quadrant HUD text pinning. The quad section (L_800517A8) draws
 # each player's RANK (x=0x20/0x110), speed readout (x=0x14-0x46 / 0xEB-0x11D), lap-notify
 # glyph (x=0x19/0x118) and the inline per-player tag texrects in the outer columns, plus

--- a/scripts/gen_syms_toml.py
+++ b/scripts/gen_syms_toml.py
@@ -1010,6 +1010,39 @@ func = "func_8000A6C0"
 before_vram = 0x8000CD3C
 text = "{ extern void lambo_no_lod_draw_distance(uint8_t*); lambo_no_lod_draw_distance(rdram); }"
 
+# no_lod full-track walk -- the remaining pop-in axis after the radius lift. The builder
+# only draws segments listed in the camera segment's authored PVS row (10 fixed slots
+# with -1 holes, NOT -1 terminated: the loop always runs its cap and skips negatives),
+# and the city circuits' rows are trimmed for N64 fill rate -- on circuit 5 the row can
+# omit a parallel street 1k units away, which pops in on the next segment boundary. All
+# segment sub-DLs stay resident for the whole race, so the fix is to widen the walk:
+# override the fetched row entry (after the lh at 0x8000D058) with a native synthesized
+# all-segments row (authored entries first, camera segment excluded) and stretch the
+# 10-iteration cap (slti at 0x8000D904) to its length. The per-frame drawn-segment list
+# at 0x800B6758 holds 21 slots (0x800B6782 is the next global), so both list-index
+# computations are clamped to slot 20 -- excess appends collapse there and the -1
+# terminator lands on top, keeping the stock-shaped prefix for the list's consumers.
+# The per-entry forward-cone tests still run untouched. Native in src/lambo_no_lod.cpp.
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000D05C
+text = "{ extern uint32_t lambo_no_lod_pvs_entry(uint8_t*, uint32_t, uint32_t); ctx->r11 = (gpr)(int32_t)lambo_no_lod_pvs_entry(rdram, (uint32_t)ctx->r11, (uint32_t)ctx->r12); }"
+
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000D908
+text = "{ extern uint32_t lambo_no_lod_pvs_more(uint8_t*, uint32_t, uint32_t); ctx->r1 = lambo_no_lod_pvs_more(rdram, (uint32_t)ctx->r1, (uint32_t)ctx->r12); }"
+
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000D8D0
+text = "{ extern uint32_t lambo_no_lod_seg_list_clamp(uint8_t*, uint32_t); ctx->r25 = lambo_no_lod_seg_list_clamp(rdram, (uint32_t)ctx->r25); }"
+
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000D920
+text = "{ extern uint32_t lambo_no_lod_seg_list_clamp(uint8_t*, uint32_t); ctx->r25 = lambo_no_lod_seg_list_clamp(rdram, (uint32_t)ctx->r25); }"
+
 # Issue #78 — 3P/4P per-quadrant HUD text pinning. The quad section (L_800517A8) draws
 # each player's RANK (x=0x20/0x110), speed readout (x=0x14-0x46 / 0xEB-0x11D), lap-notify
 # glyph (x=0x19/0x118) and the inline per-player tag texrects in the outer columns, plus

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -6,6 +6,7 @@
 // minus the RmlUi menu: this port's UI is the JSON file itself plus hotkeys.
 #include "lambo_config.h"
 
+#include <array>
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
@@ -46,6 +47,11 @@ bool g_widescreen_sky_match = true;
 // lose the far scenery entirely. Default-on; the emit still self-gates on the
 // record pointer being non-null, so segments without a scenery DL are unaffected.
 bool g_no_lod = true;
+
+// Fog density multipliers (see lambo_config.h). Stored as double: the round-trip
+// validity check in from_or_default would reject float (0.3 -> 0.3f -> 0.30000001...).
+double g_fog_scale = 1.0;
+std::array<double, 6> g_fog_scale_circuit{1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
 
 // Read a key into `out`, keeping the existing (default) value when the key is
 // missing or invalid. NLOHMANN_JSON_SERIALIZE_ENUM does NOT throw on an
@@ -90,6 +96,8 @@ nlohmann::json to_json(const ultramodern::renderer::GraphicsConfig& c) {
         {"widescreen_fog_match", g_widescreen_fog_match},
         {"widescreen_sky_match", g_widescreen_sky_match},
         {"no_lod", g_no_lod},
+        {"fog_scale", g_fog_scale},
+        {"fog_scale_circuit", g_fog_scale_circuit},
     };
 }
 
@@ -112,6 +120,8 @@ void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c
     from_or_default(j, "widescreen_fog_match", g_widescreen_fog_match);
     from_or_default(j, "widescreen_sky_match", g_widescreen_sky_match);
     from_or_default(j, "no_lod", g_no_lod);
+    from_or_default(j, "fog_scale", g_fog_scale);
+    from_or_default(j, "fog_scale_circuit", g_fog_scale_circuit);
     // Sanity-bound the window size: below the N64 framebuffer is useless, above 8K
     // is a typo -- either way SDL_CreateWindow would fail and the port would run
     // permanently headless, so reset to defaults instead.
@@ -300,6 +310,22 @@ bool no_lod() {
         return v[0] == '1';
     }
     return g_no_lod;
+}
+
+// LAMBO_FOG_SCALE=<float> overrides both JSON keys for headless capture/testing.
+double fog_scale(int circuit) {
+    double s;
+    if (const char* v = std::getenv("LAMBO_FOG_SCALE")) {
+        s = std::atof(v);
+    } else {
+        s = g_fog_scale;
+        if (circuit >= 0 && circuit < (int)g_fog_scale_circuit.size()) {
+            s *= g_fog_scale_circuit[(size_t)circuit];
+        }
+    }
+    if (s < 0.0) s = 0.0;
+    if (s > 8.0) s = 8.0;
+    return s;
 }
 
 } // namespace config

--- a/src/lambo_config.h
+++ b/src/lambo_config.h
@@ -72,6 +72,14 @@ bool widescreen_sky_match();
 // "no_lod" (default true), overridable by LAMBO_NO_LOD=1/0.
 bool no_lod();
 
+// Fog density multiplier applied to every fog moveword in the frame DL: 1.0 =
+// authored fog, 0.0 = no fog, values in between thin the fog uniformly without
+// moving its onset distance. graphics.json keys "fog_scale" (global, default 1.0)
+// and "fog_scale_circuit" (array of 6 per-circuit multipliers, default all 1.0,
+// multiplied with the global -- lets a hazy city track be cleared individually).
+// LAMBO_FOG_SCALE=<float> overrides the whole computation for capture/testing.
+double fog_scale(int circuit);
+
 } // namespace config
 } // namespace lambo
 

--- a/src/lambo_fog_widescreen.cpp
+++ b/src/lambo_fog_widescreen.cpp
@@ -1,6 +1,8 @@
-// #83: widen 3P/4P split-screen fog to the 1P window/colour. Enhancement — rewrites
-// the game-built display list in RDRAM at the top of every send_dl (both renderers
-// read the same RDRAM). Self-gates on live player count 0x800CE6A4 >= 3.
+// #83: widen 3P/4P split-screen fog to the 1P window/colour, and (fog_scale) scale
+// fog density per track. Enhancement — rewrites the game-built display list in RDRAM
+// at the top of every send_dl (both renderers read the same RDRAM). The 3P/4P match
+// self-gates on live player count 0x800CE6A4 >= 3; the density scale applies whenever
+// it is != 1 for the live circuit (0x800CE794).
 
 #include <cstdint>
 #include <cstdlib>
@@ -33,9 +35,25 @@ bool resolve(uint32_t addr, const uint32_t seg[16], uint32_t* out_off) {
     return true;
 }
 
+// Fog moveword w1 packs fm (hi s16) and fo (lo s16); per-vertex fog alpha is
+// clamp(fm * z + fo), so scaling BOTH by s scales the pre-clamp alpha by s: the
+// fog thins uniformly (s=0 removes it) while the distance where it first appears
+// (the alpha zero-crossing) stays where the ROM authored it.
+uint32_t scale_fog_mw(uint32_t w1, double s) {
+    double fm = (double)(int16_t)(w1 >> 16) * s;
+    double fo = (double)(int16_t)(w1 & 0xFFFF) * s;
+    if (fm > 32767.0) fm = 32767.0;
+    if (fm < -32768.0) fm = -32768.0;
+    if (fo > 32767.0) fo = 32767.0;
+    if (fo < -32768.0) fo = -32768.0;
+    return ((uint32_t)(uint16_t)(int16_t)fm << 16) | (uint16_t)(int16_t)fo;
+}
+
 // Walk one DL, following G_DL calls/branches and tracking segments, rewriting every
-// fog moveword and fog colour to the 1P values. Depth- and iteration-bounded.
-void rewrite(uint8_t* rdram, uint32_t start_addr, uint32_t seg[16], int depth) {
+// fog moveword (and, for the 3P/4P match, fog colour) in place. Depth- and
+// iteration-bounded.
+void rewrite(uint8_t* rdram, uint32_t start_addr, uint32_t seg[16], int depth,
+             bool match_1p, double fog_scale) {
     if (depth > 12) return;
     uint32_t off;
     if (!resolve(start_addr, seg, &off)) return;
@@ -49,12 +67,17 @@ void rewrite(uint8_t* rdram, uint32_t start_addr, uint32_t seg[16], int depth) {
                     uint32_t segnum = (((w0 >> 8) & 0xFFFF) >> 2) & 0xF;
                     seg[segnum] = *(uint32_t*)(rdram + off + 4);
                 } else if ((w0 & 0xFF) == G_MW_FOG) {
-                    *(uint32_t*)(rdram + off + 4) = FOG_MW_1P;
+                    uint32_t* w1 = (uint32_t*)(rdram + off + 4);
+                    uint32_t v = match_1p ? FOG_MW_1P : *w1;
+                    if (fog_scale != 1.0) v = scale_fog_mw(v, fog_scale);
+                    *w1 = v;
                 }
                 break;
             case G_SETFOGCOLOR: {
-                uint32_t* w1 = (uint32_t*)(rdram + off + 4);
-                *w1 = FOG_RGB_1P | (*w1 & 0xFFu);   // keep the authored alpha byte
+                if (match_1p) {
+                    uint32_t* w1 = (uint32_t*)(rdram + off + 4);
+                    *w1 = FOG_RGB_1P | (*w1 & 0xFFu);   // keep the authored alpha byte
+                }
                 break;
             }
             case G_DL: {
@@ -63,7 +86,7 @@ void rewrite(uint8_t* rdram, uint32_t start_addr, uint32_t seg[16], int depth) {
                     if (!resolve(target, seg, &off)) return;
                     continue;
                 }
-                rewrite(rdram, target, seg, depth + 1);   // call (push): recurse
+                rewrite(rdram, target, seg, depth + 1, match_1p, fog_scale);  // call (push)
                 break;
             }
             case G_ENDDL:
@@ -78,13 +101,17 @@ void rewrite(uint8_t* rdram, uint32_t start_addr, uint32_t seg[16], int depth) {
 } // namespace
 
 // Called at the top of every send_dl (both render paths) with the graphics OSTask's
-// display-list pointer. No-op unless enabled and the race is 3P/4P.
+// display-list pointer. No-op unless the 3P/4P fog match applies or the fog density
+// scale for the live circuit differs from 1.
 extern "C" void lambo_fog_match_1p(uint8_t* rdram, uint32_t dl_addr) {
-    if (rdram == nullptr || !lambo::config::widescreen_fog_match()) return;
+    if (rdram == nullptr) return;
     // Live player count at 0x800CE6A4 (high 16 bits when read as an aligned word,
     // matching the swrender's state read at 0x800CE6AC). 1P/2P stay faithful.
     uint32_t players = (*(uint32_t*)(rdram + (0x800CE6A4u & 0x1FFFFFFF)) >> 16) & 0xFFFF;
-    if (players < 3) return;
+    bool match_1p = lambo::config::widescreen_fog_match() && players >= 3;
+    int circuit = (int16_t)((*(uint32_t*)(rdram + (0x800CE794u & 0x1FFFFFFF)) >> 16) & 0xFFFF);
+    double fog_scale = lambo::config::fog_scale(circuit);
+    if (!match_1p && fog_scale == 1.0) return;
     uint32_t seg[16] = {0};
-    rewrite(rdram, dl_addr, seg, 0);
+    rewrite(rdram, dl_addr, seg, 0, match_1p, fog_scale);
 }

--- a/src/lambo_no_lod.cpp
+++ b/src/lambo_no_lod.cpp
@@ -41,3 +41,105 @@ extern "C" void lambo_no_lod_draw_distance(uint8_t* rdram) {
         MEM_W(i * 4, (gpr)(int32_t)kTableAddr) = kFarBits;
     }
 }
+
+// Full-track draw (the last pop-in axis): even with the radii lifted, the builder only
+// ever draws segments listed in the camera segment's authored PVS row -- 10 fixed slots
+// with -1 holes -- and the city circuits' rows are trimmed hard for N64 fill rate (the
+// row can omit a parallel street 1k units away, which then pops in on the next segment
+// boundary). All segment sub-DLs are resident for the whole race, so the walk itself is
+// the only limit. Two hooks bend the existing loop: the row-entry fetch (0x8000D058)
+// is overridden with entries from a synthesized all-segments row, and the 10-iteration
+// cap (0x8000D904) is widened to its length. Authored entries come first so the
+// per-frame drawn-segment list keeps its stock prefix; the per-frame cone tests still
+// run per entry, so this changes reach, not view culling.
+
+namespace {
+
+constexpr gpr kHdrPtrAddr  = (gpr)(int32_t)0x80098238u;  // track asset header pointer
+constexpr gpr kCamSegAddr  = (gpr)(int32_t)0x800BF1CCu;  // camera segment (this viewport)
+constexpr gpr kPvsPtrAddr  = (gpr)(int32_t)0x800CE678u;  // PVS base (header+0x4 copy)
+constexpr gpr kRecListAddr = (gpr)(int32_t)0x800BF1D0u;  // 64-byte segment records (viewport)
+
+int16_t s_synth_row[256];
+int s_synth_n = -1;  // -1 = passthrough (feature off or sanity check failed)
+
+bool valid_guest_ptr(int32_t p) {
+    uint32_t u = (uint32_t)p;
+    return u >= 0x80000000u && u < 0x80800000u;
+}
+
+// Rebuild the synthesized row for the viewport walk that is starting. The segment
+// count is not stored anywhere by the game -- it is (header+0x8 - header+0x4) / 20,
+// the size of the PVS block itself (verified exact on circuit 5: 1100/20 = 55 rows,
+// with a null 56th record as sentinel). Any sanity failure disables the override for
+// this walk and the authored row is used untouched.
+void build_synth_row(uint8_t* rdram) {
+    s_synth_n = -1;
+    int32_t hdr = MEM_W(0, kHdrPtrAddr);
+    int32_t pvs = MEM_W(0, kPvsPtrAddr);
+    int32_t recs = MEM_W(0, kRecListAddr);
+    if (!valid_guest_ptr(hdr) || !valid_guest_ptr(pvs) || !valid_guest_ptr(recs)) return;
+    if (MEM_W(0x4, (gpr)hdr) != pvs) return;  // header and live PVS ptr disagree
+    int32_t pvs_end = MEM_W(0x8, (gpr)hdr);
+    if (!valid_guest_ptr(pvs_end) || pvs_end <= pvs) return;
+    int32_t bytes = pvs_end - pvs;
+    if (bytes % 20 != 0) return;
+    int n = bytes / 20;
+    if (n < 2 || n > 200) return;
+    int cam = MEM_H(0, kCamSegAddr);
+    if (cam < 0 || cam >= n) return;
+
+    bool listed[256] = {};
+    int out = 0;
+    listed[cam] = true;  // the camera's own segment is drawn by its dedicated path
+    for (int i = 0; i < 10; i++) {  // authored row first: stock drawn-list prefix
+        int e = MEM_H(cam * 20 + i * 2, (gpr)pvs);
+        if (e < 0 || e >= n || listed[e]) continue;
+        listed[e] = true;
+        s_synth_row[out++] = (int16_t)e;
+    }
+    for (int s = 0; s < n; s++) {
+        if (listed[s]) continue;
+        // Skip records with no road sub-DL (defends against sentinel/padding rows).
+        if (!valid_guest_ptr(MEM_W(s * 64 + 0x4, (gpr)recs))) continue;
+        s_synth_row[out++] = (int16_t)s;
+    }
+    s_synth_n = out;
+}
+
+}  // namespace
+
+// Hooked after the row-entry fetch (before 0x8000D05C): replaces the authored entry
+// with the synthesized row's. idx is the loop counter the fetch used ($t4).
+extern "C" uint32_t lambo_no_lod_pvs_entry(uint8_t* rdram, uint32_t orig, uint32_t idx) {
+    if (!lambo::config::no_lod()) {
+        s_synth_n = -1;
+        return orig;
+    }
+    int i = (int32_t)idx;
+    if (i == 0) {
+        build_synth_row(rdram);
+    }
+    if (s_synth_n < 0) return orig;
+    if (i < 0 || i >= s_synth_n) return (uint32_t)(int32_t)-1;
+    return (uint32_t)(int32_t)s_synth_row[i];
+}
+
+// Hooked over the loop-cap test result (before 0x8000D908): keep looping until the
+// synthesized row is exhausted instead of stopping at 10. next is i+1 ($t4).
+extern "C" uint32_t lambo_no_lod_pvs_more(uint8_t* rdram, uint32_t orig, uint32_t next) {
+    (void)rdram;
+    if (!lambo::config::no_lod() || s_synth_n < 0) return orig;
+    return (int32_t)next < s_synth_n ? 1u : 0u;
+}
+
+// Hooked over the drawn-segment-list index (before 0x8000D8D0 / 0x8000D920): the
+// per-frame list at 0x800B6758 has 21 slots (0x800B6782 is the next global) and the
+// stock walk writes at most 12; the widened walk must not scribble past it. Excess
+// appends collapse onto the last slot, which the -1 terminator then overwrites, so
+// list consumers (they scan to the terminator) see the stock-shaped prefix.
+extern "C" uint32_t lambo_no_lod_seg_list_clamp(uint8_t* rdram, uint32_t count) {
+    (void)rdram;
+    if (!lambo::config::no_lod()) return count;
+    return (int32_t)count > 20 ? 20u : count;
+}

--- a/tools/pvs_distance_audit.py
+++ b/tools/pvs_distance_audit.py
@@ -37,7 +37,9 @@ def main(path):
     def gw(a):
         return struct.unpack_from('<I', d, a - 0x80000000)[0]
 
-    pvs = gw(0x800CE678)      # 20-byte rows of 10 s16 entries, -1 terminated
+    pvs = gw(0x800CE678)      # 20-byte rows of 10 s16 slots; -1 slots are HOLES, not
+                              # terminators (the builder always walks all 10, skipping
+                              # negatives)
     rec64 = gw(0x800BF1D0)    # viewport-0 segment record list (64-byte stride)
     rec16 = gw(0x800BF1C0)    # 16-byte test-point records
     circuit = gh(0x800CE794)
@@ -54,23 +56,16 @@ def main(path):
         z = gh(rec16 + idx * 16 + 0x2) + gh(rec64 + seg * 64 + 0x12)
         return x, z
 
-    # Segment count: PVS rows are only sane for real segments; stop at the first
-    # row whose entries leave plausible range.
+    # Segment count = the PVS block size itself: the track header (ptr 0x80098238)
+    # holds the PVS base at +0x4 and the next block at +0x8, and the region divides
+    # exactly into 20-byte rows (circuit 5: 1100/20 = 55 -- NOT 42; the old scan here
+    # treated -1 slots as terminators and stopped at the first all-hole-prefixed row).
+    hdr = gw(0x80098238)
+    n = (gw(hdr + 8) - gw(hdr + 4)) // 20
     rows = []
-    k = 0
-    while k < 200:
+    for k in range(n):
         raw = [gh(pvs + k * 20 + i * 2) for i in range(10)]
-        ents = []
-        for v in raw:
-            if v < 0:
-                break
-            ents.append(v)
-        if (not ents and k > 0) or any(v > 4096 for v in ents):
-            break
-        rows.append(ents)
-        k += 1
-
-    n = len(rows)
+        rows.append([v for v in raw if 0 <= v < n])
     total = 0
     worst = []
     for k, ents in enumerate(rows):


### PR DESCRIPTION
## What

Two enhancements, both continuing the pop-in work from #112/#119:

**1. `no_lod` full-track visibility walk** — eliminates the remaining world pop-in.

Even with the per-circuit radii lifted (#119), the scene builder only draws segments listed in the camera segment's authored PVS row. Investigating the reporting savestate (city track, paused in race) showed the camera in segment 21 with **segment 54 — the parallel street with the popping chimney — 1,027 units away and absent from the row**. Two data-model corrections found on the way:

- PVS rows are **10 fixed slots with `-1` holes**, not `-1`-terminated (the loop always runs its cap and skips negatives). The old `pvs_distance_audit.py` parse dropped everything after the first hole — fixed in this PR.
- The **segment count is nowhere stored**; it is `(header+0x8 − header+0x4) / 20`. Circuit 5 has **55 segments**, not 42.

All 55 segments' road/wall/scenery sub-DLs stay resident for the whole race, so three `patches.hook`s widen the existing walk instead of replicating it: override the fetched row entry with a synthesized all-segments row (authored entries first), stretch the `slti 0xA` cap to its length, and clamp the per-frame drawn-segment-list writes to the list's 21 slots (`0x800B6782` is the next global; the list accumulates across viewports without reset). Forward-cone view culling is untouched — segments now emerge at the horizon/screen edge instead of block-popping on row changes.

**2. `fog_scale` / `fog_scale_circuit`** — user-controllable fog density.

Rides the existing #83 fog DL-walker: every fog moveword's `fm`/`fo` pair is scaled, which scales pre-clamp fog alpha linearly — fog thins uniformly (0 = none) without moving its authored onset distance. `fog_scale` is global; `fog_scale_circuit` is a 6-entry per-circuit multiplier so a single hazy track can be cleared. `LAMBO_FOG_SCALE` env overrides for capture/testing.

## Verification

- Savestate repro: stock walk draws `[21,22,23,24]`; widened walk draws `[21,22,23,24,25,48,49,50]`, +645 triangles submitted (software-render stats at the identical frame).
- `LAMBO_NO_LOD=0` restores the stock drawn list bit-for-bit; drawn-list terminator and the `0x800B6782` neighbour verified intact.
- 4P warp race smokes clean (list accumulates 18 entries across 4 viewports, clamp holds).
- `LAMBO_FOG_SCALE=0.3`: fog moveword `5120/-4864 → 1536/-1459` (exactly 0.3×), rendered frame visibly clearer, geometry unchanged.
- During testing the known savestate cold-load flake (state restored while the boot asset thread streams; `osPiStartDma` AV) reproduced with the feature **off** as well — pre-existing, not introduced here.

`docs/no_lod_audit.md` §9 is the full writeup; README documents the new keys.
