### PR TITLE
no_lod: per-circuit gate, ship-safe default with pro tracks off

### DIFF
--- a/docs/TRACK_INDEX.md
+++ b/docs/TRACK_INDEX.md
@@ -1,0 +1,51 @@
+# Track index — circuit 0-based ↔ 1-based ↔ F-key
+
+The ROM has **no track-name strings**; the menu shows "CIRCUIT 1" through "CIRCUIT 6"
+with a numbered map preview (`src/lambo_warp.c:51-55`). So the only labels on disk
+are the integer index. This file maps each index to its navigation hotkey and the
+only organic category the user can read off the menu: **basic** (1-3) vs **pro**
+(4-6). Captured 2026-07-23 from the in-game track-select menu.
+
+## The table
+
+| Index (0-based) | Circuit (1-based) | F-key | Tier | Authored radius (1P) | `no_lod_circuit` default | Status |
+|---|---|---|---|---|---|---|
+| 0 | 1 | F1 | basic | 55000 | true (PVS synth on) | stable |
+| 1 | 2 | F2 | basic | 50000 | true (PVS synth on) | stable |
+| 2 | 3 | F3 | basic | 40000 | true (PVS synth on) | stable |
+| 3 | 4 | F4 | pro   | 45000 | **false (N64-style)** | experimental |
+| 4 | 5 | F5 | pro   | 35000 | **false (N64-style)** | experimental — city track |
+| 5 | 6 | F6 | pro   | 35000 | **false (N64-style)** | experimental |
+
+So `no_lod_circuit[3..5]` is `false` by default — the PVS synth is off for the pro
+tracks, restoring the authored 10-slot PVS rows. The radius cull still runs for them
+(gated by the global `no_lod`), so distance culling works; the user just doesn't
+get the modern cross-track pop-in fix on those tracks. **Opt-in:** flip the
+relevant entry to `true` in `graphics.json` to test the modern look on a pro
+track. The basic tracks (1-3) ship with the modern look on.
+
+`draw_distance_circuit[4]` (the **5th element** of the array) is the second pro
+track = city track. The currently-applied multiplier is `0.6667` × global `1.5` =
+`1.0×` the N64 authored radius — the city track runs at native N64 distances even
+with the radius cull on. (Math note: `0.6667 = 1.0 / 1.5` — the precise inversion
+of the global multiplier so the city exactly hits N64.)
+
+## Hotkeys / env var
+
+- **F1–F6** (dev-warp): jump straight to that circuit as a 1-player single race, 3 laps,
+  car 0. Active in any warpable state (3–8 except 7) — see `src/lambo_warp.c:68-72`.
+- **`LAMBO_WARP=N`** (env, 1-based): same launch-once warp. Use `LAMBO_WARP=5` to land
+  on the city track from a cold boot.
+
+## How this map is used
+
+The `draw_distance_circuit` and `no_lod_circuit` arrays in `graphics.json` are keyed
+by the **0-based** index above. The file is read at startup by
+`lambo::config::load_and_apply_graphics()`; the per-circuit value multiplies the
+global `draw_distance` (for the radius) or gates the PVS synth (for `no_lod`).
+
+If a future edit needs to tune a different circuit, change the element at the index
+above. **Common mistake:** counting the array 1-based in the JSON — the 5th element
+of the array is index 4, not index 5. The `draw_distance(c)` and `no_lod_circuit(c)`
+calls in `lambo_no_lod.cpp` are passed the 0-based index the scene builder already
+uses internally, so the table here is the single source of truth.

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -48,6 +48,11 @@ bool g_widescreen_sky_match = true;
 // record pointer being non-null, so segments without a scenery DL are unaffected.
 bool g_no_lod = true;
 
+// Per-circuit refinement of the global no_lod. Rationale + JSON key in
+// lambo_config.h; see that header for the ship-safe default and the
+// basic/pro split.
+std::array<bool, 6> g_no_lod_circuit{true, true, true, false, false, false};
+
 // Fog density multipliers (see lambo_config.h). Stored as double: the round-trip
 // validity check in from_or_default would reject float (0.3 -> 0.3f -> 0.30000001...).
 double g_fog_scale = 1.0;
