### PR TITLE
Add live native configuration menus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ cmake_minimum_required(VERSION 3.20)
 
 project(lamborghini_modern LANGUAGES C CXX)
 
+include(CTest)
+
 set(CMAKE_C_STANDARD 17)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -36,6 +38,20 @@ set(N64MR ${CMAKE_CURRENT_SOURCE_DIR}/lib/N64ModernRuntime)
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/lib/rt64/CMakeLists.txt)
     message(FATAL_ERROR "lib/rt64 submodule is missing. Initialise it first:\n"
         "  git submodule update --init --recursive")
+endif()
+
+if(BUILD_TESTING)
+    add_executable(lambo_config_tests
+        tests/test_live_config.cpp
+        src/lambo_config.cpp
+        src/lambo_log.cpp
+    )
+    target_include_directories(lambo_config_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${N64MR}/ultramodern/include
+        ${N64MR}/thirdparty
+    )
+    add_test(NAME lambo_config_live_updates COMMAND lambo_config_tests)
 endif()
 set(RT64_STATIC TRUE)
 if(WIN32)
@@ -140,6 +156,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/stub_renderer.cpp
         src/lambo_audio.cpp    # SDL2 push-audio sink for the AI buffer (audio epic #53, PR 1 of 3)
         src/lambo_config.cpp   # persistent graphics.json -> ultramodern GraphicsConfig (enhancements #1/#2)
