### PR TITLE
no_lod: configurable draw distance (default 1.5x authored radii)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ N64Recomp ports (Zelda 64: Recompiled et al.):
 | `api_option` | `Auto`, `D3D12`, `Vulkan`, `Metal` | `Auto` | Graphics API. |
 | `widescreen_fog_match` | `true`, `false` | `true` | Widens the dense 3P/4P split-screen fog to the open 1P fog window/colour so the extra draw distance shows. Only affects 3+ player races. |
 | `widescreen_sky_match` | `true`, `false` | `true` | Draws the sky panorama in 3P/4P split screen (the original skips it, leaving a flat dark backdrop above the horizon). Only affects 3+ player races. |
-| `no_lod` | `true`, `false` | `true` | Removes the ROM's draw-distance reductions: the per-mode scenery-layer skip, the per-circuit distance culls, and the trimmed per-segment visibility lists (the whole track is drawn subject only to normal view culling). Eliminates world pop-in; `false` restores the N64-authored behaviour. |
+| `no_lod` | `true`, `false` | `true` | Removes the ROM's draw-distance reductions: the per-mode scenery-layer skip and the trimmed per-segment visibility lists, with reach then governed by `draw_distance` instead of the N64 fill-rate budgets. `false` restores the N64-authored behaviour entirely. |
 | `fog_scale` | `0.0`–`8.0` | `1.0` | Fog density multiplier. `1.0` = authored fog, `0.0` = no fog; values in between thin the fog uniformly without moving where it starts. |
 | `fog_scale_circuit` | array of 6 numbers | `[1,1,1,1,1,1]` | Per-circuit fog multipliers (multiplied with `fog_scale`), e.g. clear a single hazy track by lowering its entry. |
+| `draw_distance` | `0` or `0.1`–`100` | `1.5` | Multiplier on the authored per-circuit draw-distance radii (needs `no_lod`). `1.0` = the N64 distances, higher = see further, `0` = unlimited — note that unlimited draws distant track pieces the artists never meant to be visible (they float with nothing in between). |
+| `draw_distance_circuit` | array of 6 numbers | `[1,1,1,1,1,1]` | Per-circuit draw-distance multipliers (multiplied with `draw_distance`), e.g. extend just one short-sighted city track. |
 
 ## Troubleshooting
 

--- a/docs/no_lod_audit.md
+++ b/docs/no_lod_audit.md
@@ -300,6 +300,31 @@ row-membership changes. Verified on the reporting savestate: stock walk draws
 the pipeline), `LAMBO_NO_LOD=0` restores the stock list bit-for-bit, and a 4P race
 smokes clean with the list clamp holding.
 
+## 10. Addendum (2026-07-18): configurable draw distance (`draw_distance`)
+
+Unlimited reach (§8's 1e9 radii + §9's full-track walk) exposes geometry the track
+authors relied on the radius cull to hide: segments across the map render with
+nothing modelled in between (distant track pieces "float in the sky"), and scenery
+sub-DLs appear from angles their PVS rows deliberately excluded. The forward-cone
+tests can't help — they are view culling, not occlusion.
+
+So the §8 radius rewrite is now a dial instead of a switch: `lambo_no_lod_draw_distance`
+writes `authored_radius x draw_distance` per frame, where the authored `float[6][5]`
+values are a compiled-in copy of the ROM table (extracted from the .z64 at `0x89BD0`
+= vram `0x80088FD0` − `0x80000000` + `0xC00`; the live RDRAM copy is not a usable
+baseline because the hook itself rewrites it every frame and a savestate captured
+mid-race restores the rewritten values). graphics.json keys: `draw_distance` (global,
+default **1.5**) and `draw_distance_circuit` (6 per-circuit multipliers, like
+`fog_scale_circuit`); `0` = unlimited (the previous behaviour); `LAMBO_DRAW_DISTANCE`
+env overrides both. The §9 full-track walk is unchanged — it supplies the candidates,
+the scaled radius bounds reach, so the authored 10-slot rows still never limit what
+is drawn within the radius.
+
+Default rationale: the worst measured authored-radius pop (§8: circuit 5 segment 31
+at ~51k units vs its 35000 radius) needs ≥1.46x, so 1.5 fixes every measured pop
+while staying close to authored reach. With the multiplier the per-mode budget
+*ratios* (multiplayer columns 20000–27500) are preserved rather than flattened.
+
 ---
 *Method note: MIPS classification used `tools/scan_lod_patterns.py` output cross-read
 against the recompiled C (per-instruction VRAM comments) rather than raw disassembly;

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -637,10 +637,10 @@ text = "{ extern uint32_t lambo_no_lod_scenery_guard(uint8_t*, uint32_t); ctx->r
 # players 0x800CE6A4). The radii are N64 fill-rate budgets -- circuits 5/6 are authored at
 # 35000 vs 55000 for circuit 1 -- so whole city blocks pop in at the radius edge. The hook
 # sits on the world-draw path (0x8000CD3C, after the 0x200 state gate, before the first