@@ -102,6 +107,7 @@ nlohmann::json to_json(const ultramodern::renderer::GraphicsConfig& c) {
         {"widescreen_fog_match", g_widescreen_fog_match},
         {"widescreen_sky_match", g_widescreen_sky_match},
         {"no_lod", g_no_lod},
+        {"no_lod_circuit", g_no_lod_circuit},
         {"fog_scale", g_fog_scale},
         {"fog_scale_circuit", g_fog_scale_circuit},
         {"draw_distance", g_draw_distance},
@@ -128,6 +134,7 @@ void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c
     from_or_default(j, "widescreen_fog_match", g_widescreen_fog_match);
     from_or_default(j, "widescreen_sky_match", g_widescreen_sky_match);
     from_or_default(j, "no_lod", g_no_lod);
+    from_or_default(j, "no_lod_circuit", g_no_lod_circuit);
     from_or_default(j, "fog_scale", g_fog_scale);
     from_or_default(j, "fog_scale_circuit", g_fog_scale_circuit);
     from_or_default(j, "draw_distance", g_draw_distance);
@@ -320,6 +327,16 @@ bool no_lod() {
         return v[0] == '1';
     }
     return g_no_lod;
+}
+
+// Per-circuit refinement of no_lod (see lambo_config.h). No env var: the JSON
+// array is the only knob, since per-circuit toggling is a user-facing choice,
+// not a headless test parameter. The function returns the global no_lod for an
+// out-of-range circuit so a stale array length never disables PVS synth
+// wholesale.
+bool no_lod_circuit(int circuit) {
+    if (circuit < 0 || circuit >= (int)g_no_lod_circuit.size()) return no_lod();
+    return g_no_lod_circuit[(size_t)circuit];
 }
 
 // LAMBO_FOG_SCALE=<float> overrides both JSON keys for headless capture/testing.

--- a/src/lambo_config.h
+++ b/src/lambo_config.h
@@ -72,6 +72,17 @@ bool widescreen_sky_match();
 // "no_lod" (default true), overridable by LAMBO_NO_LOD=1/0.
 bool no_lod();
 
+// Per-circuit refinement of no_lod: the full-track walk (PVS synth) is what fixes
+// the cross-track distance pop-in (PR #122), but on the pro tracks it surfaces
+// back-of-buildings / cross-track geometry the track authors relied on the
+// authored PVS rows to hide. Ship-safe default: pro tracks (3-5) ship with the
+// PVS synth OFF (N64-style authoring); basic tracks (0-2) ship with it ON (modern
+// pop-in fix). The radius cull and the 2P+ scenery sub-DL stay gated on the
+// global no_lod() so distance culling and 2P scenery work on all 6 tracks.
+// graphics.json key "no_lod_circuit" (array of 6 bools, default [true, true, true,
+// false, false, false]).
+bool no_lod_circuit(int circuit);
+
 // Fog density multiplier applied to every fog moveword in the frame DL: 1.0 =
 // authored fog, 0.0 = no fog, values in between thin the fog uniformly without
 // moving its onset distance. graphics.json keys "fog_scale" (global, default 1.0)

--- a/src/lambo_no_lod.cpp
+++ b/src/lambo_no_lod.cpp
@@ -41,13 +41,17 @@ extern "C" void lambo_no_lod_draw_distance(uint8_t* rdram) {
     }
     // ROM copy of the float[6][5] at 0x80088FD0 ([circuit][player-count column]),
     // extracted from the .z64 at 0x89BD0 (= vram - 0x80000000 + 0xC00).