+        src/lambo_menu.cpp     # lightweight native Win32 menu bar; live config actions + persistence
         src/lambo_crash.cpp    # native crash backtrace (issue #13 / A14): Win32 EXCEPTION_POINTERS +
                                # POSIX sigaction handler printing KSEG0/RDRAM offset + a 32-entry
                                # function-lookup trace ring. No deps beyond libc + DbgHelp (Win) /

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ Graphics settings persist in `graphics.json` (in `%LOCALAPPDATA%\LamborghiniReco
 Windows, `~/.config/LamborghiniRecomp` elsewhere; create a `portable.txt` in the
 directory you launch from to keep everything there instead). Game saves live in the
 same directory. The file is created with
-defaults on first run — edit it and relaunch. The schema and vocabulary match the other
+defaults on first run. On Windows, the **Graphics** and **Enhancements** menu-bar menus
+apply the commonly used options immediately and save them automatically. The graphics API
+selection is also in the menu but takes effect on the next launch because RT64 creates the
+backend at startup. Advanced settings (texture paths and per-circuit numeric overrides) remain
+available by editing the file and relaunching. The schema and vocabulary match the other
 N64Recomp ports (Zelda 64: Recompiled et al.):
 
 | Key | Values | Default | Meaning |

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -3,10 +3,11 @@
 // Schema and behaviour mirror Zelda64Recomp's src/game/config.cpp graphics.json
 // (same key names, same per-key fall-back-to-default on missing/corrupt values,
 // and a "portable.txt in the LAUNCH directory -> keep config there" escape hatch),
-// minus the RmlUi menu: this port's UI is the JSON file itself plus hotkeys.
+// with a lightweight native menu for the common live-safe options.
 #include "lambo_config.h"
 
 #include <array>
+#include <atomic>
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
@@ -35,34 +36,38 @@ std::string g_texture_dump;
 // Widen the dense 3P/4P split-screen fog to the open 1P window/colour (issue #83).
 // Enhancement default-on, consistent with the widescreen wave; 1P/2P are unaffected
 // regardless (the rewrite self-gates on player count).
-bool g_widescreen_fog_match = true;
+std::atomic_bool g_widescreen_fog_match{true};
 
 // Draw the sky panorama in 3P/4P split screen like 1P/2P (issue #84). Same
 // enhancement family as the fog match; 1P/2P take the sky path natively anyway.
-bool g_widescreen_sky_match = true;
+std::atomic_bool g_widescreen_sky_match{true};
 
 // Remove the ROM's per-mode LOD reductions (issues #87/#91): the scene builder
 // func_8000A6C0 emits each track segment's scenery layer (record+0xC sub-DL: the
 // distant canyon walls / roadside relief) only when players < 2, so 2P-4P races
 // lose the far scenery entirely. Default-on; the emit still self-gates on the
 // record pointer being non-null, so segments without a scenery DL are unaffected.
-bool g_no_lod = true;
+std::atomic_bool g_no_lod{true};
 
 // Per-circuit refinement of the global no_lod. Rationale + JSON key in
 // lambo_config.h; see that header for the ship-safe default and the
 // basic/pro split.
-std::array<bool, 6> g_no_lod_circuit{true, true, true, false, false, false};
+std::array<std::atomic_bool, 6> g_no_lod_circuit{{true, true, true, false, false, false}};
 
 // Fog density multipliers (see lambo_config.h). Stored as double: the round-trip
 // validity check in from_or_default would reject float (0.3 -> 0.3f -> 0.30000001...).
-double g_fog_scale = 1.0;
+std::atomic<double> g_fog_scale{1.0};
 std::array<double, 6> g_fog_scale_circuit{1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
 
 // Draw-distance multipliers (see lambo_config.h). 1.5 covers the worst measured
 // authored-radius pop (circuit 5 segment 31 at ~51k units vs its 35000 radius)
 // without reaching the cross-track geometry an unlimited radius exposes.
-double g_draw_distance = 1.5;
+std::atomic<double> g_draw_distance{1.5};
 std::array<double, 6> g_draw_distance_circuit{1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+// Main-thread-owned snapshot used by native menu actions. It avoids reading the
+// runtime's reference-returning getter while another thread may be applying a change.
+ultramodern::renderer::GraphicsConfig g_current_graphics{};
 
 // Read a key into `out`, keeping the existing (default) value when the key is
 // missing or invalid. NLOHMANN_JSON_SERIALIZE_ENUM does NOT throw on an
@@ -104,13 +109,16 @@ nlohmann::json to_json(const ultramodern::renderer::GraphicsConfig& c) {
         {"window_height", g_window_size.height},
         {"texture_pack", g_texture_pack},
         {"texture_dump", g_texture_dump},
-        {"widescreen_fog_match", g_widescreen_fog_match},
-        {"widescreen_sky_match", g_widescreen_sky_match},
-        {"no_lod", g_no_lod},
-        {"no_lod_circuit", g_no_lod_circuit},
-        {"fog_scale", g_fog_scale},
+        {"widescreen_fog_match", g_widescreen_fog_match.load()},
+        {"widescreen_sky_match", g_widescreen_sky_match.load()},
+        {"no_lod", g_no_lod.load()},
+        {"no_lod_circuit", nlohmann::json::array({
+            g_no_lod_circuit[0].load(), g_no_lod_circuit[1].load(),
+            g_no_lod_circuit[2].load(), g_no_lod_circuit[3].load(),
+            g_no_lod_circuit[4].load(), g_no_lod_circuit[5].load()})},
+        {"fog_scale", g_fog_scale.load()},
         {"fog_scale_circuit", g_fog_scale_circuit},
-        {"draw_distance", g_draw_distance},
+        {"draw_distance", g_draw_distance.load()},
         {"draw_distance_circuit", g_draw_distance_circuit},
     };
 }
@@ -131,14 +139,31 @@ void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c
     from_or_default(j, "window_height", g_window_size.height);
     from_or_default(j, "texture_pack", g_texture_pack);
     from_or_default(j, "texture_dump", g_texture_dump);
-    from_or_default(j, "widescreen_fog_match", g_widescreen_fog_match);
-    from_or_default(j, "widescreen_sky_match", g_widescreen_sky_match);
-    from_or_default(j, "no_lod", g_no_lod);
-    from_or_default(j, "no_lod_circuit", g_no_lod_circuit);
-    from_or_default(j, "fog_scale", g_fog_scale);
+    bool widescreen_fog_match = g_widescreen_fog_match.load();
+    bool widescreen_sky_match = g_widescreen_sky_match.load();
+    bool no_lod = g_no_lod.load();
+    std::array<bool, 6> no_lod_circuit{};
+    for (size_t i = 0; i < no_lod_circuit.size(); ++i) {
+        no_lod_circuit[i] = g_no_lod_circuit[i].load();
+    }
+    double fog_scale = g_fog_scale.load();
+    double draw_distance = g_draw_distance.load();
+    from_or_default(j, "widescreen_fog_match", widescreen_fog_match);
+    from_or_default(j, "widescreen_sky_match", widescreen_sky_match);
+    from_or_default(j, "no_lod", no_lod);
+    from_or_default(j, "no_lod_circuit", no_lod_circuit);
+    from_or_default(j, "fog_scale", fog_scale);
     from_or_default(j, "fog_scale_circuit", g_fog_scale_circuit);
-    from_or_default(j, "draw_distance", g_draw_distance);
+    from_or_default(j, "draw_distance", draw_distance);
     from_or_default(j, "draw_distance_circuit", g_draw_distance_circuit);
+    g_widescreen_fog_match.store(widescreen_fog_match);
+    g_widescreen_sky_match.store(widescreen_sky_match);
+    g_no_lod.store(no_lod);
+    for (size_t i = 0; i < no_lod_circuit.size(); ++i) {
+        g_no_lod_circuit[i].store(no_lod_circuit[i]);
+    }
+    g_fog_scale.store(fog_scale);
+    g_draw_distance.store(draw_distance);
     // Sanity-bound the window size: below the N64 framebuffer is useless, above 8K
     // is a typo -- either way SDL_CreateWindow would fail and the port would run
     // permanently headless, so reset to defaults instead.
@@ -243,6 +268,7 @@ ultramodern::renderer::GraphicsConfig load_and_apply_graphics() {
     const ReadResult r = read_graphics_file(path, cfg);
 
     ultramodern::renderer::set_graphics_config(cfg);
+    g_current_graphics = cfg;
     // Write the merged config back so the on-disk file is always complete and
     // editable (new keys appear with their defaults after an upgrade) -- but NEVER
     // overwrite a file that failed to parse: a hand-edit typo must stay recoverable,
@@ -254,17 +280,22 @@ ultramodern::renderer::GraphicsConfig load_and_apply_graphics() {
     return cfg;
 }
 
-void update_saved_window_mode(ultramodern::renderer::WindowMode wm) {
-    // Persist a runtime window-mode change by re-reading the on-disk file and
-    // updating ONLY wm_option -- a user hand-editing other keys while the game runs
-    // must not have those edits clobbered by an F11 press.
-    ultramodern::renderer::GraphicsConfig cfg = default_graphics_config();
-    const std::filesystem::path path = graphics_json_path();
-    if (read_graphics_file(path, cfg) == ReadResult::Unparseable) {
-        return; // don't destroy a recoverable (broken) file just to save a toggle
-    }
-    cfg.wm_option = wm;
+ultramodern::renderer::GraphicsConfig current_graphics() {
+    return g_current_graphics;
+}
+
+void apply_graphics(const ultramodern::renderer::GraphicsConfig& cfg) {
+    g_current_graphics = cfg;
+    ultramodern::renderer::set_graphics_config(cfg);
     save_graphics(cfg);
+}
+
+void update_saved_window_mode(ultramodern::renderer::WindowMode wm) {
+    // All runtime config values now have one main-thread snapshot. Do not re-run
+    // from_json here: its enhancement fields are read by the game/render threads.
+    // Mutating those arrays during an F11 press would introduce a data race.
+    g_current_graphics.wm_option = wm;
+    save_graphics(g_current_graphics);
 }
 
 void save_graphics(const ultramodern::renderer::GraphicsConfig& cfg) {
@@ -310,7 +341,12 @@ bool widescreen_fog_match() {
     if (const char* v = std::getenv("LAMBO_FOG_MATCH_1P")) {
         return v[0] == '1';
     }
-    return g_widescreen_fog_match;
+    return g_widescreen_fog_match.load();
+}
+
+void set_widescreen_fog_match(bool enabled) {
+    g_widescreen_fog_match.store(enabled);
+    save_graphics(g_current_graphics);
 }
 
 // LAMBO_SKY_MATCH_1P=1/0 overrides the JSON key for headless capture/testing.
@@ -318,7 +354,12 @@ bool widescreen_sky_match() {
     if (const char* v = std::getenv("LAMBO_SKY_MATCH_1P")) {
         return v[0] == '1';
     }
-    return g_widescreen_sky_match;
+    return g_widescreen_sky_match.load();
+}
+
+void set_widescreen_sky_match(bool enabled) {
+    g_widescreen_sky_match.store(enabled);
+    save_graphics(g_current_graphics);
 }
 
 // LAMBO_NO_LOD=1/0 overrides the JSON key for headless capture/testing.
@@ -326,7 +367,12 @@ bool no_lod() {
     if (const char* v = std::getenv("LAMBO_NO_LOD")) {
         return v[0] == '1';
     }
-    return g_no_lod;
+    return g_no_lod.load();
+}
+
+void set_no_lod(bool enabled) {
+    g_no_lod.store(enabled);
+    save_graphics(g_current_graphics);
 }
 
 // Per-circuit refinement of no_lod (see lambo_config.h). No env var: the JSON
@@ -336,7 +382,13 @@ bool no_lod() {
 // wholesale.
 bool no_lod_circuit(int circuit) {
     if (circuit < 0 || circuit >= (int)g_no_lod_circuit.size()) return no_lod();
-    return g_no_lod_circuit[(size_t)circuit];
+    return g_no_lod_circuit[(size_t)circuit].load();
+}
+
+void set_no_lod_circuit(int circuit, bool enabled) {
+    if (circuit < 0 || circuit >= (int)g_no_lod_circuit.size()) return;
+    g_no_lod_circuit[(size_t)circuit].store(enabled);
+    save_graphics(g_current_graphics);
 }
 
 // LAMBO_FOG_SCALE=<float> overrides both JSON keys for headless capture/testing.
@@ -345,7 +397,7 @@ double fog_scale(int circuit) {
     if (const char* v = std::getenv("LAMBO_FOG_SCALE")) {
         s = std::atof(v);
     } else {
-        s = g_fog_scale;
+        s = g_fog_scale.load();
         if (circuit >= 0 && circuit < (int)g_fog_scale_circuit.size()) {
             s *= g_fog_scale_circuit[(size_t)circuit];
         }
@@ -353,6 +405,17 @@ double fog_scale(int circuit) {
     if (s < 0.0) s = 0.0;
     if (s > 8.0) s = 8.0;
     return s;
+}
+
+double global_fog_scale() {
+    return g_fog_scale.load();
+}
+
+void set_global_fog_scale(double scale) {
+    if (scale < 0.0) scale = 0.0;
+    if (scale > 8.0) scale = 8.0;
+    g_fog_scale.store(scale);
+    save_graphics(g_current_graphics);
 }
 
 // LAMBO_DRAW_DISTANCE=<float> overrides both JSON keys for capture/testing.
@@ -363,7 +426,7 @@ double draw_distance(int circuit) {
     if (const char* v = std::getenv("LAMBO_DRAW_DISTANCE")) {
         s = std::atof(v);
     } else {
-        s = g_draw_distance;
+        s = g_draw_distance.load();
         if (circuit >= 0 && circuit < (int)g_draw_distance_circuit.size()) {
             s *= g_draw_distance_circuit[(size_t)circuit];
         }
@@ -372,6 +435,17 @@ double draw_distance(int circuit) {
     if (s < 0.1) s = 0.1;
     if (s > 100.0) s = 100.0;
     return s;
+}
+
+double global_draw_distance() {
+    return g_draw_distance.load();
+}
+
+void set_global_draw_distance(double scale) {
+    if (scale > 0.0 && scale < 0.1) scale = 0.1;
+    if (scale > 100.0) scale = 100.0;
+    g_draw_distance.store(scale <= 0.0 ? 0.0 : scale);
+    save_graphics(g_current_graphics);
 }
 
 } // namespace config

--- a/src/lambo_config.h
+++ b/src/lambo_config.h
@@ -34,12 +34,15 @@ ultramodern::renderer::GraphicsConfig default_graphics_config();
 // users always have a complete, editable file on disk. Returns the applied config.
 ultramodern::renderer::GraphicsConfig load_and_apply_graphics();
 
+// Snapshot/apply helpers for the in-app menu. apply_graphics() updates RT64 live
+// through ultramodern's config action queue and persists the same value.
+ultramodern::renderer::GraphicsConfig current_graphics();
+void apply_graphics(const ultramodern::renderer::GraphicsConfig& cfg);
+
 // Persist the given config (full overwrite of graphics.json).
 void save_graphics(const ultramodern::renderer::GraphicsConfig& cfg);
 
-// Persist a runtime window-mode change (F11) by re-reading the on-disk file and
-// updating only wm_option, so concurrent hand-edits to other keys survive. A file
-// that fails to parse is left untouched.
+// Persist a runtime window-mode change (F11/menu) in the main-thread snapshot.
 void update_saved_window_mode(ultramodern::renderer::WindowMode wm);
 
 // Requested window size for windowed mode (from graphics.json; defaults 1600x900,
@@ -61,16 +64,19 @@ std::string texture_dump_dir();
 // graphics.json key "widescreen_fog_match" (default true), overridable by
 // LAMBO_FOG_MATCH_1P=1/0. The rewrite still self-gates on player count >= 3.
 bool widescreen_fog_match();
+void set_widescreen_fog_match(bool enabled);
 
 // Draw the sky panorama in 3P/4P split screen like 1P/2P (issue #84).
 // graphics.json key "widescreen_sky_match" (default true), overridable by
 // LAMBO_SKY_MATCH_1P=1/0. Only flips a branch that 1P/2P already take.
 bool widescreen_sky_match();
+void set_widescreen_sky_match(bool enabled);
 
 // Remove the ROM's per-mode LOD reductions (issues #87/#91): emit each track
 // segment's scenery layer in 2P-4P races like 1P does. graphics.json key
 // "no_lod" (default true), overridable by LAMBO_NO_LOD=1/0.
 bool no_lod();
+void set_no_lod(bool enabled);
 
 // Per-circuit refinement of no_lod: the full-track walk (PVS synth) is what fixes
 // the cross-track distance pop-in (PR #122), but on the pro tracks it surfaces
@@ -82,6 +88,7 @@ bool no_lod();
 // graphics.json key "no_lod_circuit" (array of 6 bools, default [true, true, true,
 // false, false, false]).
 bool no_lod_circuit(int circuit);
+void set_no_lod_circuit(int circuit, bool enabled);
 
 // Fog density multiplier applied to every fog moveword in the frame DL: 1.0 =
 // authored fog, 0.0 = no fog, values in between thin the fog uniformly without
@@ -90,6 +97,8 @@ bool no_lod_circuit(int circuit);
 // multiplied with the global -- lets a hazy city track be cleared individually).
 // LAMBO_FOG_SCALE=<float> overrides the whole computation for capture/testing.
 double fog_scale(int circuit);
+double global_fog_scale();
+void set_global_fog_scale(double scale);
 
 // Draw-distance multiplier applied (while no_lod is on) to the authored per-circuit
 // segment-cull radii the scene builder tests visibility-list entries against.
@@ -101,6 +110,8 @@ double fog_scale(int circuit);
 // multipliers, default all 1.0, multiplied with the global).
 // LAMBO_DRAW_DISTANCE=<float> overrides the whole computation for capture/testing.
 double draw_distance(int circuit);
+double global_draw_distance();
+void set_global_draw_distance(double scale);
 
 } // namespace config
 } // namespace lambo

--- a/src/lambo_menu.cpp
+++ b/src/lambo_menu.cpp
@@ -1,0 +1,369 @@
+#include "lambo_menu.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <string>
+
+#include <SDL.h>
+
+#include "lambo_config.h"
+#include "lambo_log.h"
+
+#if defined(_WIN32)
+#include <SDL_syswm.h>
+
+namespace {
+
+SDL_Window* g_window = nullptr;
+HWND g_hwnd = nullptr;
+HMENU g_menu_bar = nullptr;
+HMENU g_game_menu = nullptr;
+HMENU g_resolution_menu = nullptr;
+HMENU g_supersampling_menu = nullptr;
+HMENU g_aspect_menu = nullptr;
+HMENU g_hud_menu = nullptr;
+HMENU g_rate_menu = nullptr;
+HMENU g_aa_menu = nullptr;
+HMENU g_hpfb_menu = nullptr;
+HMENU g_api_menu = nullptr;
+HMENU g_enhancements_menu = nullptr;
+HMENU g_pvs_menu = nullptr;
+HMENU g_draw_menu = nullptr;
+HMENU g_fog_menu = nullptr;
+
+enum Command : UINT {
+    CMD_FULLSCREEN = 1000,
+    CMD_QUIT,
+
+    CMD_RES_AUTO = 1100,
+    CMD_RES_ORIGINAL,
+    CMD_RES_ORIGINAL_2X,
+    CMD_SS_1X,
+    CMD_SS_2X,
+    CMD_SS_3X,
+    CMD_SS_4X,
+    CMD_ASPECT_ORIGINAL,
+    CMD_ASPECT_EXPAND,
+    CMD_HUD_ORIGINAL,
+    CMD_HUD_CLAMP_16X9,
+    CMD_HUD_FULL,
+    CMD_RATE_ORIGINAL,
+    CMD_RATE_DISPLAY,
+    CMD_RATE_30,
+    CMD_RATE_60,
+    CMD_RATE_90,
+    CMD_RATE_120,
+    CMD_RATE_144,
+    CMD_RATE_165,
+    CMD_RATE_240,
+    CMD_AA_NONE,
+    CMD_AA_2X,
+    CMD_AA_4X,
+    CMD_AA_8X,
+    CMD_HPFB_AUTO,
+    CMD_HPFB_ON,
+    CMD_HPFB_OFF,
+    CMD_API_AUTO,
+    CMD_API_D3D12,
+    CMD_API_VULKAN,
+
+    CMD_FOG_MATCH = 1200,
+    CMD_SKY_MATCH,
+    CMD_NO_LOD,
+    CMD_PVS_CIRCUIT_1,
+    CMD_PVS_CIRCUIT_2,
+    CMD_PVS_CIRCUIT_3,
+    CMD_PVS_CIRCUIT_4,
+    CMD_PVS_CIRCUIT_5,
+    CMD_PVS_CIRCUIT_6,
+    CMD_DRAW_1X,
+    CMD_DRAW_1_5X,
+    CMD_DRAW_2X,
+    CMD_DRAW_3X,
+    CMD_DRAW_UNLIMITED,
+    CMD_FOG_OFF,
+    CMD_FOG_50,
+    CMD_FOG_75,
+    CMD_FOG_100,
+    CMD_FOG_150,
+    CMD_FOG_200,
+};
+
+void append_item(HMENU menu, UINT id, const char* label) {
+    AppendMenuA(menu, MF_STRING, id, label);
+}
+
+HMENU append_submenu(HMENU parent, const char* label) {
+    HMENU child = CreatePopupMenu();
+    AppendMenuA(parent, MF_POPUP, reinterpret_cast<UINT_PTR>(child), label);
+    return child;
+}
+
+void check(HMENU menu, UINT id, bool checked) {
+    CheckMenuItem(menu, id, MF_BYCOMMAND | (checked ? MF_CHECKED : MF_UNCHECKED));
+}
+
+void radio(HMENU menu, UINT first, UINT last, UINT selected) {
+    CheckMenuRadioItem(menu, first, last, selected, MF_BYCOMMAND);
+}
+
+bool close(double a, double b) {
+    return std::abs(a - b) < 0.0001;
+}
+
+void refresh() {
+    using namespace ultramodern::renderer;
+    const GraphicsConfig cfg = lambo::config::current_graphics();
+    check(g_game_menu, CMD_FULLSCREEN, g_window != nullptr &&
+          (SDL_GetWindowFlags(g_window) & SDL_WINDOW_FULLSCREEN_DESKTOP) != 0);
+
+    radio(g_resolution_menu, CMD_RES_AUTO, CMD_RES_ORIGINAL_2X,
+          cfg.res_option == Resolution::Auto ? CMD_RES_AUTO :
+          cfg.res_option == Resolution::Original2x ? CMD_RES_ORIGINAL_2X : CMD_RES_ORIGINAL);
+    radio(g_supersampling_menu, CMD_SS_1X, CMD_SS_4X,
+          cfg.ds_option >= 1 && cfg.ds_option <= 4 ? CMD_SS_1X + cfg.ds_option - 1 : 0);
+    radio(g_aspect_menu, CMD_ASPECT_ORIGINAL, CMD_ASPECT_EXPAND,
+          cfg.ar_option == AspectRatio::Expand ? CMD_ASPECT_EXPAND :
+          cfg.ar_option == AspectRatio::Original ? CMD_ASPECT_ORIGINAL : 0);
+    radio(g_hud_menu, CMD_HUD_ORIGINAL, CMD_HUD_FULL,
+          cfg.hr_option == HUDRatioMode::Full ? CMD_HUD_FULL :
+          cfg.hr_option == HUDRatioMode::Clamp16x9 ? CMD_HUD_CLAMP_16X9 : CMD_HUD_ORIGINAL);
+
+    UINT rate = CMD_RATE_ORIGINAL;
+    if (cfg.rr_option == RefreshRate::Display) rate = CMD_RATE_DISPLAY;
+    else if (cfg.rr_option == RefreshRate::Manual) {
+        constexpr std::array<int, 7> values{30, 60, 90, 120, 144, 165, 240};
+        auto it = std::find(values.begin(), values.end(), cfg.rr_manual_value);
+        rate = it == values.end() ? 0 : CMD_RATE_30 + UINT(it - values.begin());
+    }
+    radio(g_rate_menu, CMD_RATE_ORIGINAL, CMD_RATE_240, rate);
+    radio(g_aa_menu, CMD_AA_NONE, CMD_AA_8X,
+          cfg.msaa_option == Antialiasing::MSAA8X ? CMD_AA_8X :
+          cfg.msaa_option == Antialiasing::MSAA4X ? CMD_AA_4X :
+          cfg.msaa_option == Antialiasing::MSAA2X ? CMD_AA_2X : CMD_AA_NONE);
+    radio(g_hpfb_menu, CMD_HPFB_AUTO, CMD_HPFB_OFF,
+          cfg.hpfb_option == HighPrecisionFramebuffer::On ? CMD_HPFB_ON :
+          cfg.hpfb_option == HighPrecisionFramebuffer::Off ? CMD_HPFB_OFF : CMD_HPFB_AUTO);
+    radio(g_api_menu, CMD_API_AUTO, CMD_API_VULKAN,
+          cfg.api_option == GraphicsApi::D3D12 ? CMD_API_D3D12 :
+          cfg.api_option == GraphicsApi::Vulkan ? CMD_API_VULKAN :
+          cfg.api_option == GraphicsApi::Auto ? CMD_API_AUTO : 0);
+
+    check(g_enhancements_menu, CMD_FOG_MATCH, lambo::config::widescreen_fog_match());
+    check(g_enhancements_menu, CMD_SKY_MATCH, lambo::config::widescreen_sky_match());
+    check(g_enhancements_menu, CMD_NO_LOD, lambo::config::no_lod());
+    for (int i = 0; i < 6; ++i) check(g_pvs_menu, CMD_PVS_CIRCUIT_1 + i, lambo::config::no_lod_circuit(i));
+
+    const double draw = lambo::config::global_draw_distance();
+    radio(g_draw_menu, CMD_DRAW_1X, CMD_DRAW_UNLIMITED,
+          draw <= 0.0 ? CMD_DRAW_UNLIMITED : close(draw, 3.0) ? CMD_DRAW_3X :
+          close(draw, 2.0) ? CMD_DRAW_2X : close(draw, 1.5) ? CMD_DRAW_1_5X :
+          close(draw, 1.0) ? CMD_DRAW_1X : 0);
+    const double fog = lambo::config::global_fog_scale();
+    radio(g_fog_menu, CMD_FOG_OFF, CMD_FOG_200,
+          close(fog, 2.0) ? CMD_FOG_200 : close(fog, 1.5) ? CMD_FOG_150 :
+          close(fog, 1.0) ? CMD_FOG_100 : close(fog, 0.75) ? CMD_FOG_75 :
+          close(fog, 0.5) ? CMD_FOG_50 : close(fog, 0.0) ? CMD_FOG_OFF : 0);
+    if (g_hwnd != nullptr) DrawMenuBar(g_hwnd);
+}
+
+void apply_graphics_command(UINT command) {
+    using namespace ultramodern::renderer;
+    GraphicsConfig cfg = lambo::config::current_graphics();
+    switch (command) {
+        case CMD_RES_AUTO: cfg.res_option = Resolution::Auto; break;
+        case CMD_RES_ORIGINAL: cfg.res_option = Resolution::Original; break;
+        case CMD_RES_ORIGINAL_2X: cfg.res_option = Resolution::Original2x; break;
+        case CMD_SS_1X: case CMD_SS_2X: case CMD_SS_3X: case CMD_SS_4X:
+            cfg.ds_option = int(command - CMD_SS_1X) + 1; break;
+        case CMD_ASPECT_ORIGINAL: cfg.ar_option = AspectRatio::Original; break;
+        case CMD_ASPECT_EXPAND: cfg.ar_option = AspectRatio::Expand; break;
+        case CMD_HUD_ORIGINAL: cfg.hr_option = HUDRatioMode::Original; break;
+        case CMD_HUD_CLAMP_16X9: cfg.hr_option = HUDRatioMode::Clamp16x9; break;
+        case CMD_HUD_FULL: cfg.hr_option = HUDRatioMode::Full; break;
+        case CMD_RATE_ORIGINAL: cfg.rr_option = RefreshRate::Original; break;
+        case CMD_RATE_DISPLAY: cfg.rr_option = RefreshRate::Display; break;
+        case CMD_RATE_30: case CMD_RATE_60: case CMD_RATE_90: case CMD_RATE_120:
+        case CMD_RATE_144: case CMD_RATE_165: case CMD_RATE_240: {
+            constexpr std::array<int, 7> values{30, 60, 90, 120, 144, 165, 240};
+            cfg.rr_option = RefreshRate::Manual;
+            cfg.rr_manual_value = values[command - CMD_RATE_30];
+            break;
+        }
+        case CMD_AA_NONE: cfg.msaa_option = Antialiasing::None; break;
+        case CMD_AA_2X: cfg.msaa_option = Antialiasing::MSAA2X; break;
+        case CMD_AA_4X: cfg.msaa_option = Antialiasing::MSAA4X; break;
+        case CMD_AA_8X: cfg.msaa_option = Antialiasing::MSAA8X; break;
+        case CMD_HPFB_AUTO: cfg.hpfb_option = HighPrecisionFramebuffer::Auto; break;
+        case CMD_HPFB_ON: cfg.hpfb_option = HighPrecisionFramebuffer::On; break;
+        case CMD_HPFB_OFF: cfg.hpfb_option = HighPrecisionFramebuffer::Off; break;
+        // RT64 selects its backend while constructing the renderer. Persist this
+        // immediately, but the menu label is explicit that activation is next launch.
+        case CMD_API_AUTO: cfg.api_option = GraphicsApi::Auto; break;
+        case CMD_API_D3D12: cfg.api_option = GraphicsApi::D3D12; break;
+        case CMD_API_VULKAN: cfg.api_option = GraphicsApi::Vulkan; break;
+        default: return;
+    }
+    lambo::config::apply_graphics(cfg);
+}
+
+void dispatch(UINT command) {
+    switch (command) {
+        case CMD_FULLSCREEN: lambo::menu::toggle_fullscreen(); break;
+        case CMD_QUIT: {
+            SDL_Event quit{};
+            quit.type = SDL_QUIT;
+            SDL_PushEvent(&quit);
+            break;
+        }
+        case CMD_FOG_MATCH: lambo::config::set_widescreen_fog_match(!lambo::config::widescreen_fog_match()); break;
+        case CMD_SKY_MATCH: lambo::config::set_widescreen_sky_match(!lambo::config::widescreen_sky_match()); break;
+        case CMD_NO_LOD: lambo::config::set_no_lod(!lambo::config::no_lod()); break;
+        case CMD_PVS_CIRCUIT_1: case CMD_PVS_CIRCUIT_2: case CMD_PVS_CIRCUIT_3:
+        case CMD_PVS_CIRCUIT_4: case CMD_PVS_CIRCUIT_5: case CMD_PVS_CIRCUIT_6: {
+            int circuit = int(command - CMD_PVS_CIRCUIT_1);
+            lambo::config::set_no_lod_circuit(circuit, !lambo::config::no_lod_circuit(circuit));
+            break;
+        }
+        case CMD_DRAW_1X: lambo::config::set_global_draw_distance(1.0); break;
+        case CMD_DRAW_1_5X: lambo::config::set_global_draw_distance(1.5); break;
+        case CMD_DRAW_2X: lambo::config::set_global_draw_distance(2.0); break;
+        case CMD_DRAW_3X: lambo::config::set_global_draw_distance(3.0); break;
+        case CMD_DRAW_UNLIMITED: lambo::config::set_global_draw_distance(0.0); break;
+        case CMD_FOG_OFF: lambo::config::set_global_fog_scale(0.0); break;
+        case CMD_FOG_50: lambo::config::set_global_fog_scale(0.5); break;
+        case CMD_FOG_75: lambo::config::set_global_fog_scale(0.75); break;
+        case CMD_FOG_100: lambo::config::set_global_fog_scale(1.0); break;
+        case CMD_FOG_150: lambo::config::set_global_fog_scale(1.5); break;
+        case CMD_FOG_200: lambo::config::set_global_fog_scale(2.0); break;
+        default: apply_graphics_command(command); break;
+    }
+    refresh();
+}
+
+} // anonymous namespace
+
+namespace lambo::menu {
+
+void attach(SDL_Window* window) {
+    g_window = window;
+    SDL_SysWMinfo info{};
+    SDL_VERSION(&info.version);
+    if (SDL_GetWindowWMInfo(window, &info) != SDL_TRUE) return;
+    g_hwnd = info.info.win.window;
+
+    g_menu_bar = CreateMenu();
+    HMENU game = g_game_menu = append_submenu(g_menu_bar, "&Game");
+    append_item(game, CMD_FULLSCREEN, "&Fullscreen\tF11");
+    AppendMenuA(game, MF_SEPARATOR, 0, nullptr);
+    append_item(game, CMD_QUIT, "E&xit");
+
+    HMENU graphics = append_submenu(g_menu_bar, "&Graphics");
+    HMENU resolution = g_resolution_menu = append_submenu(graphics, "Internal resolution");
+    append_item(resolution, CMD_RES_AUTO, "Automatic (window scale)");
+    append_item(resolution, CMD_RES_ORIGINAL, "Original");
+    append_item(resolution, CMD_RES_ORIGINAL_2X, "Original 2x");
+    HMENU supersampling = g_supersampling_menu = append_submenu(graphics, "Supersampling");
+    append_item(supersampling, CMD_SS_1X, "1x"); append_item(supersampling, CMD_SS_2X, "2x");
+    append_item(supersampling, CMD_SS_3X, "3x"); append_item(supersampling, CMD_SS_4X, "4x");
+    HMENU aspect = g_aspect_menu = append_submenu(graphics, "Aspect ratio");
+    append_item(aspect, CMD_ASPECT_ORIGINAL, "Original (4:3)");
+    append_item(aspect, CMD_ASPECT_EXPAND, "Expand (widescreen)");
+    HMENU hud = g_hud_menu = append_submenu(graphics, "HUD placement");
+    append_item(hud, CMD_HUD_ORIGINAL, "Original (4:3)");
+    append_item(hud, CMD_HUD_CLAMP_16X9, "Clamp to 16:9");
+    append_item(hud, CMD_HUD_FULL, "Full width");
+    HMENU rate = g_rate_menu = append_submenu(graphics, "Frame rate");
+    append_item(rate, CMD_RATE_ORIGINAL, "Original"); append_item(rate, CMD_RATE_DISPLAY, "Display refresh rate");
+    AppendMenuA(rate, MF_SEPARATOR, 0, nullptr);
+    append_item(rate, CMD_RATE_30, "30 FPS"); append_item(rate, CMD_RATE_60, "60 FPS");
+    append_item(rate, CMD_RATE_90, "90 FPS"); append_item(rate, CMD_RATE_120, "120 FPS");
+    append_item(rate, CMD_RATE_144, "144 FPS"); append_item(rate, CMD_RATE_165, "165 FPS");
+    append_item(rate, CMD_RATE_240, "240 FPS");
+    HMENU aa = g_aa_menu = append_submenu(graphics, "Anti-aliasing");
+    append_item(aa, CMD_AA_NONE, "Off"); append_item(aa, CMD_AA_2X, "MSAA 2x");
+    append_item(aa, CMD_AA_4X, "MSAA 4x"); append_item(aa, CMD_AA_8X, "MSAA 8x");
+    HMENU hpfb = g_hpfb_menu = append_submenu(graphics, "High-precision framebuffer");
+    append_item(hpfb, CMD_HPFB_AUTO, "Automatic"); append_item(hpfb, CMD_HPFB_ON, "On");
+    append_item(hpfb, CMD_HPFB_OFF, "Off");
+    HMENU api = g_api_menu = append_submenu(graphics, "Graphics API (restart required)");
+    append_item(api, CMD_API_AUTO, "Automatic"); append_item(api, CMD_API_D3D12, "Direct3D 12");
+    append_item(api, CMD_API_VULKAN, "Vulkan");
+
+    HMENU enhancements = g_enhancements_menu = append_submenu(g_menu_bar, "&Enhancements");
+    append_item(enhancements, CMD_FOG_MATCH, "3P/4P widescreen fog");
+    append_item(enhancements, CMD_SKY_MATCH, "3P/4P widescreen sky");
+    append_item(enhancements, CMD_NO_LOD, "Remove N64 LOD reductions");
+    HMENU pvs = g_pvs_menu = append_submenu(enhancements, "Full-track visibility by circuit");
+    for (int i = 0; i < 6; ++i) {
+        std::string label = "Circuit " + std::to_string(i + 1);
+        append_item(pvs, CMD_PVS_CIRCUIT_1 + i, label.c_str());
+    }
+    HMENU draw = g_draw_menu = append_submenu(enhancements, "Draw distance");
+    append_item(draw, CMD_DRAW_1X, "Original (1x)"); append_item(draw, CMD_DRAW_1_5X, "1.5x");
+    append_item(draw, CMD_DRAW_2X, "2x"); append_item(draw, CMD_DRAW_3X, "3x");
+    append_item(draw, CMD_DRAW_UNLIMITED, "Unlimited");
+    HMENU fog = g_fog_menu = append_submenu(enhancements, "Fog density");
+    append_item(fog, CMD_FOG_OFF, "Off"); append_item(fog, CMD_FOG_50, "50%");
+    append_item(fog, CMD_FOG_75, "75%"); append_item(fog, CMD_FOG_100, "Original (100%)");
+    append_item(fog, CMD_FOG_150, "150%"); append_item(fog, CMD_FOG_200, "200%");
+
+    if ((SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0) {
+        SetMenu(g_hwnd, g_menu_bar);
+    }
+    SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE);
+    refresh();
+}
+
+bool handle_event(const SDL_Event& event) {
+    if (event.type != SDL_SYSWMEVENT || event.syswm.msg == nullptr) return false;
+    const SDL_SysWMmsg& msg = *event.syswm.msg;
+    if (msg.subsystem != SDL_SYSWM_WINDOWS || msg.msg.win.msg != WM_COMMAND) return false;
+    dispatch(LOWORD(msg.msg.win.wParam));
+    return true;
+}
+
+void toggle_fullscreen() {
+    if (g_window == nullptr) return;
+    const bool fullscreen = (SDL_GetWindowFlags(g_window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0;
+    if (SDL_SetWindowFullscreen(g_window, fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0) != 0) {
+        LAMBO_LOG("config", "fullscreen toggle FAILED: %s\n", SDL_GetError());
+        return;
+    }
+    SetMenu(g_hwnd, fullscreen ? nullptr : g_menu_bar);
+    auto cfg = lambo::config::current_graphics();
+    cfg.wm_option = fullscreen ? ultramodern::renderer::WindowMode::Fullscreen
+                               : ultramodern::renderer::WindowMode::Windowed;
+    // Window mode is owned by SDL and deliberately not sent through RT64.
+    lambo::config::update_saved_window_mode(cfg.wm_option);
+    LAMBO_LOG("config", "fullscreen %s (menu / F11 / Alt+Enter)\n", fullscreen ? "ON" : "OFF");
+    refresh();
+}
+
+} // namespace lambo::menu
+
+#else
+
+namespace {
+SDL_Window* g_window = nullptr;
+}
+
+namespace lambo::menu {
+void attach(SDL_Window* window) { g_window = window; }
+bool handle_event(const SDL_Event&) { return false; }
+void toggle_fullscreen() {
+    if (g_window == nullptr) return;
+    const bool fullscreen = (SDL_GetWindowFlags(g_window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0;
+    if (SDL_SetWindowFullscreen(g_window, fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0) != 0) {
+        LAMBO_LOG("config", "fullscreen toggle FAILED: %s\n", SDL_GetError());
+        return;
+    }
+    lambo::config::update_saved_window_mode(
+        fullscreen ? ultramodern::renderer::WindowMode::Fullscreen
+                   : ultramodern::renderer::WindowMode::Windowed);
+    LAMBO_LOG("config", "fullscreen %s (F11 / Alt+Enter)\n", fullscreen ? "ON" : "OFF");
+}
+} // namespace lambo::menu
+
+#endif

--- a/src/lambo_menu.h
+++ b/src/lambo_menu.h
@@ -1,0 +1,18 @@
+#ifndef LAMBO_MENU_H
+#define LAMBO_MENU_H
+
+union SDL_Event;
+struct SDL_Window;
+
+namespace lambo::menu {
+
+// Attach the lightweight native application menu where the platform supports it
+// (currently Win32). Other platforms deliberately remain no-op until the port has
+// a renderer-integrated UI layer.
+void attach(SDL_Window* window);
+bool handle_event(const SDL_Event& event);
+void toggle_fullscreen();
+
+} // namespace lambo::menu
+
+#endif

--- a/src/lambo_no_lod.cpp
+++ b/src/lambo_no_lod.cpp
@@ -36,9 +36,6 @@ extern "C" uint32_t lambo_no_lod_scenery_guard(uint8_t* rdram, uint32_t at) {
 // it ran would restore the rewritten values. The forward-cone/half-plane tests and
 // the per-frame visibility walk still decide what is drawn.
 extern "C" void lambo_no_lod_draw_distance(uint8_t* rdram) {
-    if (!lambo::config::no_lod()) {
-        return;
-    }
     // ROM copy of the float[6][5] at 0x80088FD0 ([circuit][player-count column]),
     // extracted from the .z64 at 0x89BD0 (= vram - 0x80000000 + 0xC00).
     // Basics: index 0-2 (1P radii 55000/50000/40000), pros 3-5 (45000/35000/35000).
@@ -55,8 +52,12 @@ extern "C" void lambo_no_lod_draw_distance(uint8_t* rdram) {
     };
     constexpr uint32_t kTableAddr = 0x80088FD0u;
     constexpr float kUnlimited = 1e9f;  // beyond any on-track distance
+    const bool enabled = lambo::config::no_lod();
     for (int c = 0; c < 6; c++) {
-        const double scale = lambo::config::draw_distance(c);
+        // This hook runs every frame, so switching the enhancement off must also
+        // put the ROM-authored radii back. An early return would leave the most
+        // recently expanded table live until the next track load.
+        const double scale = enabled ? lambo::config::draw_distance(c) : 1.0;
         for (int p = 0; p < 5; p++) {
             float r = scale <= 0.0 ? kUnlimited : (float)(kAuthored[c][p] * scale);
             if (r > kUnlimited) r = kUnlimited;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,6 +41,7 @@
 #include "lambo_crash.h"   // issue #13 / A14
 #include "lambo_gpu_advisory.h"  // issue #109: outdated-driver popup handoff
 #include "lambo_log.h"   
+#include "lambo_menu.h"
 // ultramodern's native VI API (events.cpp), used by the promote_vi_context RT64 bridge.
 extern "C" void osViSwapBuffer(uint8_t* rdram, int32_t frameBufPtr);
 extern "C" void osViSetMode(uint8_t* rdram, int32_t mode_);
@@ -321,17 +322,7 @@ static SDL_Window* g_sdl_window = nullptr;
 //    an upstream ultramodern flaw). Nothing renderer-side consumes wm_option, so the
 //    live config staying at its startup value is harmless.
 static void toggle_fullscreen() {
-    if (g_sdl_window == nullptr) return;
-    bool to_fullscreen = (SDL_GetWindowFlags(g_sdl_window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0;
-    if (SDL_SetWindowFullscreen(g_sdl_window,
-                                to_fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0) != 0) {
-        LAMBO_LOG("config", "fullscreen toggle FAILED: %s\n", SDL_GetError());
-        return; // window unchanged -> persist nothing, config and reality stay agreed
-    }
-    lambo::config::update_saved_window_mode(
-        to_fullscreen ? ultramodern::renderer::WindowMode::Fullscreen
-                      : ultramodern::renderer::WindowMode::Windowed);
-    LAMBO_LOG("config", "fullscreen %s (F11 / Alt+Enter)\n", to_fullscreen ? "ON" : "OFF");
+    lambo::menu::toggle_fullscreen();
 }
 
 static ultramodern::renderer::WindowHandle create_window_stub(void* /*gfx_data*/) {
@@ -377,6 +368,7 @@ static ultramodern::renderer::WindowHandle create_window_stub(void* /*gfx_data*/
             return ultramodern::renderer::WindowHandle{};
         }
         g_sdl_window = window;
+        lambo::menu::attach(window);
 #if defined(__linux__)
         LAMBO_LOG("rt64", "SDL window created (%dx%d, Vulkan surface)\n",
                      win_size.width, win_size.height);
@@ -410,6 +402,9 @@ static void update_gfx_stub(void* /*gfx_data*/) {
     if (lambo_rt64::enabled()) {
         SDL_Event event;
         while (SDL_PollEvent(&event)) {
+            if (lambo::menu::handle_event(event)) {
+                continue;
+            }
             // Play mode has no VI cap (see quit_after_vis), so closing the window is the
             // quit path: reuse the summary+_Exit teardown (game threads are torn down by
             // process exit; see boot_summary_and_exit's rationale).

--- a/tests/test_live_config.cpp
+++ b/tests/test_live_config.cpp
@@ -1,0 +1,89 @@
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+#include "json/json.hpp"
+#include "lambo_config.h"
+
+namespace {
+
+int failures = 0;
+
+void expect(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+nlohmann::json read_json(const std::filesystem::path& path) {
+    std::ifstream in(path);
+    nlohmann::json result;
+    in >> result;
+    return result;
+}
+
+} // namespace
+
+// lambo_config.cpp normally calls into the runtime. This focused test only needs
+// to verify the port-owned snapshot and persistent representation.
+namespace ultramodern::renderer {
+void set_graphics_config(const GraphicsConfig&) {}
+}
+
+int main() {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto dir = std::filesystem::temp_directory_path() /
+                     ("lambo-config-test-" + std::to_string(unique));
+    const auto path = dir / "graphics.json";
+#if defined(_WIN32)
+    _putenv_s("LAMBO_GRAPHICS_CONFIG", path.string().c_str());
+#else
+    setenv("LAMBO_GRAPHICS_CONFIG", path.string().c_str(), 1);
+#endif
+
+    auto cfg = lambo::config::load_and_apply_graphics();
+    expect(std::filesystem::exists(path), "first load creates graphics.json");
+    expect(cfg.ar_option == ultramodern::renderer::AspectRatio::Expand,
+           "enhancement-oriented aspect default is preserved");
+
+    cfg.msaa_option = ultramodern::renderer::Antialiasing::MSAA4X;
+    cfg.rr_option = ultramodern::renderer::RefreshRate::Manual;
+    cfg.rr_manual_value = 120;
+    lambo::config::apply_graphics(cfg);
+    expect(lambo::config::current_graphics().msaa_option ==
+               ultramodern::renderer::Antialiasing::MSAA4X,
+           "graphics menu changes update the live snapshot");
+
+    lambo::config::set_widescreen_fog_match(false);
+    lambo::config::set_widescreen_sky_match(false);
+    lambo::config::set_no_lod(false);
+    lambo::config::set_no_lod_circuit(4, true);
+    lambo::config::set_global_fog_scale(1.5);
+    lambo::config::set_global_draw_distance(2.0);
+    expect(!lambo::config::widescreen_fog_match(), "fog toggle updates live");
+    expect(!lambo::config::widescreen_sky_match(), "sky toggle updates live");
+    expect(!lambo::config::no_lod(), "LOD toggle updates live");
+    expect(lambo::config::no_lod_circuit(4), "per-circuit visibility updates live");
+    expect(lambo::config::global_fog_scale() == 1.5, "fog scale updates live");
+    expect(lambo::config::global_draw_distance() == 2.0, "draw distance updates live");
+
+    lambo::config::update_saved_window_mode(ultramodern::renderer::WindowMode::Fullscreen);
+    const auto json = read_json(path);
+    expect(json.at("wm_option") == "Fullscreen", "fullscreen selection persists");
+    expect(json.at("msaa_option") == "MSAA4X", "graphics selection persists");
+    expect(json.at("rr_option") == "Manual" && json.at("rr_manual_value") == 120,
+           "manual frame rate persists");
+    expect(json.at("widescreen_fog_match") == false, "fog toggle persists");
+    expect(json.at("widescreen_sky_match") == false, "sky toggle persists");
+    expect(json.at("no_lod") == false, "LOD toggle persists");
+    expect(json.at("no_lod_circuit").at(4) == true, "per-circuit visibility persists");
+    expect(json.at("fog_scale") == 1.5, "fog scale persists");
+    expect(json.at("draw_distance") == 2.0, "draw distance persists");
+
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- add a native Windows menu bar with **Game**, **Graphics**, and **Enhancements** menus
- apply live-safe graphics and enhancement changes immediately and persist them to `graphics.json`
- expose fullscreen, resolution, supersampling, aspect ratio, HUD placement, frame rate, MSAA, framebuffer precision, graphics API, widescreen fog/sky, LOD, per-circuit visibility, draw distance, and fog density
- keep graphics API selection explicitly restart-required because RT64 chooses its backend during renderer construction
- make runtime enhancement values atomic and keep a main-thread graphics snapshot for menu actions
- restore the ROM-authored draw-distance table immediately when live LOD removal is switched off
- document the in-app configuration boundary and add focused live-update/persistence coverage

## Why

Lamborghini previously exposed its settings through `graphics.json` and a small set of hotkeys only. Other N64 recomp ports generally carry a full RmlUi configuration stack, while menu-bar-driven ports dispatch actions directly. Pulling an entire UI framework into this port would be disproportionate for the first settings surface, so this adds a lightweight native Win32 menu through the existing SDL window and event pump.

Common options now behave like normal application settings: selecting one updates the running renderer or enhancement immediately and saves it automatically.

## Validation

- focused `test_live_config.cpp` executable passes
- syntax checks pass for `lambo_config.cpp`, `lambo_menu.cpp`, `lambo_no_lod.cpp`, and `main.cpp`
- Windows-specific menu code passes a Win32/SDL syntax check
- existing Python suite passes: 7 tests
- `git diff --check` passes

A full ROM boot smoke was not available in the working environment because the legally supplied ROM and local CMake/Ninja packages were absent.