-# table read) and rewrites the radii to 1e9 when no_lod(): per frame, not once at load,
-# because a savestate restore brings the ROM values back. Cone/half-plane tests and the
-# authored visibility lists are untouched, so nothing is synthesised -- the game just stops
-# hiding segments it already streamed. Native in src/lambo_no_lod.cpp.
+# table read) and rewrites the radii when no_lod() to authored * draw_distance config
+# (0 = unlimited 1e9): per frame, not once at load, because a savestate restore brings
+# the ROM values back. Cone/half-plane tests are untouched, so nothing is synthesised --
+# the game just stops hiding segments it already streamed. Native in src/lambo_no_lod.cpp.
 [[patches.hook]]
 func = "func_8000A6C0"
 before_vram = 0x8000CD3C

--- a/scripts/gen_syms_toml.py
+++ b/scripts/gen_syms_toml.py
@@ -1001,10 +1001,10 @@ text = "{ extern uint32_t lambo_no_lod_scenery_guard(uint8_t*, uint32_t); ctx->r
 # players 0x800CE6A4). The radii are N64 fill-rate budgets -- circuits 5/6 are authored at
 # 35000 vs 55000 for circuit 1 -- so whole city blocks pop in at the radius edge. The hook
 # sits on the world-draw path (0x8000CD3C, after the 0x200 state gate, before the first
-# table read) and rewrites the radii to 1e9 when no_lod(): per frame, not once at load,
-# because a savestate restore brings the ROM values back. Cone/half-plane tests and the
-# authored visibility lists are untouched, so nothing is synthesised -- the game just stops
-# hiding segments it already streamed. Native in src/lambo_no_lod.cpp.
+# table read) and rewrites the radii when no_lod() to authored * draw_distance config
+# (0 = unlimited 1e9): per frame, not once at load, because a savestate restore brings
+# the ROM values back. Cone/half-plane tests are untouched, so nothing is synthesised --
+# the game just stops hiding segments it already streamed. Native in src/lambo_no_lod.cpp.
 [[patches.hook]]
 func = "func_8000A6C0"
 before_vram = 0x8000CD3C

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -53,6 +53,12 @@ bool g_no_lod = true;
 double g_fog_scale = 1.0;
 std::array<double, 6> g_fog_scale_circuit{1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
 
+// Draw-distance multipliers (see lambo_config.h). 1.5 covers the worst measured
+// authored-radius pop (circuit 5 segment 31 at ~51k units vs its 35000 radius)
+// without reaching the cross-track geometry an unlimited radius exposes.
+double g_draw_distance = 1.5;
+std::array<double, 6> g_draw_distance_circuit{1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
 // Read a key into `out`, keeping the existing (default) value when the key is
 // missing or invalid. NLOHMANN_JSON_SERIALIZE_ENUM does NOT throw on an
 // unrecognised string -- it silently maps it to the FIRST enumerator, which for
@@ -98,6 +104,8 @@ nlohmann::json to_json(const ultramodern::renderer::GraphicsConfig& c) {
         {"no_lod", g_no_lod},
         {"fog_scale", g_fog_scale},
         {"fog_scale_circuit", g_fog_scale_circuit},
+        {"draw_distance", g_draw_distance},
+        {"draw_distance_circuit", g_draw_distance_circuit},
     };
 }
 
@@ -122,6 +130,8 @@ void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c
     from_or_default(j, "no_lod", g_no_lod);
     from_or_default(j, "fog_scale", g_fog_scale);
     from_or_default(j, "fog_scale_circuit", g_fog_scale_circuit);
+    from_or_default(j, "draw_distance", g_draw_distance);
+    from_or_default(j, "draw_distance_circuit", g_draw_distance_circuit);
     // Sanity-bound the window size: below the N64 framebuffer is useless, above 8K
     // is a typo -- either way SDL_CreateWindow would fail and the port would run
     // permanently headless, so reset to defaults instead.
@@ -325,6 +335,25 @@ double fog_scale(int circuit) {
     }
     if (s < 0.0) s = 0.0;
     if (s > 8.0) s = 8.0;
+    return s;
+}
+
+// LAMBO_DRAW_DISTANCE=<float> overrides both JSON keys for capture/testing.
+// Returns 0.0 for "unlimited"; positive values are clamped to [0.1, 100] (100x the
+// shortest authored radius already exceeds any cross-track distance).
+double draw_distance(int circuit) {
+    double s;
+    if (const char* v = std::getenv("LAMBO_DRAW_DISTANCE")) {
+        s = std::atof(v);
+    } else {
+        s = g_draw_distance;
+        if (circuit >= 0 && circuit < (int)g_draw_distance_circuit.size()) {
+            s *= g_draw_distance_circuit[(size_t)circuit];
+        }
+    }
+    if (s <= 0.0) return 0.0;
+    if (s < 0.1) s = 0.1;
+    if (s > 100.0) s = 100.0;
     return s;
 }
 