+    // Basics: index 0-2 (1P radii 55000/50000/40000), pros 3-5 (45000/35000/35000).
+    // Index 4 is the city track (second pro) — the one we routinely tune down via
+    // draw_distance_circuit[4] in graphics.json. See docs/TRACK_INDEX.md for the
+    // full 0-based/1-based/F-key mapping.
     static constexpr float kAuthored[6][5] = {
-        {55000.0f, 55000.0f, 50000.0f, 25000.0f, 25000.0f},
-        {50000.0f, 50000.0f, 40000.0f, 20000.0f, 20000.0f},
-        {40000.0f, 40000.0f, 30000.0f, 20000.0f, 20000.0f},
-        {45000.0f, 45000.0f, 30000.0f, 25000.0f, 25000.0f},
-        {35000.0f, 35000.0f, 27500.0f, 25000.0f, 25000.0f},
-        {35000.0f, 35000.0f, 27500.0f, 25000.0f, 25000.0f},
+        {55000.0f, 55000.0f, 50000.0f, 25000.0f, 25000.0f},  // circuit 1 (basic)
+        {50000.0f, 50000.0f, 40000.0f, 20000.0f, 20000.0f},  // circuit 2 (basic)
+        {40000.0f, 40000.0f, 30000.0f, 20000.0f, 20000.0f},  // circuit 3 (basic)
+        {45000.0f, 45000.0f, 30000.0f, 25000.0f, 25000.0f},  // circuit 4 (pro 1)
+        {35000.0f, 35000.0f, 27500.0f, 25000.0f, 25000.0f},  // circuit 5 (pro 2, city)
+        {35000.0f, 35000.0f, 27500.0f, 25000.0f, 25000.0f},  // circuit 6 (pro 3)
     };
     constexpr uint32_t kTableAddr = 0x80088FD0u;
     constexpr float kUnlimited = 1e9f;  // beyond any on-track distance
@@ -80,6 +84,7 @@ constexpr gpr kHdrPtrAddr  = (gpr)(int32_t)0x80098238u;  // track asset header p
 constexpr gpr kCamSegAddr  = (gpr)(int32_t)0x800BF1CCu;  // camera segment (this viewport)
 constexpr gpr kPvsPtrAddr  = (gpr)(int32_t)0x800CE678u;  // PVS base (header+0x4 copy)
 constexpr gpr kRecListAddr = (gpr)(int32_t)0x800BF1D0u;  // 64-byte segment records (viewport)
+constexpr gpr kCurCircuitAddr = (gpr)(int32_t)0x800CE794u;  // current circuit (no_lod_audit.md §8)
 
 int16_t s_synth_row[256];
 int s_synth_n = -1;  // -1 = passthrough (feature off or sanity check failed)
@@ -96,6 +101,13 @@ bool valid_guest_ptr(int32_t p) {
 // this walk and the authored row is used untouched.
 void build_synth_row(uint8_t* rdram) {
     s_synth_n = -1;
+    // Per-circuit gate (2026-07-23): the PVS synth surfaces back-of-building /
+    // cross-track geometry on the pro tracks that the authored PVS rows
+    // deliberately hid. See lambo_config.h for the basic/pro default. The
+    // radius cull and 2P+ scenery sub-DL stay gated on the global no_lod()
+    // so they still work on tracks where the synth is off.
+    int32_t cur_circuit = MEM_H(0, kCurCircuitAddr);
+    if (!lambo::config::no_lod_circuit(cur_circuit)) return;
     int32_t hdr = MEM_W(0, kHdrPtrAddr);
     int32_t pvs = MEM_W(0, kPvsPtrAddr);
     int32_t recs = MEM_W(0, kRecListAddr);
@@ -132,6 +144,9 @@ void build_synth_row(uint8_t* rdram) {
 
 // Hooked after the row-entry fetch (before 0x8000D05C): replaces the authored entry
 // with the synthesized row's. idx is the loop counter the fetch used ($t4).
+// s_synth_n < 0 here means "passthrough" -- one of: global no_lod off, per-circuit
+// no_lod_circuit off (city/pro tracks), or build_synth_row failed its sanity
+// checks. All three fall back to the ROM-authored 10-slot PVS row.
 extern "C" uint32_t lambo_no_lod_pvs_entry(uint8_t* rdram, uint32_t orig, uint32_t idx) {
     if (!lambo::config::no_lod()) {
         s_synth_n = -1;
@@ -147,7 +162,8 @@ extern "C" uint32_t lambo_no_lod_pvs_entry(uint8_t* rdram, uint32_t orig, uint32
 }
 
 // Hooked over the loop-cap test result (before 0x8000D908): keep looping until the
-// synthesized row is exhausted instead of stopping at 10. next is i+1 ($t4).
+// synthesized row is exhausted instead of stopping at 10. next is i+1 ($t4). Like
+// pvs_entry, s_synth_n < 0 here means passthrough (see pvs_entry comment).
 extern "C" uint32_t lambo_no_lod_pvs_more(uint8_t* rdram, uint32_t orig, uint32_t next) {
     (void)rdram;
     if (!lambo::config::no_lod() || s_synth_n < 0) return orig;

--- a/src/lambo_warp.c
+++ b/src/lambo_warp.c
@@ -50,6 +50,8 @@ void func_80008ECC(uint8_t* rdram, recomp_context* ctx);
 
 // The game's circuits are unnamed (menu shows "CIRCUIT" + a numbered map preview;
 // ROM has no track-name strings), so the scene table mirrors that presentation.
+// The basic/pro split is documented in docs/TRACK_INDEX.md, not in these labels —
+// the labels feed runtime log output, and the basic/pro category is a doc concern.
 static const char* const lambo_scene_table[6] = {
     "CIRCUIT 1", "CIRCUIT 2", "CIRCUIT 3", "CIRCUIT 4", "CIRCUIT 5", "CIRCUIT 6",
 };


### PR DESCRIPTION
## Summary

The full-track walk (PVS synth, PR #122) fixes the cross-track distance pop-in, but on the pro tracks it surfaces back-of-buildings and floating geometry that the track authors relied on the authored PVS rows to hide.

This adds a per-circuit `no_lod_circuit[6]` array to `graphics.json` so the PVS synth can be disabled per track. The radius cull and 2P+ scenery sub-DL stay gated on the global `no_lod()` so distance culling and 2P scenery work on all 6 tracks.

**Ship-safe default:** pro tracks (3-5) ship with PVS synth **off** (N64-style authoring, radius cull still on); basic tracks (0-2) ship with the modern pop-in fix. The basic/pro split was confirmed in-session from F1-F6 in the track-select menu — basic = the 1P starter set with longer authored radii, pro = the harder set with 35000-radius budgets (including the city track at index 4).

## Changes

- `src/lambo_config.{cpp,h}`: add `no_lod_circuit(int circuit)` function and the matching JSON key. Default is `[true, true, true, false, false, false]` (basic on, pro off). Out-of-range circuits fall back to the global `no_lod()` for safety.
- `src/lambo_no_lod.cpp`: `build_synth_row` reads the current circuit from `0x800CE794` and skips the PVS synth when `no_lod_circuit(c)` is false. The other no_lod features (radius cull, scenery sub-DL) are still gated on the global `no_lod()`. Comments in `pvs_entry` and `pvs_more` explain that `s_synth_n < 0` can mean either "global off", "per-circuit off", or "sanity check failed".
- `src/lambo_warp.c`: dev-warp scene table reverts to plain "CIRCUIT 1"..."CIRCUIT 6" — the basic/pro classification is documentation, not log output.
- `docs/TRACK_INDEX.md` (new): authoritative 0-based/1-based/F-key/basic-pro map. Cross-referenced from the radius table in `lambo_no_lod.cpp:43-52` and the config comment in `lambo_config.h`.

## Test

- Live RDRAM radii table dump (with `--lambo-debug`) confirms the per-circuit multiplier is applied: city track 1P radius = 35000 (= N64 authored) at `draw_distance_circuit[4]=0.6667`.
- `no_lod: false` global test: back-of-buildings gone, confirming the PVS synth is the root cause. Reverted.
- Per-circuit implementation: city track looks correct (no back-of-buildings, radius cull at 35000), other basic tracks retain the modern look.

## Refs

- #87 (parent no_lod feature)
- #122 (full-track walk — root cause of the back-of-buildings)
- PR #123 (draw_distance / draw_distance_circuit — same toolchain)