--- a/src/lambo_config.h
+++ b/src/lambo_config.h
@@ -80,6 +80,17 @@ bool no_lod();
 // LAMBO_FOG_SCALE=<float> overrides the whole computation for capture/testing.
 double fog_scale(int circuit);
 
+// Draw-distance multiplier applied (while no_lod is on) to the authored per-circuit
+// segment-cull radii the scene builder tests visibility-list entries against.
+// 1.0 = the N64 radii, larger = see further, 0 (or negative) = unlimited: the whole
+// track subject only to the per-frame view-cone tests. Unlimited shows geometry the
+// track authors never meant to be visible (distant segments floating with nothing
+// in between), hence the finite default. graphics.json keys "draw_distance"
+// (global, default 1.5) and "draw_distance_circuit" (array of 6 per-circuit
+// multipliers, default all 1.0, multiplied with the global).
+// LAMBO_DRAW_DISTANCE=<float> overrides the whole computation for capture/testing.
+double draw_distance(int circuit);
+
 } // namespace config
 } // namespace lambo
 

--- a/src/lambo_no_lod.cpp
+++ b/src/lambo_no_lod.cpp
@@ -12,6 +12,7 @@
 // state: record+0xC pointers populated), so no geometry is synthesised here.
 
 #include <cstdint>
+#include <cstring>
 
 #include "recomp.h"
 
@@ -29,16 +30,36 @@ extern "C" uint32_t lambo_no_lod_scenery_guard(uint8_t* rdram, uint32_t at) {
 // authored shortest (35000 vs 55000 on circuit 1), so whole blocks pop in at the
 // radius edge. Hooked per frame on the world-draw path (0x8000CD3C, before the first
 // table read) rather than once at load because a savestate restore brings the ROM
-// values back. Only the radius is lifted: the forward-cone/half-plane tests and the
-// authored per-segment visibility lists still decide what is drawn.
+// values back. The radii are scaled by the draw_distance config (0 = unlimited) from
+// a compiled-in copy of the authored table: the live table can't be trusted as the
+// baseline because this hook rewrites it every frame and a savestate captured while
+// it ran would restore the rewritten values. The forward-cone/half-plane tests and
+// the per-frame visibility walk still decide what is drawn.
 extern "C" void lambo_no_lod_draw_distance(uint8_t* rdram) {
     if (!lambo::config::no_lod()) {
         return;
     }
-    constexpr uint32_t kTableAddr = 0x80088FD0u;  // float[6][5]: [circuit][player-count]
-    constexpr int32_t kFarBits = 0x4E6E6B28;      // 1e9f, beyond any on-track distance
-    for (uint32_t i = 0; i < 6 * 5; i++) {
-        MEM_W(i * 4, (gpr)(int32_t)kTableAddr) = kFarBits;
+    // ROM copy of the float[6][5] at 0x80088FD0 ([circuit][player-count column]),
+    // extracted from the .z64 at 0x89BD0 (= vram - 0x80000000 + 0xC00).
+    static constexpr float kAuthored[6][5] = {
+        {55000.0f, 55000.0f, 50000.0f, 25000.0f, 25000.0f},
+        {50000.0f, 50000.0f, 40000.0f, 20000.0f, 20000.0f},
+        {40000.0f, 40000.0f, 30000.0f, 20000.0f, 20000.0f},
+        {45000.0f, 45000.0f, 30000.0f, 25000.0f, 25000.0f},
+        {35000.0f, 35000.0f, 27500.0f, 25000.0f, 25000.0f},
+        {35000.0f, 35000.0f, 27500.0f, 25000.0f, 25000.0f},
+    };
+    constexpr uint32_t kTableAddr = 0x80088FD0u;
+    constexpr float kUnlimited = 1e9f;  // beyond any on-track distance
+    for (int c = 0; c < 6; c++) {
+        const double scale = lambo::config::draw_distance(c);
+        for (int p = 0; p < 5; p++) {
+            float r = scale <= 0.0 ? kUnlimited : (float)(kAuthored[c][p] * scale);
+            if (r > kUnlimited) r = kUnlimited;
+            int32_t bits;
+            std::memcpy(&bits, &r, sizeof(bits));
+            MEM_W((c * 5 + p) * 4, (gpr)(int32_t)kTableAddr) = bits;
+        }
     }
 }
 


### PR DESCRIPTION
Follow-up to #122. Rendering the whole track at unlimited radius exposes geometry the track authors relied on the radius cull to hide: distant track pieces float in the sky with nothing modelled in between, and scenery renders from angles its PVS rows deliberately excluded. The forward-cone tests can't help — they are view culling, not occlusion.

## What changed

The per-frame radius rewrite (the #119 hook at `0x8000CD3C`) becomes a dial instead of a switch: it now writes `authored_radius × draw_distance` into the `float[6][5]` table at `0x80088FD0`, from a compiled-in copy of the ROM values (extracted from the .z64 at `0x89BD0`). The live RDRAM table is not a usable baseline — the hook itself rewrites it every frame, and a savestate captured mid-race restores the rewritten values.

New `graphics.json` keys (mirroring the `fog_scale` pair):

| Key | Default | Meaning |
|---|---|---|
| `draw_distance` | `1.5` | Multiplier on the authored per-circuit radii. `1.0` = N64 distances, higher = further, `0` = unlimited (the previous behaviour). |
| `draw_distance_circuit` | `[1,1,1,1,1,1]` | Per-circuit multipliers, multiplied with the global. |

`LAMBO_DRAW_DISTANCE=<float>` overrides both for capture/testing. The #122 full-track walk is unchanged: it supplies the candidates so the authored 10-slot PVS rows never bound reach; the scaled radius decides distance. Using a multiplier (not an absolute distance) preserves the authored per-mode budget ratios — the multiplayer columns (20000–27500) stay proportionally shorter than 1P.

**Default rationale:** the worst measured authored-radius pop (#119: circuit 5 segment 31 popping at ~51k units against its 35000 radius) needs ≥1.46×, so 1.5 fixes every measured pop while staying close to authored reach.

No new hooks — native + config changes only (the `gen_syms_toml.py`/`us.toml` diffs are comment sync).

## Verification

Clean bootstrap build green. Headless warp into circuit 5 (`LAMBO_HEADLESS` + `LAMBO_WARP=5` + `LAMBO_DL_RENDER_EVERY=100`), software-rasterizer `tris_in` at matching send_dl frames:

| send_dl | 1.0 | 1.5 | unlimited |
|---|---|---|---|
| ~282 | 2866 | 3368 | 3509 |
| ~382 | 2762 | 3264 | 3405 |
| ~482 | 2642 | 3144 | 3285 |
| ~582 | 2186 | 2688 | 2829 |

Monotonic at every frame; the steady ~140-triangle delta between 1.5 and unlimited is the far cross-track geometry now culled again. Config round-trip verified (keys persist with defaults in a fresh `graphics.json`).

Tuning guidance if 1.5 still shows a floating piece somewhere (or hides something wanted): lower/raise `draw_distance`, or adjust just that circuit via `draw_distance_circuit`.
