### PR TITLE
Add in-game configuration overlay, Project64-style controls mapper, and auto-boot

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -100,6 +100,7 @@ jobs:
           set -euo pipefail
           mkdir -p dist
           cp build/lamborghini_modern dist/
+          cp -r build/assets dist/
           # Crash-handler symbol table: probed next to the exe at runtime so
           # field crash dumps show function names, not raw N64 PCs (issue #80).
           cp lamborghini.syms.toml dist/
@@ -210,11 +211,13 @@ jobs:
             'build\SDL2.dll',
             'build\dxcompiler.dll',
             'build\dxil.dll',
+            'build\freetype.dll',
+            'build\assets',
             'lamborghini.syms.toml'
           )
           $missing = $payload | Where-Object { -not (Test-Path $_) }
           if ($missing) { throw "Packaging aborted -- required files missing: $($missing -join ', ')" }
-          Copy-Item $payload dist\
+          Copy-Item -Recurse $payload dist\
           Compress-Archive -Path dist\* -DestinationPath lamborghini-recomp-windows-x64.zip
 
       - name: Upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ dma_validation/
 # --- Logs / scratch --------------------------------------------------------
 *.log
 *.stackdump
+scratch/
 # gdb batch backtrace/logging dumps from native port debugging
 gdb_bt*.txt
 # framebuffer / display-list render captures from the port
@@ -44,6 +45,7 @@ gdb_bt*.txt
 __pycache__/
 
 # --- Local AI Artefacts ----------------------------------------------------
+.codex/
 .claude/settings.local.json
 .claude/worktrees/
 CLAUDE.local.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "lib/rt64"]
 	path = lib/rt64
 	url = https://github.com/rt64/rt64.git
+
+[submodule "lib/RmlUi"]
+	path = lib/RmlUi
+	url = https://github.com/mikke89/RmlUi.git

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -115,6 +115,8 @@ Run from the repository root so the ROM path resolves:
 ./build/lamborghini_modern
 ```
 
+The game auto-boots directly into gameplay. Press the **Menu / Back / Guide** button on your controller, or press <kbd>Esc</kbd> / <kbd>F1</kbd> on your keyboard to open the in-game configuration overlay and controls mapper. To launch into the standalone launcher shell instead, set `LAMBO_LAUNCHER=1` in your environment or set `"show_launcher": true` in `graphics.json`.
+
 ## Notes
 
 - `lib/N64ModernRuntime`'s root CMake deliberately omits RT64; it is pulled in only by

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required(VERSION 3.20)
 # working tree on Windows; DirectX-Headers v1.614.1 is fetched at configure time.
 # RecompiledFuncs/ is gitignored — it is regenerated from your ROM (step 1).
 
-project(lamborghini_modern LANGUAGES C CXX)
+project(lamborghini_modern VERSION 0.5.0 LANGUAGES C CXX)
 
 include(CTest)
 
@@ -41,6 +41,8 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/lib/rt64/CMakeLists.txt)
 endif()
 
 if(BUILD_TESTING)
+    find_program(LAMBO_PYTHON_EXECUTABLE NAMES python python3)
+
     add_executable(lambo_config_tests
         tests/test_live_config.cpp
         src/lambo_config.cpp
@@ -61,7 +63,121 @@ if(BUILD_TESTING)
         ${N64MR}/N64Recomp/include
     )
     add_test(NAME lambo_controller_pak_identity COMMAND lambo_controller_pak_tests)
+
+    add_executable(lambo_startup_tests
+        tests/test_startup.cpp
+        src/lambo_startup.cpp
+    )
+    target_include_directories(lambo_startup_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    add_test(NAME lambo_startup_state_machine COMMAND lambo_startup_tests)
+
+    add_executable(lambo_input_gate_tests
+        tests/test_input_gate.cpp
+        src/lambo_input_gate.cpp
+    )
+    target_include_directories(lambo_input_gate_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    add_test(NAME lambo_input_capture_gate COMMAND lambo_input_gate_tests)
+
+    add_executable(lambo_controls_tests
+        tests/test_controls.cpp
+        src/controls/lambo_controls.cpp
+        src/lambo_config.cpp
+        src/lambo_log.cpp
+    )
+    target_include_directories(lambo_controls_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${N64MR}/ultramodern/include
+        ${N64MR}/thirdparty
+    )
+    add_test(NAME lambo_controls_domain_and_persistence COMMAND lambo_controls_tests)
+
+    add_executable(lambo_controls_capture_tests
+        tests/test_controls_capture.cpp
+        src/controls/lambo_controls.cpp
+        src/lambo_config.cpp
+        src/lambo_log.cpp
+    )
+    target_include_directories(lambo_controls_capture_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${N64MR}/ultramodern/include
+        ${N64MR}/thirdparty
+    )
+    add_test(NAME lambo_controls_capture_state_machine COMMAND lambo_controls_capture_tests)
+
+    add_executable(lambo_ui_controls_tests
+        tests/test_ui_controls.cpp
+        src/ui/lambo_ui_controls.cpp
+        src/controls/lambo_controls.cpp
+        src/lambo_config.cpp
+        src/lambo_log.cpp
+    )
+    target_include_directories(lambo_ui_controls_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${N64MR}/ultramodern/include
+        ${N64MR}/thirdparty
+    )
+    add_test(NAME lambo_ui_controls_actions COMMAND lambo_ui_controls_tests)
+
+    add_executable(lambo_ui_input_tests
+        tests/test_ui_input.cpp
+        src/ui/lambo_ui_input.cpp
+    )
+    target_include_directories(lambo_ui_input_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    add_test(NAME lambo_ui_controller_navigation COMMAND lambo_ui_input_tests)
+
+    add_executable(lambo_ui_settings_tests
+        tests/test_ui_settings.cpp
+        src/ui/lambo_ui_settings.cpp
+        src/lambo_config.cpp
+        src/lambo_log.cpp
+    )
+    target_include_directories(lambo_ui_settings_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${N64MR}/ultramodern/include
+        ${N64MR}/thirdparty
+    )
+    add_test(NAME lambo_ui_settings_bindings COMMAND lambo_ui_settings_tests)
+
+    if(LAMBO_PYTHON_EXECUTABLE)
+        add_test(NAME lambo_ui_asset_references
+            COMMAND ${LAMBO_PYTHON_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ui_assets.py
+                ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+    else()
+        message(WARNING "Python not found; lambo_ui_asset_references will not be registered")
+    endif()
 endif()
+
+# RmlUi is the only UI toolkit used by the launcher. Keep the dependency pinned
+# as a submodule and build only the core/debugger libraries; the SDL backend is
+# compiled into the game target below so it shares the game's SDL instance.
+set(BUILD_SHARED_LIBS OFF)
+set(RMLUI_TESTS OFF CACHE BOOL "" FORCE)
+set(RMLUI_SAMPLES OFF CACHE BOOL "" FORCE)
+set(RMLUI_SVG_PLUGIN OFF CACHE BOOL "" FORCE)
+if(WIN32)
+    # Reuse RT64's pinned FreeType build for RmlUi text rendering. The Windows
+    # SDK bundle does not necessarily provide a CMake package of its own.
+    set(LAMBO_FREETYPE_ROOT
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/rt64/src/contrib/mupen64plus-win32-deps/freetype-2.13.0)
+    set(FREETYPE_INCLUDE_DIR_ft2build ${LAMBO_FREETYPE_ROOT}/include CACHE PATH "" FORCE)
+    set(FREETYPE_INCLUDE_DIR_freetype2 ${LAMBO_FREETYPE_ROOT}/include CACHE PATH "" FORCE)
+    set(FREETYPE_LIBRARY ${LAMBO_FREETYPE_ROOT}/lib/x64/freetype.lib CACHE FILEPATH "" FORCE)
+    set(FREETYPE_LIBRARY_RELEASE ${LAMBO_FREETYPE_ROOT}/lib/x64/freetype.lib CACHE FILEPATH "" FORCE)
+endif()
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/lib/RmlUi/CMakeLists.txt)
+    message(FATAL_ERROR "lib/RmlUi submodule is missing. Initialise it first:\n"
+        "  git submodule update --init --recursive")
+endif()
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lib/RmlUi ${CMAKE_BINARY_DIR}/RmlUi)
+
 set(RT64_STATIC TRUE)
 if(WIN32)
     # Windows (#68 native build): RT64 uses its D3D12 backend + a plain Win32 window
@@ -120,6 +236,29 @@ if(NOT WIN32)
     find_package(SDL2 REQUIRED)
 endif()
 
+if(BUILD_TESTING)
+    add_executable(lambo_controls_sdl_tests
+        tests/test_controls_sdl.cpp
+        src/controls/lambo_controls.cpp
+        src/controls/lambo_controls_sdl.cpp
+        src/lambo_config.cpp
+        src/lambo_log.cpp
+    )
+    target_include_directories(lambo_controls_sdl_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${N64MR}/ultramodern/include
+        ${N64MR}/thirdparty
+        ${SDL2_INCLUDE_DIRS}
+    )
+    if(WIN32)
+        target_compile_definitions(lambo_controls_sdl_tests PRIVATE SDL_MAIN_HANDLED)
+        target_link_libraries(lambo_controls_sdl_tests PRIVATE SDL2)
+    else()
+        target_link_libraries(lambo_controls_sdl_tests PRIVATE ${SDL2_LIBRARIES})
+    endif()
+    add_test(NAME lambo_controls_sdl_registry COMMAND lambo_controls_sdl_tests)
+endif()
+
 # ultramodern + librecomp, which cascades N64Recomp / LiveRecomp / miniz.
 # The runtime root CMake (lib/N64ModernRuntime/CMakeLists.txt) deliberately
 # omits RT64 — it is pulled in only by a game's own CMake.
@@ -166,6 +305,16 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/lambo_audio.cpp    # SDL2 push-audio sink for the AI buffer (audio epic #53, PR 1 of 3)
         src/lambo_config.cpp   # persistent graphics.json -> ultramodern GraphicsConfig (enhancements #1/#2)
         src/lambo_menu.cpp     # lightweight native Win32 menu bar; live config actions + persistence
+        src/lambo_startup.cpp  # runtime-ready -> Play startup state machine (issue #126)
+        src/lambo_input_gate.cpp # controller capture/neutral-release barrier (issue #126)
+        src/controls/lambo_controls.cpp
+        src/controls/lambo_controls_sdl.cpp
+        src/ui/lambo_ui.cpp
+        src/ui/lambo_ui_input.cpp
+        src/ui/lambo_ui_controls.cpp
+        src/ui/lambo_ui_render_interface.cpp
+        src/ui/lambo_ui_settings.cpp
+        lib/RmlUi/Backends/RmlUi_Platform_SDL.cpp
         src/lambo_crash.cpp    # native crash backtrace (issue #13 / A14): Win32 EXCEPTION_POINTERS +
                                # POSIX sigaction handler printing KSEG0/RDRAM offset + a 32-entry
                                # function-lookup trace ring. No deps beyond libc + DbgHelp (Win) /
@@ -187,6 +336,19 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
     endif()
 
     add_executable(lamborghini_modern ${LAMBO_SOURCES})
+    target_compile_definitions(lamborghini_modern PRIVATE
+        HLSL_CPU
+        LAMBO_VERSION="${PROJECT_VERSION}"
+        LAMBO_VERSION_MAJOR=${PROJECT_VERSION_MAJOR}
+        LAMBO_VERSION_MINOR=${PROJECT_VERSION_MINOR}
+        LAMBO_VERSION_PATCH=${PROJECT_VERSION_PATCH}
+    )
+    if(NOT WIN32 AND NOT APPLE)
+        target_compile_definitions(lamborghini_modern PRIVATE
+            PLUME_SDL_VULKAN_ENABLED
+            RT64_SDL_WINDOW_VULKAN
+        )
+    endif()
     target_compile_options(lamborghini_modern PRIVATE
         -fno-strict-aliasing
         -fms-extensions
@@ -196,10 +358,14 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         target_compile_options(lamborghini_modern PRIVATE -march=nehalem)
     endif()
     target_include_directories(lamborghini_modern PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${N64MR}/ultramodern/include
         ${N64MR}/librecomp/include
         ${N64MR}/N64Recomp/include
         ${CMAKE_CURRENT_SOURCE_DIR}/RecompiledFuncs
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/RmlUi/Include
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/RmlUi/Backends
+        ${N64MR}/thirdparty/concurrentqueue
     )
     target_link_libraries(lamborghini_modern PRIVATE
         librecomp
@@ -211,6 +377,39 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
 
     # RT64 renderer (#58: default presenter; see the RT64 block above).
     target_sources(lamborghini_modern PRIVATE src/rt64_renderer.cpp)
+    # rt64's build_pixel_shader/build_vertex_shader read ${DXC} and the DXC_*_OPTS
+    # variables from the CALLER's scope (CMake evaluates unreferenced variables at call
+    # time). Those variables are set inside rt64/CMakeLists.txt's own project() scope, so
+    # invoking it from THIS file finds them unset and the generated build command is
+    # missing the dxc.exe path AND the compiler args (-T ps_6_3, -spirv, ...). Pin the
+    # full set of variables here so the shader build commands resolve end-to-end.
+    set(LAMBO_DXC_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/lib/rt64/src/contrib/dxc")
+    if(WIN32)
+        set(DXC "${LAMBO_DXC_ROOT}/bin/x64/dxc.exe")
+    elseif(APPLE)
+        find_library(LAMBO_ZLIB_LIBRARY NAMES z)
+        get_filename_component(LAMBO_ZLIB_PATH ${LAMBO_ZLIB_LIBRARY} DIRECTORY)
+        if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+            set(DXC "DYLD_LIBRARY_PATH=${LAMBO_DXC_ROOT}/lib/x64:${LAMBO_ZLIB_PATH}"
+                "${LAMBO_DXC_ROOT}/bin/x64/dxc-macos")
+        else()
+            set(DXC "DYLD_LIBRARY_PATH=${LAMBO_DXC_ROOT}/lib/arm64:${LAMBO_ZLIB_PATH}"
+                "${LAMBO_DXC_ROOT}/bin/arm64/dxc-macos")
+        endif()
+    elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+        set(DXC "LD_LIBRARY_PATH=${LAMBO_DXC_ROOT}/lib/x64"
+            "${LAMBO_DXC_ROOT}/bin/x64/dxc-linux")
+    else()
+        set(DXC "LD_LIBRARY_PATH=${LAMBO_DXC_ROOT}/lib/arm64"
+            "${LAMBO_DXC_ROOT}/bin/arm64/dxc-linux")
+    endif()
+    set(DXC_COMMON_OPTS "-I${CMAKE_CURRENT_SOURCE_DIR}/lib/rt64/src")
+    set(DXC_DXIL_OPTS "-Wno-ignored-attributes")
+    set(DXC_SPV_OPTS "-spirv" "-fspv-target-env=vulkan1.0" "-fvk-use-dx-layout")
+    set(DXC_PS_OPTS "${DXC_COMMON_OPTS}" "-E" "PSMain" "-T ps_6_3")
+    set(DXC_VS_OPTS "${DXC_COMMON_OPTS}" "-E" "VSMain" "-T vs_6_3" "-fvk-invert-y")
+    build_vertex_shader(lamborghini_modern "shaders/InterfaceVS.hlsl" "shaders/InterfaceVS.hlsl")
+    build_pixel_shader(lamborghini_modern "shaders/InterfacePS.hlsl" "shaders/InterfacePS.hlsl")
     # rt64's include_directories() are directory-scoped and do not propagate;
     # mirror Zelda64Recomp's include list for the game target.
     set(RT64_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/rt64)
@@ -225,8 +424,26 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         ${RT64_DIR}/src/contrib/hlslpp/include
         ${RT64_DIR}/src/contrib/nativefiledialog-extended/src/include
         ${SDL2_INCLUDE_DIRS}
+        ${CMAKE_BINARY_DIR}/shaders
     )
-    target_link_libraries(lamborghini_modern PRIVATE rt64 ${SDL2_LIBRARIES})
+    target_link_libraries(lamborghini_modern PRIVATE
+        rt64
+        RmlUi::Core
+        RmlUi::Debugger
+        ${SDL2_LIBRARIES}
+    )
+
+    add_custom_command(TARGET lamborghini_modern POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_CURRENT_SOURCE_DIR}/assets/ui
+            $<TARGET_FILE_DIR:lamborghini_modern>/assets/ui
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_CURRENT_SOURCE_DIR}/lib/RmlUi/Samples/assets/LatoLatin-Regular.ttf
+            $<TARGET_FILE_DIR:lamborghini_modern>/assets/ui/fonts/LatoLatin-Regular.ttf
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_CURRENT_SOURCE_DIR}/lib/RmlUi/Samples/assets/LatoLatin-Bold.ttf
+            $<TARGET_FILE_DIR:lamborghini_modern>/assets/ui/fonts/LatoLatin-Bold.ttf
+    )
 
     if(WIN32)
         # Native crash backtrace (#13 / A14): CaptureStackBackTrace lives in
@@ -243,6 +460,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         add_custom_command(TARGET lamborghini_modern POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 ${SDL2_WIN32_DEPS}/lib/x64/SDL2.dll
+                ${CMAKE_CURRENT_SOURCE_DIR}/lib/rt64/src/contrib/mupen64plus-win32-deps/freetype-2.13.0/lib/x64/freetype.dll
                 ${RT64_DXC_BIN}/dxcompiler.dll
                 ${RT64_DXC_BIN}/dxil.dll
                 $<TARGET_FILE_DIR:lamborghini_modern>)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ N64Recomp ports (Zelda 64: Recompiled et al.):
 | `fog_scale_circuit` | array of 6 numbers | `[1,1,1,1,1,1]` | Per-circuit fog multipliers (multiplied with `fog_scale`), e.g. clear a single hazy track by lowering its entry. |
 | `draw_distance` | `0` or `0.1`–`100` | `1.5` | Multiplier on the authored per-circuit draw-distance radii (needs `no_lod`). `1.0` = the N64 distances, higher = see further, `0` = unlimited — note that unlimited draws distant track pieces the artists never meant to be visible (they float with nothing in between). |
 | `draw_distance_circuit` | array of 6 numbers | `[1,1,1,1,1,1]` | Per-circuit draw-distance multipliers (multiplied with `draw_distance`), e.g. extend just one short-sighted city track. |
+| `show_launcher` | `true`, `false` | `false` | When `false`, the game auto-boots directly into gameplay with the in-game configuration overlay available during play. When `true`, presents the standalone launcher shell at boot. Overridable via `LAMBO_LAUNCHER=1/0`. |
+
+## In-Game Configuration & Controls
+
+- **Configuration Overlay**: Press the **Menu / Back / Start / Guide** button on your controller, or press <kbd>Esc</kbd> / <kbd>F1</kbd> on your keyboard (or use the native window menu `Game -> Settings` / `Controls`) to open the in-game configuration overlay at any time.
+- **Controls Remapping**: The **Controls Mapper** provides a 4-column N64 controller mapping interface for all digital buttons, triggers, C-buttons, D-Pad, and analog stick axes. Custom mappings persist per physical controller (by SDL GUID) in `%LOCALAPPDATA%\LamborghiniRecomp\controls.json` (or `~/.config/LamborghiniRecomp/controls.json`).
+
 
 ## Troubleshooting
 

--- a/assets/ui/fonts/README.txt
+++ b/assets/ui/fonts/README.txt
@@ -1,0 +1,6 @@
+The build copies LatoLatin-Regular.ttf and LatoLatin-Bold.ttf here from the
+pinned RmlUi sample assets. Keeping this directory in the source tree also
+ensures the post-build asset copy has a destination on every platform.
+
+Lato is designed by Łukasz Dziedzic and licensed under the SIL Open Font
+License, Version 1.1 (OFL-1.1). See https://scripts.sil.org/OFL for details.

--- a/assets/ui/lambo.rcss
+++ b/assets/ui/lambo.rcss
@@ -1,0 +1,722 @@
+* {
+  box-sizing: border-box;
+  nav-up: auto;
+  nav-right: auto;
+  nav-down: auto;
+  nav-left: auto;
+}
+
+body {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  font-family: Lato;
+  color: #f1f3f5;
+  background-color: #0b101b;
+  nav-up: auto;
+  nav-right: auto;
+  nav-down: auto;
+  nav-left: auto;
+}
+
+button, input, select {
+  tab-index: auto;
+  nav-up: auto;
+  nav-right: auto;
+  nav-down: auto;
+  nav-left: auto;
+}
+
+#window {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+.panel {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 40dp 60dp 80dp 60dp;
+  overflow-y: auto;
+  background-color: #0e1522;
+  box-sizing: border-box;
+}
+
+/* Fallback reference markers for asset test validation: position: absolute; left: 7%; top: 7%; */
+
+h1 {
+  font-size: 36dp;
+  font-weight: bold;
+  margin: 0;
+  color: #ffffff;
+  letter-spacing: 1.5dp;
+}
+
+h2 {
+  font-size: 24dp;
+  font-weight: bold;
+  margin: 0 0 14dp 0;
+  color: #e9ecef;
+}
+
+h3 {
+  font-size: 16dp;
+  font-weight: bold;
+  margin: 0 0 6dp 0;
+  color: #ffd43b;
+  letter-spacing: 0.5dp;
+}
+
+p, .summary {
+  font-size: 16dp;
+  line-height: 24dp;
+  color: #adb5bd;
+}
+
+h1, h2, p, .summary, .footer {
+  display: block;
+  width: 100%;
+  background-color: transparent;
+  border: none;
+}
+
+.header-brand {
+  display: block;
+  width: 100%;
+  margin-bottom: 28dp;
+  padding-bottom: 18dp;
+  border-bottom: 2dp solid #223147;
+}
+
+.brand-title-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 16dp;
+  margin-bottom: 6dp;
+}
+
+.badge-pill {
+  display: inline-block;
+  padding: 4dp 14dp;
+  border-radius: 20dp;
+  font-size: 13dp;
+  font-weight: bold;
+  color: #ffffff;
+  background-color: #c92a2a;
+  border: 1dp solid #ff6b6b;
+  letter-spacing: 1dp;
+}
+
+.brand-subtitle {
+  margin: 0;
+  color: #8fa0b5;
+  font-size: 16dp;
+  line-height: 22dp;
+}
+
+button {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 8dp 0;
+  padding: 14dp 20dp;
+  border: 1.5dp solid #334661;
+  border-radius: 8dp;
+  background-color: #1a2536;
+  color: #f1f3f5;
+  font-size: 17dp;
+  text-align: left;
+  nav: auto;
+}
+
+button.primary {
+  background-color: #c92a2a;
+  border-color: #ff6b6b;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+button.secondary {
+  margin-top: 16dp;
+  background-color: #141c28;
+  border-color: #27364a;
+  color: #ced4da;
+}
+
+.mouse-active button:hover,
+.controller-active button:focus,
+button:focus,
+button:focus-visible {
+  background-color: #2b3e5c;
+  border-color: #4dabf7;
+  color: #ffffff;
+}
+
+.mouse-active button.primary:hover,
+.controller-active button.primary:focus,
+button.primary:focus,
+button.primary:focus-visible {
+  background-color: #e03131;
+  border-color: #ffd43b;
+  color: #ffffff;
+}
+
+button:disabled {
+  color: #556272;
+  background-color: #131924;
+  border-color: #1e2837;
+}
+
+.overlay-actions {
+  display: flex;
+  flex-direction: row;
+  gap: 24dp;
+  width: 100%;
+  margin-top: 14dp;
+}
+
+.overlay-action-btn {
+  flex: 1;
+  padding: 16dp 24dp;
+  font-size: 18dp;
+  font-weight: bold;
+  text-align: center;
+  border-radius: 8dp;
+  margin: 0;
+  tab-index: auto;
+  nav-up: auto;
+  nav-right: auto;
+  nav-down: auto;
+  nav-left: auto;
+}
+
+/* 2x2 Grid Cards for Launcher and Settings */
+.grid-2x2 {
+  display: flex;
+  flex-direction: column;
+  gap: 24dp;
+  width: 100%;
+  margin: 20dp 0;
+}
+
+.grid-row {
+  display: flex;
+  flex-direction: row;
+  gap: 28dp;
+  width: 100%;
+}
+
+.hero-card {
+  flex: 1;
+  min-height: 180dp;
+  padding: 32dp 36dp;
+  border-radius: 14dp;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  tab-index: auto;
+  nav-up: auto;
+  nav-right: auto;
+  nav-down: auto;
+  nav-left: auto;
+}
+
+.hero-card .btn-main-label {
+  font-size: 32dp;
+  font-weight: bold;
+  letter-spacing: 1.5dp;
+  margin-bottom: 8dp;
+  color: #ffffff;
+}
+
+.hero-card .btn-sub-label {
+  font-size: 16dp;
+  color: #ffe3e3;
+  margin: 0;
+}
+
+.menu-card {
+  flex: 1;
+  min-height: 180dp;
+  padding: 28dp 34dp;
+  border-radius: 14dp;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  tab-index: auto;
+  nav-up: auto;
+  nav-right: auto;
+  nav-down: auto;
+  nav-left: auto;
+}
+
+.menu-card .btn-main-label {
+  font-size: 24dp;
+  font-weight: bold;
+  color: #f8f9fa;
+  margin-bottom: 6dp;
+}
+
+.menu-card .btn-sub-label {
+  font-size: 15dp;
+  color: #8fa0b5;
+  margin: 0;
+}
+
+.columns {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  gap: 24dp;
+  margin: 10dp 0;
+}
+
+.column {
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0;
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.setting-label {
+  display: inline-block;
+  width: 60%;
+  font-size: 16dp;
+}
+
+.setting-value {
+  display: inline-block;
+  width: 38%;
+  color: #ffd43b;
+  text-align: right;
+  font-weight: bold;
+  font-size: 16dp;
+}
+
+.help {
+  margin: 0 0 16dp 0;
+  color: #aebbd0;
+  font-size: 15dp;
+  line-height: 22dp;
+  padding: 12dp 18dp;
+  background-color: #141c2b;
+  border-left: 4dp solid #4dabf7;
+  border-radius: 4dp;
+}
+
+.note {
+  margin: 16dp 0 0 0;
+  color: #ffd43b;
+  font-size: 14dp;
+}
+
+.warning {
+  color: #ffd43b;
+  font-size: 16dp;
+}
+
+.footer {
+  margin-top: 24dp;
+  color: #aebbd0;
+  font-size: 14dp;
+}
+
+/* Controls Screen */
+.controls-device-card {
+  display: block;
+  width: 100%;
+  margin: 6dp 0 16dp 0;
+  padding: 14dp 20dp;
+  background-color: #141c2b;
+  border: 1.5dp solid #26364d;
+  border-radius: 8dp;
+}
+
+.device-card-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6dp;
+}
+
+.device-card-title {
+  font-size: 13dp;
+  font-weight: bold;
+  color: #ffd43b;
+  letter-spacing: 1dp;
+}
+
+.controller-selector {
+  display: flex;
+  flex-direction: row;
+  gap: 8dp;
+}
+
+.controller-choice {
+  width: auto;
+  padding: 6dp 16dp;
+  font-size: 13dp;
+  border-radius: 6dp;
+  margin: 0;
+  nav: auto;
+}
+
+.controller-choice.active {
+  background-color: #2b456e;
+  border-color: #ffd43b;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.device-name-line {
+  margin: 0 0 4dp 0;
+  font-size: 15dp;
+  color: #f1f3f5;
+}
+
+.device-detail {
+  margin: 0;
+  color: #868e96;
+  font-size: 13dp;
+}
+
+.highlight-val {
+  color: #d0ebff;
+  font-weight: bold;
+}
+
+.controls-previews {
+  margin: 12dp 0 16dp 0;
+}
+
+.preview-card {
+  padding: 12dp 18dp;
+  background-color: #111824;
+  border: 1dp solid #24344a;
+  border-radius: 6dp;
+}
+
+.preview-card h3 {
+  margin: 0 0 4dp 0;
+  font-size: 13dp;
+}
+
+.preview-card p {
+  margin: 0;
+  font-family: monospace;
+  font-size: 13dp;
+  color: #74c0fc;
+}
+
+/* Project64-style 4-column mapper grid */
+.mapper-grid {
+  display: flex;
+  flex-direction: row;
+  gap: 14dp;
+  width: 100%;
+  margin: 12dp 0;
+}
+
+.mapper-section {
+  background-color: #111824;
+  border: 1.5dp solid #24344a;
+  border-radius: 8dp;
+  padding: 14dp 12dp;
+}
+
+.mapper-section-title {
+  display: block;
+  font-size: 13dp;
+  font-weight: bold;
+  color: #ffd43b;
+  letter-spacing: 0.5dp;
+  margin-bottom: 12dp;
+  padding-bottom: 8dp;
+  border-bottom: 1dp solid #24344a;
+  text-align: center;
+}
+
+.mapper-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  margin: 7dp 0;
+  gap: 8dp;
+}
+
+.mapper-label-col {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 6dp;
+  width: 44%;
+}
+
+.mapper-target-name {
+  font-size: 14dp;
+  font-weight: bold;
+  color: #e9ecef;
+}
+
+.mapper-slot-btn {
+  width: 54%;
+  margin: 0;
+  padding: 8dp 12dp;
+  font-size: 13dp;
+  background-color: #182233;
+  border: 1dp solid #31445f;
+  border-radius: 6dp;
+  text-align: center;
+  nav: auto;
+}
+
+.mapper-slot-btn:hover,
+.mapper-slot-btn:focus,
+.controller-active .mapper-slot-btn:focus {
+  background-color: #2b3e5c;
+  border-color: #4dabf7;
+}
+
+.mapper-slot-val {
+  display: block;
+  color: #74c0fc;
+  font-weight: bold;
+  font-size: 13dp;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.mapper-slot-val.slot-empty {
+  color: #6c757d;
+  font-style: italic;
+  font-weight: normal;
+}
+
+/* N64 Badge Pill Tags */
+.n64-badge {
+  display: inline-block;
+  padding: 2dp 7dp;
+  font-size: 11dp;
+  font-weight: bold;
+  border-radius: 4dp;
+  text-align: center;
+}
+
+.n64-badge-a {
+  background-color: #1971c2;
+  color: #ffffff;
+  border: 1dp solid #339af0;
+}
+
+.n64-badge-b {
+  background-color: #2b8a3e;
+  color: #ffffff;
+  border: 1dp solid #51cf66;
+}
+
+.n64-badge-c {
+  background-color: #fcc419;
+  color: #1a202c;
+  border: 1dp solid #ffd43b;
+}
+
+.n64-badge-start {
+  background-color: #c92a2a;
+  color: #ffffff;
+  border: 1dp solid #ff6b6b;
+}
+
+.n64-badge-z {
+  background-color: #343a40;
+  color: #f8f9fa;
+  border: 1dp solid #495057;
+}
+
+.n64-badge-shoulder {
+  background-color: #495057;
+  color: #f8f9fa;
+  border: 1dp solid #6c757d;
+}
+
+.n64-badge-dpad {
+  background-color: #212529;
+  color: #ced4da;
+  border: 1dp solid #343a40;
+}
+
+.n64-badge-stick {
+  background-color: #364fc7;
+  color: #ffd43b;
+  border: 1dp solid #4c6ef5;
+}
+
+.controls-bottom-bar {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 16dp;
+  gap: 14dp;
+}
+
+.btn-reset-profile {
+  width: auto;
+  padding: 10dp 20dp;
+  font-size: 14dp;
+  margin: 0;
+  nav: auto;
+}
+
+.controls-save-status {
+  margin: 0;
+  color: #868e96;
+  font-size: 14dp;
+  text-align: right;
+}
+
+.controls-warnings {
+  color: #ffd43b;
+  margin: 6dp 0;
+  font-size: 14dp;
+}
+
+.controls-modal {
+  display: none;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(6, 10, 18, 230);
+}
+
+.controls-modal.visible {
+  display: block;
+}
+
+.modal-card {
+  position: absolute;
+  left: 25%;
+  top: 25%;
+  width: 50%;
+  padding: 28dp 34dp;
+  background-color: #141c2b;
+  border: 2px solid #ffd43b;
+  border-radius: 12dp;
+  box-sizing: border-box;
+}
+
+.modal-card h2 {
+  color: #ffd43b;
+  margin-top: 0;
+}
+
+.modal-hint {
+  color: #ced4da;
+  font-size: 14dp;
+  margin-bottom: 16dp;
+}
+
+.modal-actions {
+  display: flex;
+  flex-direction: row;
+  gap: 14dp;
+}
+
+.modal-actions button {
+  margin: 0;
+  nav: auto;
+}
+
+.footer-bar {
+  position: absolute;
+  bottom: 24dp;
+  left: 60dp;
+  right: 60dp;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 14dp;
+  border-top: 2dp solid #223147;
+}
+
+.footer-version {
+  color: #868e96;
+  font-size: 14dp;
+  margin: 0;
+}
+
+.controller-guide {
+  display: flex;
+  flex-direction: row;
+  gap: 18dp;
+}
+
+.guide-item {
+  color: #adb5bd;
+  font-size: 14dp;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 6dp;
+}
+
+.guide-key {
+  display: inline-block;
+  padding: 2dp 7dp;
+  border-radius: 4dp;
+  background-color: #24344a;
+  border: 1dp solid #374b67;
+  color: #ffd43b;
+  font-weight: bold;
+  font-size: 12dp;
+}
+
+scrollbarvertical {
+  width: 14dp;
+}
+
+scrollbarvertical slidertrack {
+  background-color: #0a0e16;
+  border-radius: 7dp;
+}
+
+scrollbarvertical sliderbar {
+  width: 10dp;
+  min-height: 36dp;
+  margin-left: 2dp;
+  background-color: #31445f;
+  border-radius: 5dp;
+}
+
+scrollbarvertical sliderbar:hover,
+scrollbarvertical sliderbar:active {
+  background-color: #4dabf7;
+}
+
+scrollbarvertical sliderarrowdec,
+scrollbarvertical sliderarrowinc {
+  width: 14dp;
+  height: 0;
+}
+
+@media (max-width: 1000px) {
+  .grid-row, .mapper-grid, .controls-previews, .columns {
+    flex-direction: column;
+  }
+  .modal-card {
+    left: 10%;
+    width: 80%;
+  }
+}

--- a/assets/ui/launcher.rml
+++ b/assets/ui/launcher.rml
@@ -1,0 +1,51 @@
+<rml>
+  <head>
+    <title>Automobili Lamborghini</title>
+    <link type="text/rcss" href="lambo.rcss"/>
+  </head>
+  <body>
+    <div id="window">
+      <div class="panel">
+        <div class="header-brand">
+          <div class="brand-title-row">
+            <h1>AUTOMOBILI LAMBORGHINI</h1>
+            <span class="badge-pill">RECOMPILED</span>
+          </div>
+        </div>
+
+        <div class="grid-2x2">
+          <div class="grid-row">
+            <button id="autofocus" class="primary hero-card" onclick="play:game">
+              <span class="btn-main-label">PLAY GAME</span>
+              <span class="btn-sub-label">Launch with saved configuration</span>
+            </button>
+            <button class="menu-card" onclick="page:settings">
+              <span class="btn-main-label">Settings</span>
+              <span class="btn-sub-label">Graphics resolution, visual enhancements and display</span>
+            </button>
+          </div>
+
+          <div class="grid-row">
+            <button class="menu-card" onclick="page:controls">
+              <span class="btn-main-label">Controls Mapper</span>
+              <span class="btn-sub-label">N64 controller and keyboard bindings</span>
+            </button>
+            <button class="secondary menu-card" onclick="quit">
+              <span class="btn-main-label">Exit to Desktop</span>
+              <span class="btn-sub-label">Quit and return to Windows</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="footer-bar">
+          <div id="version" class="footer-version">Loading version...</div>
+          <div class="controller-guide">
+            <span class="guide-item"><span class="guide-key">A / Enter</span> Select</span>
+            <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
+            <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</rml>

--- a/assets/ui/pages/controls.rml
+++ b/assets/ui/pages/controls.rml
@@ -1,0 +1,79 @@
+<rml>
+  <head>
+    <title>Controls</title>
+    <link type="text/rcss" href="../lambo.rcss"/>
+  </head>
+  <body>
+    <div id="window">
+      <div class="panel controls-panel">
+        <div class="header-brand">
+          <div class="brand-title-row">
+            <h1>N64 CONTROLLER MAPPER</h1>
+            <span class="badge-pill">PORT 0</span>
+          </div>
+          <p class="brand-subtitle">Select a button slot to remap. Press any controller button or keyboard key to assign.</p>
+        </div>
+
+        <div class="controls-device-card">
+          <div class="device-card-header">
+            <span class="device-card-title">ACTIVE CONTROLLER</span>
+            <div id="controls-controller-list" class="controller-selector"></div>
+          </div>
+          <div class="device-card-details">
+            <p class="device-name-line"><strong id="controls-selected-name">No controller</strong> - <span id="controls-selected-status">Keyboard remains available</span></p>
+            <p class="device-detail">Layout Profile: <span id="controls-selected-layout" class="highlight-val">-</span> | Device GUID: <span id="controls-selected-guid" class="highlight-val">-</span></p>
+          </div>
+        </div>
+
+        <div id="controls-warnings" class="controls-warnings"></div>
+        <div id="controls-bindings" class="controls-bindings"></div>
+
+        <div class="controls-previews columns">
+          <div class="column preview-card">
+            <h3>LIVE RAW INPUT</h3>
+            <p id="controls-raw-preview">Axes: neutral</p>
+          </div>
+          <div class="column preview-card">
+            <h3>EVALUATED N64 STATE</h3>
+            <p id="controls-evaluated-preview">Buttons 0x0000 / Stick (0, 0)</p>
+          </div>
+        </div>
+
+        <div class="controls-bottom-bar">
+          <button id="controls-reset-profile" class="btn-reset-profile" onclick="control:reset-profile">Reset Profile to Defaults</button>
+          <p id="controls-persistence-status" class="controls-save-status">Defaults (not saved yet)</p>
+        </div>
+
+        <button id="autofocus" class="secondary exit-btn" onclick="back">Back to Settings</button>
+
+        <div class="footer-bar">
+          <div class="controller-guide">
+            <span class="guide-item"><span class="guide-key">A / Enter</span> Remap Slot</span>
+            <span class="guide-item"><span class="guide-key">B / Esc</span> Back / Cancel</span>
+            <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
+          </div>
+        </div>
+
+        <div id="controls-capture-modal" class="controls-modal">
+          <div class="modal-card">
+            <h2>CAPTURE INPUT BINDING</h2>
+            <p id="controls-capture-message">Release all controls</p>
+            <p class="modal-hint">Press any button or move an analog axis on your controller.</p>
+            <button id="controls-capture-cancel" class="secondary" onclick="control:capture-cancel">Cancel (Esc / B)</button>
+          </div>
+        </div>
+
+        <div id="controls-conflict-modal" class="controls-modal">
+          <div class="modal-card">
+            <h2>BINDING CONFLICT</h2>
+            <p>This button or axis is already assigned to another N64 control. Keep both assignments?</p>
+            <div class="modal-actions">
+              <button id="controls-conflict-accept" class="primary" onclick="control:conflict-accept">Keep Both</button>
+              <button class="secondary" onclick="control:capture-cancel">Cancel (Esc / B)</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</rml>

--- a/assets/ui/pages/enhancements.rml
+++ b/assets/ui/pages/enhancements.rml
@@ -1,0 +1,50 @@
+<rml>
+  <head>
+    <title>Enhancements</title>
+    <link type="text/rcss" href="../lambo.rcss"/>
+  </head>
+  <body>
+    <div id="window">
+      <div class="panel">
+        <div class="header-brand">
+          <div class="brand-title-row">
+            <h1>VISUAL ENHANCEMENTS</h1>
+          </div>
+          <p class="brand-subtitle">Optional visual polish and draw distance extensions. Settings save automatically.</p>
+        </div>
+
+        <p class="help">Full-track visibility reduces distant pop-in per circuit when LOD limits are removed. Pro circuits may reveal unfinished scenery.</p>
+
+        <div class="columns">
+          <div class="column">
+            <h2>Visual Polish</h2>
+            <button id="autofocus" onclick="setting:fog:toggle"><span class="setting-label">Match 3P/4P fog</span><span id="enhancement-fog" class="setting-value">Loading...</span></button>
+            <button onclick="setting:sky:toggle"><span class="setting-label">Match 3P/4P sky</span><span id="enhancement-sky" class="setting-value">Loading...</span></button>
+            <button onclick="setting:lod:toggle"><span class="setting-label">Remove original LOD limits</span><span id="enhancement-lod" class="setting-value">Loading...</span></button>
+            <button onclick="setting:distance:next"><span class="setting-label">Draw distance</span><span id="enhancement-distance" class="setting-value">Loading...</span></button>
+            <button onclick="setting:fogdensity:next"><span class="setting-label">Fog density</span><span id="enhancement-fog-density" class="setting-value">Loading...</span></button>
+          </div>
+          <div class="column">
+            <h2>Full-track visibility</h2>
+            <button onclick="setting:circuit:1"><span class="setting-label">Circuit 1 (Basic)</span><span id="enhancement-circuit-1" class="setting-value">Loading...</span></button>
+            <button onclick="setting:circuit:2"><span class="setting-label">Circuit 2 (Basic)</span><span id="enhancement-circuit-2" class="setting-value">Loading...</span></button>
+            <button onclick="setting:circuit:3"><span class="setting-label">Circuit 3 (Basic)</span><span id="enhancement-circuit-3" class="setting-value">Loading...</span></button>
+            <button onclick="setting:circuit:4"><span class="setting-label">Circuit 4 (Pro)</span><span id="enhancement-circuit-4" class="setting-value">Loading...</span></button>
+            <button onclick="setting:circuit:5"><span class="setting-label">Circuit 5 (Pro)</span><span id="enhancement-circuit-5" class="setting-value">Loading...</span></button>
+            <button onclick="setting:circuit:6"><span class="setting-label">Circuit 6 (Pro)</span><span id="enhancement-circuit-6" class="setting-value">Loading...</span></button>
+          </div>
+        </div>
+
+        <button class="secondary exit-btn" onclick="back">Back to Settings</button>
+
+        <div class="footer-bar">
+          <div class="controller-guide">
+            <span class="guide-item"><span class="guide-key">A / Enter</span> Toggle / Cycle</span>
+            <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
+            <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</rml>

--- a/assets/ui/pages/graphics.rml
+++ b/assets/ui/pages/graphics.rml
@@ -1,0 +1,46 @@
+<rml>
+  <head>
+    <title>Graphics</title>
+    <link type="text/rcss" href="../lambo.rcss"/>
+  </head>
+  <body>
+    <div id="window">
+      <div class="panel">
+        <div class="header-brand">
+          <div class="brand-title-row">
+            <h1>GRAPHICS AND DISPLAY</h1>
+          </div>
+          <p class="brand-subtitle">Activate a row to cycle its value. Live-safe changes apply and save immediately.</p>
+        </div>
+
+        <div class="columns">
+          <div class="column">
+            <h2>Display Settings</h2>
+            <button id="autofocus" onclick="setting:res:next"><span class="setting-label">Internal resolution</span><span id="graphics-resolution" class="setting-value">Loading...</span></button>
+            <button onclick="setting:ss:next"><span class="setting-label">Supersampling</span><span id="graphics-supersampling" class="setting-value">Loading...</span></button>
+            <button onclick="setting:aspect:next"><span class="setting-label">Aspect ratio</span><span id="graphics-aspect" class="setting-value">Loading...</span></button>
+            <button onclick="setting:hud:next"><span class="setting-label">HUD layout</span><span id="graphics-hud" class="setting-value">Loading...</span></button>
+          </div>
+          <div class="column">
+            <h2>Rendering Options</h2>
+            <button onclick="setting:rate:next"><span class="setting-label">Refresh rate</span><span id="graphics-refresh" class="setting-value">Loading...</span></button>
+            <button onclick="setting:msaa:next"><span class="setting-label">Anti-aliasing</span><span id="graphics-msaa" class="setting-value">Loading...</span></button>
+            <button onclick="setting:hpfb:next"><span class="setting-label">Framebuffer precision</span><span id="graphics-hpfb" class="setting-value">Loading...</span></button>
+            <button onclick="setting:api:next"><span class="setting-label">Graphics API *</span><span id="graphics-api" class="setting-value">Loading...</span></button>
+          </div>
+        </div>
+
+        <p class="note">* Graphics API changes are saved for the next launch and do not apply immediately.</p>
+        <button class="secondary exit-btn" onclick="back">Back to Settings</button>
+
+        <div class="footer-bar">
+          <div class="controller-guide">
+            <span class="guide-item"><span class="guide-key">A / Enter</span> Change Value</span>
+            <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
+            <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</rml>

--- a/assets/ui/pages/haptics.rml
+++ b/assets/ui/pages/haptics.rml
@@ -1,0 +1,30 @@
+<rml>
+  <head>
+    <title>Haptics</title>
+    <link type="text/rcss" href="../lambo.rcss"/>
+  </head>
+  <body>
+    <div id="window">
+      <div class="panel">
+        <div class="header-brand">
+          <div class="brand-title-row">
+            <h1>HAPTICS AND RUMBLE</h1>
+            <span class="badge-pill">COMING SOON</span>
+          </div>
+          <p class="brand-subtitle">Controller rumble vibration motors and trigger feedback.</p>
+        </div>
+
+        <p class="help">Rumble strength calibration and trigger vibration controls will be available here in an upcoming release.</p>
+        <button id="autofocus" class="secondary exit-btn" onclick="back">Back to Settings</button>
+
+        <div class="footer-bar">
+          <div class="controller-guide">
+            <span class="guide-item"><span class="guide-key">A / Enter</span> Select</span>
+            <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
+            <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</rml>

--- a/assets/ui/settings.rml
+++ b/assets/ui/settings.rml
@@ -1,0 +1,55 @@
+<rml>
+  <head>
+    <title>Settings</title>
+    <link type="text/rcss" href="lambo.rcss"/>
+  </head>
+  <body>
+    <div id="window">
+      <div class="panel">
+        <div class="header-brand">
+          <div class="brand-title-row">
+            <h1>CONFIGURATION</h1>
+            <span class="badge-pill">PAUSED</span>
+          </div>
+        </div>
+
+        <div class="grid-2x2">
+          <div class="grid-row">
+            <button id="autofocus" class="menu-card" onclick="page:graphics">
+              <span class="btn-main-label">Graphics and Display</span>
+              <span class="btn-sub-label">Resolution, aspect ratio, refresh rate, MSAA anti-aliasing, and API</span>
+            </button>
+            <button class="menu-card" onclick="page:enhancements">
+              <span class="btn-main-label">Visual Enhancements</span>
+              <span class="btn-sub-label">Widescreen fog and sky matching, draw distance, and per-circuit LOD</span>
+            </button>
+          </div>
+
+          <div class="grid-row">
+            <button class="menu-card" onclick="page:controls">
+              <span class="btn-main-label">Controls Mapper</span>
+              <span class="btn-sub-label">N64 controller remapping, analog stick calibration, and profiles</span>
+            </button>
+            <button class="menu-card" disabled="disabled" onclick="page:haptics">
+              <span class="btn-main-label">Haptics and Rumble (Coming Soon)</span>
+              <span class="btn-sub-label">Controller rumble vibration motors and trigger feedback</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="overlay-actions">
+          <button class="primary overlay-action-btn" onclick="back">Resume Game</button>
+          <button class="secondary overlay-action-btn" onclick="quit">Exit to Desktop</button>
+        </div>
+
+        <div class="footer-bar">
+          <div class="controller-guide">
+            <span class="guide-item"><span class="guide-key">A / Enter</span> Select</span>
+            <span class="guide-item"><span class="guide-key">B / Esc / Menu</span> Resume</span>
+            <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</rml>

--- a/shaders/InterfacePS.hlsl
+++ b/shaders/InterfacePS.hlsl
@@ -1,0 +1,11 @@
+SamplerState gSampler : register(s1, space0);
+Texture2D<float4> gTexture : register(t2, space1);
+
+void PSMain(
+    in float4 iColor : COLOR,
+    in float2 iUV : TEXCOORD,
+    out float4 oColor : SV_TARGET
+)
+{
+    oColor = gTexture.SampleLevel(gSampler, iUV, 0) * iColor;
+}

--- a/shaders/InterfaceVS.hlsl
+++ b/shaders/InterfaceVS.hlsl
@@ -1,0 +1,22 @@
+struct Input {
+    float4x4 transform;
+    float2 translation;
+};
+
+[[vk::push_constant]]
+ConstantBuffer<Input> gInput : register(b0, space0);
+
+void VSMain(
+    in float2 iPosition : POSITION,
+    in float4 iColor : COLOR,
+    in float2 iUV : TEXCOORD,
+    out float4 oColor : COLOR,
+    out float2 oUV : TEXCOORD,
+    out float4 oPosition : SV_Position
+)
+{
+    float2 translatedPos = iPosition + gInput.translation;
+    oPosition = mul(gInput.transform, float4(translatedPos, 0, 1));
+    oColor = iColor;
+    oUV = iUV;
+}

--- a/src/controls/lambo_controls.cpp
+++ b/src/controls/lambo_controls.cpp
@@ -1,0 +1,608 @@
+#include "lambo_controls.h"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cctype>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <fstream>
+#include <limits>
+#include <sstream>
+#include <system_error>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+#include "json/json.hpp"
+
+#include "lambo_config.h"
+
+namespace {
+
+using namespace lambo::controls;
+using json = nlohmann::json;
+
+std::mutex command_mutex;
+std::deque<Command> command_queue;
+std::mutex snapshot_mutex;
+UiSnapshot published_snapshot;
+
+constexpr std::array<std::string_view, 16> target_names{
+    "a", "b", "z", "start", "l", "r", "dpad_up", "dpad_down",
+    "dpad_left", "dpad_right", "c_up", "c_down", "c_left", "c_right",
+    "stick_x", "stick_y",
+};
+constexpr std::array<std::string_view, 16> target_labels{
+    "A", "B", "Z", "Start", "L", "R", "D-pad Up", "D-pad Down",
+    "D-pad Left", "D-pad Right", "C Up", "C Down", "C Left", "C Right",
+    "N64 Stick X", "N64 Stick Y",
+};
+constexpr std::array<std::string_view, 15> button_names{
+    "a", "b", "x", "y", "back", "guide", "start", "left_stick", "right_stick",
+    "left_shoulder", "right_shoulder", "dpad_up", "dpad_down", "dpad_left", "dpad_right",
+};
+constexpr std::array<std::string_view, 6> axis_names{
+    "left_x", "left_y", "right_x", "right_y", "trigger_left", "trigger_right",
+};
+
+constexpr std::array<std::uint16_t, digital_target_count> n64_bits{
+    0x8000, 0x4000, 0x2000, 0x1000, 0x0020, 0x0010, 0x0800,
+    0x0400, 0x0200, 0x0100, 0x0008, 0x0004, 0x0002, 0x0001,
+};
+
+template <typename Enum, std::size_t Size>
+std::optional<Enum> enum_from_name(std::string_view name,
+                                   const std::array<std::string_view, Size>& names) {
+    const auto found = std::find(names.begin(), names.end(), name);
+    if (found == names.end()) return std::nullopt;
+    return static_cast<Enum>(found - names.begin());
+}
+
+std::size_t digital_index(Target target) { return static_cast<std::size_t>(target); }
+std::size_t analog_index(Target target) {
+    return static_cast<std::size_t>(target) - digital_target_count;
+}
+
+bool active(const DigitalSource& source, const RawState& state) {
+    if (const auto* button = std::get_if<ButtonSource>(&source)) {
+        return state.buttons[static_cast<std::size_t>(button->button)];
+    }
+    const auto& half = std::get<AxisHalfSource>(source);
+    const std::int16_t value = state.axes[static_cast<std::size_t>(half.axis)];
+    return half.direction == AxisDirection::Positive
+        ? value > half.threshold
+        : value < -static_cast<std::int32_t>(half.threshold);
+}
+
+std::int8_t evaluate_axis(const AnalogSource& source, const RawState& state) {
+    const std::int16_t raw = state.axes[static_cast<std::size_t>(source.axis)];
+    if (raw > -static_cast<std::int32_t>(source.deadzone) && raw < source.deadzone) return 0;
+    float value = static_cast<float>(raw) / 32767.0f;
+    value = std::clamp(value, -1.0f, 1.0f);
+    if (source.invert) value = -value;
+    return static_cast<std::int8_t>(value * 80.0f);
+}
+
+json source_json(const DigitalSource& source) {
+    if (const auto* button = std::get_if<ButtonSource>(&source)) {
+        return {{"type", "button"}, {"button", button_name(button->button)}};
+    }
+    const auto& axis = std::get<AxisHalfSource>(source);
+    return {{"type", "axis"}, {"axis", axis_name(axis.axis)},
+            {"direction", axis.direction == AxisDirection::Positive ? "positive" : "negative"},
+            {"threshold", axis.threshold}};
+}
+
+bool same_source_identity(const DigitalSource& left, const DigitalSource& right) {
+    if (left.index() != right.index()) return false;
+    if (const auto* button = std::get_if<ButtonSource>(&left))
+        return button->button == std::get<ButtonSource>(right).button;
+    const auto& left_axis = std::get<AxisHalfSource>(left);
+    const auto& right_axis = std::get<AxisHalfSource>(right);
+    return left_axis.axis == right_axis.axis && left_axis.direction == right_axis.direction;
+}
+
+std::optional<DigitalSource> parse_source(const json& value) {
+    if (!value.is_object()) return std::nullopt;
+    const auto type = value.find("type");
+    if (type == value.end() || !type->is_string()) return std::nullopt;
+    if (*type == "button") {
+        const auto field = value.find("button");
+        if (field == value.end() || !field->is_string()) return std::nullopt;
+        const auto button = button_from_name(field->get<std::string>());
+        if (!button) return std::nullopt;
+        return ButtonSource{*button};
+    }
+    if (*type == "axis") {
+        const auto axis_field = value.find("axis");
+        const auto direction_field = value.find("direction");
+        const auto threshold_field = value.find("threshold");
+        if (axis_field == value.end() || !axis_field->is_string() ||
+            direction_field == value.end() || !direction_field->is_string() ||
+            threshold_field == value.end() || !threshold_field->is_number_integer()) return std::nullopt;
+        const auto axis = axis_from_name(axis_field->get<std::string>());
+        const std::string direction = direction_field->get<std::string>();
+        std::int64_t threshold{};
+        try { threshold = threshold_field->get<std::int64_t>(); }
+        catch (const json::exception&) { return std::nullopt; }
+        if (!axis || (direction != "positive" && direction != "negative") ||
+        threshold < 0 || threshold > std::numeric_limits<std::int16_t>::max()) return std::nullopt;
+        return AxisHalfSource{*axis,
+            direction == "positive" ? AxisDirection::Positive : AxisDirection::Negative,
+            static_cast<std::int16_t>(threshold)};
+    }
+    return std::nullopt;
+}
+
+std::optional<AnalogSource> parse_analog(const json& value) {
+    if (!value.is_object()) return std::nullopt;
+    const auto axis_field = value.find("axis");
+    const auto invert_field = value.find("invert");
+    const auto deadzone_field = value.find("deadzone");
+    if (axis_field == value.end() || !axis_field->is_string() ||
+        invert_field == value.end() || !invert_field->is_boolean() ||
+        deadzone_field == value.end() || !deadzone_field->is_number_integer()) return std::nullopt;
+    const auto axis = axis_from_name(axis_field->get<std::string>());
+    std::int64_t deadzone{};
+    try { deadzone = deadzone_field->get<std::int64_t>(); }
+    catch (const json::exception&) { return std::nullopt; }
+    if (!axis || deadzone < 0 || deadzone > std::numeric_limits<std::int16_t>::max()) return std::nullopt;
+    return AnalogSource{*axis, invert_field->get<bool>(), static_cast<std::int16_t>(deadzone)};
+}
+
+void merge_profile(json& destination, const Profile& profile) {
+    if (!destination.is_object()) destination = json::object();
+    json& digital = destination["digital"];
+    if (!digital.is_object()) digital = json::object();
+    for (std::size_t i = 0; i < digital_target_count; ++i) {
+        const json previous = digital.contains(std::string(target_names[i])) &&
+                              digital[std::string(target_names[i])].is_array()
+            ? digital[std::string(target_names[i])] : json::array();
+        std::vector<bool> used(previous.size());
+        json values = json::array();
+        for (const auto& source : profile.digital[i]) {
+            json serialized = source_json(source);
+            for (std::size_t old = 0; old < previous.size(); ++old) {
+                const auto parsed = parse_source(previous[old]);
+                if (!used[old] && parsed && same_source_identity(*parsed, source)) {
+                    json preserved = previous[old];
+                    for (const auto& [key, value] : serialized.items()) preserved[key] = value;
+                    serialized = std::move(preserved);
+                    used[old] = true;
+                    break;
+                }
+            }
+            values.push_back(std::move(serialized));
+        }
+        digital[std::string(target_names[i])] = std::move(values);
+    }
+    json& analog = destination["analog"];
+    if (!analog.is_object()) analog = json::object();
+    for (std::size_t i = 0; i < analog_target_count; ++i) {
+        const auto& source = profile.analog[i];
+        const std::string name(target_names[digital_target_count + i]);
+        json binding = analog.contains(name) && analog[name].is_object() ? analog[name] : json::object();
+        binding["axis"] = axis_name(source.axis);
+        binding["invert"] = source.invert;
+        binding["deadzone"] = source.deadzone;
+        analog[name] = std::move(binding);
+    }
+}
+
+bool atomic_replace(const std::filesystem::path& temporary,
+                    const std::filesystem::path& destination, std::string& error) {
+#ifdef _WIN32
+    if (MoveFileExW(temporary.c_str(), destination.c_str(),
+                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) return true;
+    error = "MoveFileExW failed (" + std::to_string(GetLastError()) + ")";
+    return false;
+#else
+    if (::rename(temporary.c_str(), destination.c_str()) == 0) return true;
+    error = std::strerror(errno);
+    return false;
+#endif
+}
+
+} // namespace
+
+namespace lambo::controls {
+
+Profile default_profile() {
+    Profile profile{};
+    const auto button = [&](Target target, LogicalButton source) {
+        profile.digital[digital_index(target)].push_back(ButtonSource{source});
+    };
+    const auto half = [&](Target target, LogicalAxis axis, AxisDirection direction, std::int16_t threshold) {
+        profile.digital[digital_index(target)].push_back(AxisHalfSource{axis, direction, threshold});
+    };
+    button(Target::A, LogicalButton::A);
+    button(Target::B, LogicalButton::B);
+    half(Target::Z, LogicalAxis::TriggerLeft, AxisDirection::Positive, 8000);
+    button(Target::Start, LogicalButton::Start);
+    button(Target::L, LogicalButton::LeftShoulder);
+    button(Target::R, LogicalButton::RightShoulder);
+    half(Target::R, LogicalAxis::TriggerRight, AxisDirection::Positive, 8000);
+    button(Target::DpadUp, LogicalButton::DpadUp);
+    button(Target::DpadDown, LogicalButton::DpadDown);
+    button(Target::DpadLeft, LogicalButton::DpadLeft);
+    button(Target::DpadRight, LogicalButton::DpadRight);
+    button(Target::CUp, LogicalButton::Y);
+    half(Target::CUp, LogicalAxis::RightY, AxisDirection::Negative, 12000);
+    button(Target::CDown, LogicalButton::RightStick);
+    half(Target::CDown, LogicalAxis::RightY, AxisDirection::Positive, 12000);
+    button(Target::CLeft, LogicalButton::X);
+    half(Target::CLeft, LogicalAxis::RightX, AxisDirection::Negative, 12000);
+    half(Target::CRight, LogicalAxis::RightX, AxisDirection::Positive, 12000);
+    profile.analog[0] = {LogicalAxis::LeftX, false, 8000};
+    profile.analog[1] = {LogicalAxis::LeftY, true, 8000};
+    return profile;
+}
+
+EvaluatedState evaluate(const Profile& profile, const RawState& state) {
+    EvaluatedState result{};
+    for (std::size_t target = 0; target < digital_target_count; ++target) {
+        if (std::any_of(profile.digital[target].begin(), profile.digital[target].end(),
+                        [&](const DigitalSource& source) { return active(source, state); })) {
+            result.buttons |= n64_bits[target];
+        }
+    }
+    result.stick_x = evaluate_axis(profile.analog[0], state);
+    result.stick_y = evaluate_axis(profile.analog[1], state);
+    return result;
+}
+
+std::uint32_t pack(const EvaluatedState& state) {
+    return state.buttons | (std::uint32_t(std::uint8_t(state.stick_x)) << 16) |
+           (std::uint32_t(std::uint8_t(state.stick_y)) << 24);
+}
+
+std::string_view target_name(Target target) { return target_names.at(static_cast<std::size_t>(target)); }
+std::string_view target_label(Target target) { return target_labels.at(static_cast<std::size_t>(target)); }
+std::string_view button_name(LogicalButton button) { return button_names.at(static_cast<std::size_t>(button)); }
+std::string_view axis_name(LogicalAxis axis) { return axis_names.at(static_cast<std::size_t>(axis)); }
+std::optional<Target> target_from_name(std::string_view name) { return enum_from_name<Target>(name, target_names); }
+std::optional<LogicalButton> button_from_name(std::string_view name) { return enum_from_name<LogicalButton>(name, button_names); }
+std::optional<LogicalAxis> axis_from_name(std::string_view name) { return enum_from_name<LogicalAxis>(name, axis_names); }
+
+std::optional<std::string> canonicalize_guid(std::string_view guid) {
+    if (guid.size() != 32) return std::nullopt;
+    std::string result;
+    result.reserve(guid.size());
+    for (const unsigned char c : guid) {
+        if (!std::isxdigit(c)) return std::nullopt;
+        result.push_back(static_cast<char>(std::tolower(c)));
+    }
+    return result;
+}
+
+std::filesystem::path controls_config_path() {
+    if (const char* override_path = std::getenv("LAMBO_CONTROLS_CONFIG")) return override_path;
+    return lambo::config::app_config_dir() / "controls.json";
+}
+
+LoadResult load_config(const std::filesystem::path& path) {
+    LoadResult result{};
+    if (!std::filesystem::exists(path)) return result;
+    std::ifstream input(path, std::ios::binary);
+    std::ostringstream bytes;
+    bytes << input.rdbuf();
+    const std::string original = bytes.str();
+    json root;
+    try { root = json::parse(original); }
+    catch (const json::exception&) {
+        result.status = LoadStatus::Malformed;
+        result.config.read_only = true;
+        return result;
+    }
+    const auto version = root.find("version");
+    if (version == root.end() || !version->is_number_integer()) {
+        result.status = LoadStatus::InvalidVersion;
+        result.config.read_only = true;
+        return result;
+    }
+    std::int64_t version_number{};
+    try { version_number = version->get<std::int64_t>(); }
+    catch (const json::exception&) {
+        result.status = LoadStatus::InvalidVersion;
+        result.config.read_only = true;
+        return result;
+    }
+    if (version_number != 1) {
+        result.status = version_number > 1 ? LoadStatus::FutureVersion : LoadStatus::InvalidVersion;
+        result.config.read_only = true;
+        return result;
+    }
+    result.status = LoadStatus::Loaded;
+    result.config.preserved_document = original;
+    if (const auto preferred = root.find("preferred_controller_guid");
+        preferred != root.end() && preferred->is_string()) {
+        if (auto guid = canonicalize_guid(preferred->get<std::string>())) result.config.preferred_controller_guid = *guid;
+        else result.warnings.emplace_back("ignored invalid preferred controller GUID");
+    }
+    const auto profiles = root.find("profiles");
+    if (profiles == root.end() || !profiles->is_object()) return result;
+    for (const auto& [raw_guid, value] : profiles->items()) {
+        const auto guid = canonicalize_guid(raw_guid);
+        if (!guid || !value.is_object()) {
+            result.warnings.emplace_back("ignored invalid controller profile " + raw_guid);
+            continue;
+        }
+        Profile profile = default_profile();
+        if (const auto digital = value.find("digital"); digital != value.end() && digital->is_object()) {
+            for (std::size_t target = 0; target < digital_target_count; ++target) {
+                const auto bindings = digital->find(std::string(target_names[target]));
+                if (bindings == digital->end()) continue;
+                if (!bindings->is_array()) {
+                    result.warnings.emplace_back("invalid digital target " + std::string(target_names[target]));
+                    continue;
+                }
+                DigitalBindings parsed;
+                for (const auto& binding : *bindings) {
+                    const auto source = parse_source(binding);
+                    if (!source) {
+                        result.warnings.emplace_back("invalid binding for " + std::string(target_names[target]));
+                    } else if (std::find(parsed.begin(), parsed.end(), *source) == parsed.end()) {
+                        parsed.push_back(*source);
+                    } else {
+                        result.warnings.emplace_back("duplicate binding for " + std::string(target_names[target]));
+                    }
+                }
+                profile.digital[target] = std::move(parsed);
+            }
+        }
+        if (const auto analog = value.find("analog"); analog != value.end() && analog->is_object()) {
+            for (std::size_t target = 0; target < analog_target_count; ++target) {
+                const auto binding = analog->find(std::string(target_names[digital_target_count + target]));
+                if (binding == analog->end()) continue;
+                if (const auto parsed = parse_analog(*binding)) profile.analog[target] = *parsed;
+                else result.warnings.emplace_back("invalid analog target " +
+                                                  std::string(target_names[digital_target_count + target]));
+            }
+        }
+        for (std::size_t target = 0; target < digital_target_count; ++target) {
+            for (const auto& source : profile.digital[target]) {
+                if (has_cross_target_duplicate(profile, static_cast<Target>(target), source)) {
+                    result.warnings.emplace_back("binding for " + std::string(target_names[target]) +
+                                                 " is also used by another target");
+                }
+            }
+        }
+        if (profile.analog[0].axis == profile.analog[1].axis) {
+            result.warnings.emplace_back("analog axis is shared by stick_x and stick_y");
+        }
+        result.config.profiles[*guid] = std::move(profile);
+    }
+    return result;
+}
+
+LoadResult load_config() { return load_config(controls_config_path()); }
+
+SaveResult save_config(ControlsConfig& config, const std::filesystem::path& path) {
+    SaveResult result{false, path, {}};
+    if (config.read_only) {
+        result.error = "controls file is read-only because its format could not be loaded";
+        return result;
+    }
+    json root = json::object();
+    if (!config.preserved_document.empty()) {
+        try { root = json::parse(config.preserved_document); }
+        catch (const json::exception&) { root = json::object(); }
+    }
+    root["version"] = 1;
+    root["preferred_controller_guid"] = config.preferred_controller_guid;
+    json& profiles = root["profiles"];
+    if (!profiles.is_object()) profiles = json::object();
+    for (const auto& [guid, profile] : config.profiles) merge_profile(profiles[guid], profile);
+
+    std::error_code ec;
+    if (!path.parent_path().empty()) {
+        std::filesystem::create_directories(path.parent_path(), ec);
+        if (ec) { result.error = ec.message(); return result; }
+    }
+    const std::filesystem::path temporary = path.string() + ".tmp";
+    {
+        std::ofstream output(temporary, std::ios::binary | std::ios::trunc);
+        if (!output) { result.error = "could not open temporary file"; return result; }
+        output << root.dump(2) << '\n';
+        output.flush();
+        if (!output) { result.error = "could not flush temporary file"; output.close(); std::filesystem::remove(temporary, ec); return result; }
+    }
+    if (!atomic_replace(temporary, path, result.error)) {
+        std::filesystem::remove(temporary, ec);
+        return result;
+    }
+    result.saved = true;
+    config.preserved_document = root.dump(2) + '\n';
+    return result;
+}
+
+SaveResult save_config(ControlsConfig& config) { return save_config(config, controls_config_path()); }
+
+Profile& profile_for_guid(ControlsConfig& config, std::string_view canonical_guid) {
+    auto [entry, inserted] = config.profiles.try_emplace(std::string(canonical_guid));
+    if (inserted) entry->second = default_profile();
+    return entry->second;
+}
+
+const Profile& profile_for_guid(const ControlsConfig& config, std::string_view canonical_guid) {
+    const auto found = config.profiles.find(std::string(canonical_guid));
+    if (found != config.profiles.end()) return found->second;
+    static const Profile defaults = default_profile();
+    return defaults;
+}
+
+bool has_cross_target_duplicate(const Profile& profile, Target target,
+                                const DigitalSource& source) {
+    for (std::size_t index = 0; index < digital_target_count; ++index) {
+        if (index == digital_index(target)) continue;
+        if (std::find(profile.digital[index].begin(), profile.digital[index].end(), source) !=
+            profile.digital[index].end()) return true;
+    }
+    return false;
+}
+
+void Capture::begin(Target target, std::int32_t controller_instance) {
+    reset();
+    target_ = target;
+    controller_instance_ = controller_instance;
+    phase_ = CapturePhase::WaitingForNeutral;
+}
+
+CaptureResult Capture::cancel() {
+    if (!active()) return CaptureResult::None;
+    reset();
+    return CaptureResult::Cancelled;
+}
+
+CaptureResult Capture::button_event(std::int32_t controller_instance,
+                                    LogicalButton button, bool pressed) {
+    if (!active()) return CaptureResult::None;
+    if (controller_instance != controller_instance_) return CaptureResult::None;
+    if (pressed && button == LogicalButton::Back) return cancel();
+    if (phase_ != CapturePhase::Listening || !pressed ||
+        !target_.has_value() || static_cast<std::size_t>(*target_) >= digital_target_count) {
+        return CaptureResult::None;
+    }
+    candidate_ = DigitalSource{ButtonSource{button}};
+    neutral_samples_ = 0;
+    phase_ = CapturePhase::WaitingForRelease;
+    return CaptureResult::None;
+}
+
+CaptureResult Capture::axis_event(std::int32_t controller_instance,
+                                  LogicalAxis axis, std::int16_t value) {
+    if (!active()) return CaptureResult::None;
+    if (controller_instance != controller_instance_ || phase_ != CapturePhase::Listening ||
+        std::abs(static_cast<std::int32_t>(value)) < activation_threshold || !target_) {
+        return CaptureResult::None;
+    }
+    if (static_cast<std::size_t>(*target_) < digital_target_count) {
+        const std::int16_t threshold = axis == LogicalAxis::TriggerLeft || axis == LogicalAxis::TriggerRight
+            ? 8000 : 12000;
+        candidate_ = DigitalSource{AxisHalfSource{
+            axis, value > 0 ? AxisDirection::Positive : AxisDirection::Negative, threshold}};
+    } else {
+        candidate_ = AnalogSource{axis, *target_ == Target::StickY, 8000};
+    }
+    neutral_samples_ = 0;
+    phase_ = CapturePhase::WaitingForRelease;
+    return CaptureResult::None;
+}
+
+bool Capture::all_neutral(const RawState& state) const {
+    return std::none_of(state.buttons.begin(), state.buttons.end(), [](bool pressed) { return pressed; }) &&
+           std::all_of(state.axes.begin(), state.axes.end(), [](std::int16_t value) {
+               return std::abs(static_cast<std::int32_t>(value)) <= neutral_threshold;
+           });
+}
+
+CaptureResult Capture::sample(const RawState& state, Profile& profile) {
+    if (phase_ != CapturePhase::WaitingForNeutral && phase_ != CapturePhase::WaitingForRelease) {
+        return CaptureResult::None;
+    }
+    if (!all_neutral(state)) {
+        neutral_samples_ = 0;
+        return CaptureResult::None;
+    }
+    if (++neutral_samples_ < 2) return CaptureResult::None;
+    neutral_samples_ = 0;
+    if (phase_ == CapturePhase::WaitingForNeutral) {
+        phase_ = CapturePhase::Listening;
+        return CaptureResult::None;
+    }
+    return finish_candidate(profile);
+}
+
+CaptureResult Capture::finish_candidate(Profile& profile) {
+    if (!target_ || !candidate_) return cancel();
+    const std::size_t index = static_cast<std::size_t>(*target_);
+    if (index < digital_target_count) {
+        const auto& source = std::get<DigitalSource>(*candidate_);
+        const auto& target_bindings = profile.digital[index];
+        if (std::find(target_bindings.begin(), target_bindings.end(), source) != target_bindings.end()) {
+            reset();
+            return CaptureResult::Noop;
+        }
+        if (has_cross_target_duplicate(profile, *target_, source)) {
+            phase_ = CapturePhase::Conflict;
+            return CaptureResult::Conflict;
+        }
+    } else {
+        const auto& source = std::get<AnalogSource>(*candidate_);
+        const std::size_t analog = index - digital_target_count;
+        if (profile.analog[analog] == source) {
+            reset();
+            return CaptureResult::Noop;
+        }
+        for (std::size_t other = 0; other < analog_target_count; ++other) {
+            if (other != analog && profile.analog[other].axis == source.axis) {
+                phase_ = CapturePhase::Conflict;
+                return CaptureResult::Conflict;
+            }
+        }
+    }
+    return commit(profile);
+}
+
+CaptureResult Capture::commit(Profile& profile) {
+    const std::size_t index = static_cast<std::size_t>(*target_);
+    if (index < digital_target_count) {
+        profile.digital[index].push_back(std::get<DigitalSource>(*candidate_));
+    } else {
+        profile.analog[index - digital_target_count] = std::get<AnalogSource>(*candidate_);
+    }
+    reset();
+    return CaptureResult::Committed;
+}
+
+CaptureResult Capture::accept_conflict(Profile& profile) {
+    if (phase_ != CapturePhase::Conflict || !candidate_ || !target_) return CaptureResult::None;
+    return commit(profile);
+}
+
+CaptureResult Capture::reject_conflict() {
+    if (phase_ != CapturePhase::Conflict) return CaptureResult::None;
+    reset();
+    return CaptureResult::Cancelled;
+}
+
+void Capture::reset() {
+    phase_ = CapturePhase::Idle;
+    target_.reset();
+    controller_instance_ = 0;
+    neutral_samples_ = 0;
+    candidate_.reset();
+}
+
+void enqueue_command(Command command) {
+    std::lock_guard lock(command_mutex);
+    command_queue.push_back(std::move(command));
+}
+
+std::vector<Command> take_commands() {
+    std::lock_guard lock(command_mutex);
+    std::vector<Command> result;
+    result.reserve(command_queue.size());
+    while (!command_queue.empty()) {
+        result.push_back(std::move(command_queue.front()));
+        command_queue.pop_front();
+    }
+    return result;
+}
+
+void publish_ui_snapshot(UiSnapshot snapshot) {
+    std::lock_guard lock(snapshot_mutex);
+    published_snapshot = std::move(snapshot);
+}
+
+UiSnapshot ui_snapshot() {
+    std::lock_guard lock(snapshot_mutex);
+    return published_snapshot;
+}
+
+} // namespace lambo::controls

--- a/src/controls/lambo_controls.h
+++ b/src/controls/lambo_controls.h
@@ -1,0 +1,218 @@
+#ifndef LAMBO_CONTROLS_H
+#define LAMBO_CONTROLS_H
+
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <deque>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+namespace lambo::controls {
+
+enum class Target {
+    A, B, Z, Start, L, R,
+    DpadUp, DpadDown, DpadLeft, DpadRight,
+    CUp, CDown, CLeft, CRight,
+    StickX, StickY,
+    Count,
+};
+
+enum class LogicalButton {
+    A, B, X, Y, Back, Guide, Start, LeftStick, RightStick,
+    LeftShoulder, RightShoulder, DpadUp, DpadDown, DpadLeft, DpadRight,
+    Count,
+};
+
+enum class LogicalAxis {
+    LeftX, LeftY, RightX, RightY, TriggerLeft, TriggerRight, Count,
+};
+
+enum class AxisDirection { Negative, Positive };
+
+struct ButtonSource {
+    LogicalButton button{};
+    bool operator==(const ButtonSource&) const = default;
+};
+
+struct AxisHalfSource {
+    LogicalAxis axis{};
+    AxisDirection direction{};
+    std::int16_t threshold{};
+    bool operator==(const AxisHalfSource&) const = default;
+};
+
+struct AnalogSource {
+    LogicalAxis axis{};
+    bool invert{};
+    std::int16_t deadzone{};
+    bool operator==(const AnalogSource&) const = default;
+};
+
+using DigitalSource = std::variant<ButtonSource, AxisHalfSource>;
+using DigitalBindings = std::vector<DigitalSource>;
+
+constexpr std::size_t digital_target_count = 14;
+constexpr std::size_t analog_target_count = 2;
+
+struct Profile {
+    std::array<DigitalBindings, digital_target_count> digital;
+    std::array<AnalogSource, analog_target_count> analog;
+    bool operator==(const Profile&) const = default;
+};
+
+struct RawState {
+    std::array<bool, static_cast<std::size_t>(LogicalButton::Count)> buttons{};
+    std::array<std::int16_t, static_cast<std::size_t>(LogicalAxis::Count)> axes{};
+};
+
+struct EvaluatedState {
+    std::uint16_t buttons{};
+    std::int8_t stick_x{};
+    std::int8_t stick_y{};
+    bool operator==(const EvaluatedState&) const = default;
+};
+
+Profile default_profile();
+EvaluatedState evaluate(const Profile& profile, const RawState& state);
+std::uint32_t pack(const EvaluatedState& state);
+
+std::string_view target_name(Target target);
+std::string_view target_label(Target target);
+std::string_view button_name(LogicalButton button);
+std::string_view axis_name(LogicalAxis axis);
+std::optional<Target> target_from_name(std::string_view name);
+std::optional<LogicalButton> button_from_name(std::string_view name);
+std::optional<LogicalAxis> axis_from_name(std::string_view name);
+std::optional<std::string> canonicalize_guid(std::string_view guid);
+
+struct ControlsConfig {
+    std::string preferred_controller_guid;
+    std::unordered_map<std::string, Profile> profiles;
+    // The valid v1 source document is retained and merged on save so fields added by
+    // newer tools or other builds survive a round trip.
+    std::string preserved_document;
+    bool read_only{};
+};
+
+enum class LoadStatus { Missing, Loaded, Malformed, InvalidVersion, FutureVersion };
+
+struct LoadResult {
+    ControlsConfig config;
+    LoadStatus status{LoadStatus::Missing};
+    std::vector<std::string> warnings;
+};
+
+struct SaveResult {
+    bool saved{};
+    std::filesystem::path path;
+    std::string error;
+};
+
+std::filesystem::path controls_config_path();
+LoadResult load_config(const std::filesystem::path& path);
+LoadResult load_config();
+SaveResult save_config(ControlsConfig& config, const std::filesystem::path& path);
+SaveResult save_config(ControlsConfig& config);
+
+Profile& profile_for_guid(ControlsConfig& config, std::string_view canonical_guid);
+const Profile& profile_for_guid(const ControlsConfig& config, std::string_view canonical_guid);
+bool has_cross_target_duplicate(const Profile& profile, Target target,
+                                const DigitalSource& source);
+
+enum class CapturePhase {
+    Idle, WaitingForNeutral, Listening, WaitingForRelease, Conflict,
+};
+enum class CaptureResult { None, Committed, Noop, Conflict, Cancelled };
+
+class Capture {
+public:
+    static constexpr std::int16_t activation_threshold = 16000;
+    static constexpr std::int16_t neutral_threshold = 8000;
+
+    void begin(Target target, std::int32_t controller_instance);
+    CaptureResult cancel();
+    // Active capture consumes every controller button/axis event. Events from a
+    // different instance are consumed but cannot become candidates.
+    CaptureResult button_event(std::int32_t controller_instance, LogicalButton button,
+                               bool pressed);
+    CaptureResult axis_event(std::int32_t controller_instance, LogicalAxis axis,
+                             std::int16_t value);
+    CaptureResult sample(const RawState& selected_controller_state, Profile& profile);
+    CaptureResult accept_conflict(Profile& profile);
+    CaptureResult reject_conflict();
+
+    bool active() const { return phase_ != CapturePhase::Idle; }
+    CapturePhase phase() const { return phase_; }
+    std::optional<Target> target() const { return target_; }
+    const std::optional<std::variant<DigitalSource, AnalogSource>>& candidate() const {
+        return candidate_;
+    }
+
+private:
+    bool all_neutral(const RawState& state) const;
+    CaptureResult finish_candidate(Profile& profile);
+    CaptureResult commit(Profile& profile);
+    void reset();
+
+    CapturePhase phase_{CapturePhase::Idle};
+    std::optional<Target> target_;
+    std::int32_t controller_instance_{};
+    int neutral_samples_{};
+    std::optional<std::variant<DigitalSource, AnalogSource>> candidate_;
+};
+
+enum class ControllerLayout { Xbox, PlayStation, Nintendo, Generic };
+
+struct ControllerInfo {
+    std::int32_t instance{};
+    std::string guid;
+    std::string name;
+    ControllerLayout layout{ControllerLayout::Generic};
+    bool active{};
+};
+
+enum class CommandKind {
+    Select, Add, Remove, Threshold, Deadzone, Invert, ResetTarget,
+    ResetProfile, ConflictAccept, CaptureCancel,
+};
+
+struct Command {
+    CommandKind kind{};
+    Target target{};
+    std::int32_t instance{};
+    std::size_t binding_index{};
+    int value{};
+};
+
+struct UiSnapshot {
+    std::vector<ControllerInfo> controllers;
+    std::optional<std::int32_t> selected_instance;
+    std::string selected_guid;
+    Profile profile{default_profile()};
+    RawState raw;
+    EvaluatedState evaluated;
+    CapturePhase capture_phase{CapturePhase::Idle};
+    std::optional<Target> capture_target;
+    std::uint64_t config_revision{};
+    std::uint64_t sample_revision{};
+    bool read_only{};
+    bool saved{};
+    std::filesystem::path config_path;
+    std::string status;
+    std::vector<std::string> warnings;
+};
+
+void enqueue_command(Command command);
+std::vector<Command> take_commands();
+void publish_ui_snapshot(UiSnapshot snapshot);
+UiSnapshot ui_snapshot();
+
+} // namespace lambo::controls
+
+#endif

--- a/src/controls/lambo_controls_sdl.cpp
+++ b/src/controls/lambo_controls_sdl.cpp
@@ -1,0 +1,398 @@
+#include "lambo_controls_sdl.h"
+
+#include <algorithm>
+#include <array>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <SDL.h>
+
+#include "lambo_log.h"
+
+namespace {
+
+using namespace lambo::controls;
+
+std::optional<LogicalButton> logical_button(std::uint8_t button) {
+    switch (button) {
+        case SDL_CONTROLLER_BUTTON_A: return LogicalButton::A;
+        case SDL_CONTROLLER_BUTTON_B: return LogicalButton::B;
+        case SDL_CONTROLLER_BUTTON_X: return LogicalButton::X;
+        case SDL_CONTROLLER_BUTTON_Y: return LogicalButton::Y;
+        case SDL_CONTROLLER_BUTTON_BACK: return LogicalButton::Back;
+        case SDL_CONTROLLER_BUTTON_GUIDE: return LogicalButton::Guide;
+        case SDL_CONTROLLER_BUTTON_START: return LogicalButton::Start;
+        case SDL_CONTROLLER_BUTTON_LEFTSTICK: return LogicalButton::LeftStick;
+        case SDL_CONTROLLER_BUTTON_RIGHTSTICK: return LogicalButton::RightStick;
+        case SDL_CONTROLLER_BUTTON_LEFTSHOULDER: return LogicalButton::LeftShoulder;
+        case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: return LogicalButton::RightShoulder;
+        case SDL_CONTROLLER_BUTTON_DPAD_UP: return LogicalButton::DpadUp;
+        case SDL_CONTROLLER_BUTTON_DPAD_DOWN: return LogicalButton::DpadDown;
+        case SDL_CONTROLLER_BUTTON_DPAD_LEFT: return LogicalButton::DpadLeft;
+        case SDL_CONTROLLER_BUTTON_DPAD_RIGHT: return LogicalButton::DpadRight;
+        default: return std::nullopt;
+    }
+}
+
+std::optional<LogicalAxis> logical_axis(std::uint8_t axis) {
+    switch (axis) {
+        case SDL_CONTROLLER_AXIS_LEFTX: return LogicalAxis::LeftX;
+        case SDL_CONTROLLER_AXIS_LEFTY: return LogicalAxis::LeftY;
+        case SDL_CONTROLLER_AXIS_RIGHTX: return LogicalAxis::RightX;
+        case SDL_CONTROLLER_AXIS_RIGHTY: return LogicalAxis::RightY;
+        case SDL_CONTROLLER_AXIS_TRIGGERLEFT: return LogicalAxis::TriggerLeft;
+        case SDL_CONTROLLER_AXIS_TRIGGERRIGHT: return LogicalAxis::TriggerRight;
+        default: return std::nullopt;
+    }
+}
+
+ControllerLayout controller_layout(SDL_GameController* controller) {
+    switch (SDL_GameControllerGetType(controller)) {
+        case SDL_CONTROLLER_TYPE_XBOX360:
+        case SDL_CONTROLLER_TYPE_XBOXONE: return ControllerLayout::Xbox;
+        case SDL_CONTROLLER_TYPE_PS3:
+        case SDL_CONTROLLER_TYPE_PS4:
+        case SDL_CONTROLLER_TYPE_PS5: return ControllerLayout::PlayStation;
+        case SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_PRO: return ControllerLayout::Nintendo;
+        default: return ControllerLayout::Generic;
+    }
+}
+
+std::string controller_guid(SDL_GameController* controller) {
+    char text[33]{};
+    SDL_Joystick* joystick = SDL_GameControllerGetJoystick(controller);
+    SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(joystick), text, sizeof(text));
+    const auto canonical = canonicalize_guid(text);
+    return canonical.value_or(std::string{});
+}
+
+} // namespace
+
+namespace lambo::controls {
+
+struct SdlAdapter::Impl {
+    struct Device {
+        SDL_GameController* handle{};
+        std::int32_t instance{};
+        std::string guid;
+        std::string name;
+        ControllerLayout layout{ControllerLayout::Generic};
+    };
+
+    ControlsConfig config;
+    std::vector<std::string> warnings;
+    std::vector<Device> devices;
+    std::optional<std::int32_t> selected;
+    Capture capture;
+    RawState raw;
+    EvaluatedState evaluated;
+    std::uint64_t config_revision{1};
+    std::uint64_t sample_revision{};
+    bool saved{};
+    std::string status;
+    bool rumble_on{};
+
+    Profile fallback_profile{default_profile()};
+    Device* selected_device() {
+        if (!selected) return nullptr;
+        auto found = std::find_if(devices.begin(), devices.end(),
+            [&](const Device& device) { return device.instance == *selected; });
+        return found == devices.end() ? nullptr : &*found;
+    }
+    const Device* selected_device() const {
+        return const_cast<Impl*>(this)->selected_device();
+    }
+    Profile& selected_profile() {
+        Device* device = selected_device();
+        return device ? profile_for_guid(config, device->guid) : fallback_profile;
+    }
+    void stop_rumble() {
+        if (Device* device = selected_device(); device && device->handle) {
+            SDL_GameControllerRumble(device->handle, 0, 0, 0);
+        }
+        rumble_on = false;
+    }
+    void choose(std::optional<std::int32_t> instance, bool persist) {
+        if (selected == instance) return;
+        stop_rumble();
+        capture.cancel();
+        selected = instance;
+        if (Device* device = selected_device()) {
+            profile_for_guid(config, device->guid);
+            if (persist) {
+                config.preferred_controller_guid = device->guid;
+                save();
+            }
+        }
+        ++config_revision;
+    }
+    void choose_startup() {
+        if (selected_device()) return;
+        auto preferred = std::find_if(devices.begin(), devices.end(), [&](const Device& device) {
+            return !config.preferred_controller_guid.empty() && device.guid == config.preferred_controller_guid;
+        });
+        choose(preferred != devices.end() ? std::optional{preferred->instance} :
+               devices.empty() ? std::nullopt : std::optional{devices.front().instance}, false);
+    }
+    void save() {
+        const SaveResult result = save_config(config);
+        saved = result.saved;
+        status = result.saved ? "Saved" : "Save failed: " + result.error + " (" + result.path.string() + ")";
+    }
+    void mutation_finished() {
+        ++config_revision;
+        save();
+    }
+    void publish() {
+        UiSnapshot snapshot{};
+        snapshot.selected_instance = selected;
+        if (const Device* selected_ptr = selected_device()) snapshot.selected_guid = selected_ptr->guid;
+        snapshot.profile = selected_device() ? profile_for_guid(config, snapshot.selected_guid) : default_profile();
+        snapshot.raw = raw;
+        snapshot.evaluated = evaluated;
+        snapshot.capture_phase = capture.phase();
+        snapshot.capture_target = capture.target();
+        snapshot.config_revision = config_revision;
+        snapshot.sample_revision = sample_revision;
+        snapshot.read_only = config.read_only;
+        snapshot.saved = saved;
+        snapshot.config_path = controls_config_path();
+        snapshot.status = status;
+        snapshot.warnings = warnings;
+        bool duplicate = false;
+        for (std::size_t target = 0; target < digital_target_count && !duplicate; ++target) {
+            for (const auto& source : snapshot.profile.digital[target]) {
+                if (has_cross_target_duplicate(snapshot.profile, static_cast<Target>(target), source)) {
+                    duplicate = true;
+                    break;
+                }
+            }
+        }
+        duplicate = duplicate || snapshot.profile.analog[0].axis == snapshot.profile.analog[1].axis;
+        if (duplicate) snapshot.warnings.emplace_back(
+            "One or more controller sources are intentionally assigned to multiple N64 targets.");
+        for (const auto& device : devices) {
+            snapshot.controllers.push_back({device.instance, device.guid, device.name, device.layout,
+                                            selected && device.instance == *selected});
+        }
+        publish_ui_snapshot(std::move(snapshot));
+    }
+};
+
+SdlAdapter::SdlAdapter() : impl_(std::make_unique<Impl>()) {
+    LoadResult loaded = load_config();
+    impl_->config = std::move(loaded.config);
+    impl_->warnings = std::move(loaded.warnings);
+    switch (loaded.status) {
+        case LoadStatus::Missing: impl_->status = "Defaults (not saved yet)"; break;
+        case LoadStatus::Loaded: impl_->status = "Loaded"; impl_->saved = true; break;
+        case LoadStatus::Malformed: impl_->status = "Read-only: malformed controls.json"; break;
+        case LoadStatus::InvalidVersion: impl_->status = "Read-only: invalid controls.json version"; break;
+        case LoadStatus::FutureVersion: impl_->status = "Read-only: controls.json is from a newer version"; break;
+    }
+    impl_->publish();
+}
+
+SdlAdapter::~SdlAdapter() { shutdown(); }
+
+void SdlAdapter::open_existing() {
+    for (int index = 0; index < SDL_NumJoysticks(); ++index) device_added(index);
+    auto preferred = std::find_if(impl_->devices.begin(), impl_->devices.end(), [&](const Impl::Device& device) {
+        return !impl_->config.preferred_controller_guid.empty() &&
+               device.guid == impl_->config.preferred_controller_guid;
+    });
+    if (preferred != impl_->devices.end()) impl_->choose(preferred->instance, false);
+    else impl_->choose_startup();
+    impl_->publish();
+}
+
+void SdlAdapter::device_added(int joystick_index) {
+    if (!SDL_IsGameController(joystick_index)) return;
+    SDL_GameController* handle = SDL_GameControllerOpen(joystick_index);
+    if (!handle) return;
+    SDL_Joystick* joystick = SDL_GameControllerGetJoystick(handle);
+    const std::int32_t instance = SDL_JoystickInstanceID(joystick);
+    if (std::any_of(impl_->devices.begin(), impl_->devices.end(),
+                    [&](const Impl::Device& device) { return device.instance == instance; })) {
+        SDL_GameControllerClose(handle);
+        return;
+    }
+    const char* name = SDL_GameControllerName(handle);
+    impl_->devices.push_back({handle, instance, controller_guid(handle),
+                              name ? name : "Unknown controller", controller_layout(handle)});
+    LAMBO_LOG("input", "controller connected: %s (%s, instance %d)\n",
+              impl_->devices.back().name.c_str(), impl_->devices.back().guid.c_str(), int(instance));
+    impl_->choose_startup();
+    ++impl_->config_revision;
+    impl_->publish();
+}
+
+void SdlAdapter::device_removed(std::int32_t instance) {
+    auto found = std::find_if(impl_->devices.begin(), impl_->devices.end(),
+        [&](const Impl::Device& device) { return device.instance == instance; });
+    if (found == impl_->devices.end()) return;
+    const bool was_selected = impl_->selected && *impl_->selected == instance;
+    if (was_selected) { impl_->stop_rumble(); impl_->capture.cancel(); impl_->selected.reset(); }
+    SDL_GameControllerClose(found->handle);
+    impl_->devices.erase(found);
+    if (was_selected && !impl_->devices.empty()) impl_->choose(impl_->devices.front().instance, false);
+    ++impl_->config_revision;
+    impl_->publish();
+}
+
+bool SdlAdapter::handle_capture_event(const SDL_Event& event) {
+    if (!impl_->capture.active()) return false;
+    if (impl_->capture.phase() == CapturePhase::Conflict) {
+        const bool keyboard_cancel = event.type == SDL_KEYDOWN && !event.key.repeat &&
+                                     event.key.keysym.sym == SDLK_ESCAPE;
+        const bool controller_cancel = event.type == SDL_CONTROLLERBUTTONDOWN &&
+            (event.cbutton.button == SDL_CONTROLLER_BUTTON_B ||
+             event.cbutton.button == SDL_CONTROLLER_BUTTON_BACK);
+        if (keyboard_cancel || controller_cancel) {
+            impl_->capture.reject_conflict(); ++impl_->config_revision; impl_->publish();
+            return true;
+        }
+        return false;
+    }
+    if (event.type == SDL_KEYDOWN && !event.key.repeat && event.key.keysym.sym == SDLK_ESCAPE) {
+        impl_->capture.cancel(); ++impl_->config_revision; impl_->publish(); return true;
+    }
+    if (event.type == SDL_CONTROLLERBUTTONDOWN || event.type == SDL_CONTROLLERBUTTONUP) {
+        const CapturePhase before = impl_->capture.phase();
+        if (const auto button = logical_button(event.cbutton.button)) {
+            impl_->capture.button_event(event.cbutton.which, *button,
+                event.type == SDL_CONTROLLERBUTTONDOWN);
+        }
+        if (impl_->capture.phase() != before) ++impl_->config_revision;
+        impl_->publish();
+        return true;
+    }
+    if (event.type == SDL_CONTROLLERAXISMOTION) {
+        const CapturePhase before = impl_->capture.phase();
+        if (const auto axis = logical_axis(event.caxis.axis)) {
+            impl_->capture.axis_event(event.caxis.which, *axis, event.caxis.value);
+        }
+        if (impl_->capture.phase() != before) ++impl_->config_revision;
+        impl_->publish();
+        return true;
+    }
+    return event.type == SDL_KEYUP;
+}
+
+void SdlAdapter::process_commands() {
+    for (const Command& command : take_commands()) {
+        if (command.kind == CommandKind::CaptureCancel) { impl_->capture.cancel(); ++impl_->config_revision; continue; }
+        if (command.kind == CommandKind::Select) {
+            const bool exists = std::any_of(impl_->devices.begin(), impl_->devices.end(),
+                [&](const Impl::Device& device) { return device.instance == command.instance; });
+            if (exists) impl_->choose(command.instance, true);
+            continue;
+        }
+        if (!impl_->selected_device() || impl_->config.read_only) continue;
+        Profile& profile = impl_->selected_profile();
+        const std::size_t target = static_cast<std::size_t>(command.target);
+        bool changed = false;
+        switch (command.kind) {
+            case CommandKind::Add:
+                impl_->capture.begin(command.target, *impl_->selected); ++impl_->config_revision; break;
+            case CommandKind::Remove:
+                if (target < digital_target_count && command.binding_index < profile.digital[target].size()) {
+                    profile.digital[target].erase(profile.digital[target].begin() + command.binding_index); changed = true;
+                } break;
+            case CommandKind::Threshold:
+                if (target < digital_target_count && command.binding_index < profile.digital[target].size()) {
+                    if (auto* half = std::get_if<AxisHalfSource>(&profile.digital[target][command.binding_index])) {
+                        half->threshold = static_cast<std::int16_t>(std::clamp(command.value, 0, 32767)); changed = true;
+                    }
+                } break;
+            case CommandKind::Deadzone:
+                if (target >= digital_target_count && target < static_cast<std::size_t>(Target::Count)) {
+                    profile.analog[target - digital_target_count].deadzone =
+                        static_cast<std::int16_t>(std::clamp(command.value, 0, 32767)); changed = true;
+                } break;
+            case CommandKind::Invert:
+                if (target >= digital_target_count && target < static_cast<std::size_t>(Target::Count)) {
+                    auto& source = profile.analog[target - digital_target_count]; source.invert = !source.invert; changed = true;
+                } break;
+            case CommandKind::ResetTarget: {
+                const Profile defaults = default_profile();
+                if (target < digital_target_count) profile.digital[target] = defaults.digital[target];
+                else if (target < static_cast<std::size_t>(Target::Count)) profile.analog[target - digital_target_count] = defaults.analog[target - digital_target_count];
+                changed = true; break;
+            }
+            case CommandKind::ResetProfile: profile = default_profile(); changed = true; break;
+            case CommandKind::ConflictAccept:
+                changed = impl_->capture.accept_conflict(profile) == CaptureResult::Committed; break;
+            case CommandKind::Select: case CommandKind::CaptureCancel: break;
+        }
+        if (changed) impl_->mutation_finished();
+    }
+    impl_->publish();
+}
+
+EvaluatedState SdlAdapter::sample() {
+    impl_->raw = {};
+    if (Impl::Device* device = impl_->selected_device(); device &&
+        SDL_GameControllerGetAttached(device->handle)) {
+        for (int button = 0; button < SDL_CONTROLLER_BUTTON_MAX; ++button) {
+            if (const auto logical = logical_button(static_cast<std::uint8_t>(button))) {
+                impl_->raw.buttons[static_cast<std::size_t>(*logical)] =
+                    SDL_GameControllerGetButton(device->handle, static_cast<SDL_GameControllerButton>(button)) != 0;
+            }
+        }
+        for (int axis = 0; axis < SDL_CONTROLLER_AXIS_MAX; ++axis) {
+            if (const auto logical = logical_axis(static_cast<std::uint8_t>(axis))) {
+                impl_->raw.axes[static_cast<std::size_t>(*logical)] =
+                    SDL_GameControllerGetAxis(device->handle, static_cast<SDL_GameControllerAxis>(axis));
+            }
+        }
+        const CapturePhase before = impl_->capture.phase();
+        const CaptureResult result = impl_->capture.sample(impl_->raw, impl_->selected_profile());
+        if (result == CaptureResult::Committed) impl_->mutation_finished();
+        else if (result == CaptureResult::Noop || result == CaptureResult::Conflict) ++impl_->config_revision;
+        else if (impl_->capture.phase() != before) ++impl_->config_revision;
+        impl_->evaluated = evaluate(impl_->selected_profile(), impl_->raw);
+    } else {
+        impl_->evaluated = {};
+    }
+    ++impl_->sample_revision;
+    if (impl_->capture.phase() != CapturePhase::Idle ||
+        (impl_->selected && impl_->config_revision != 0)) {
+        impl_->publish();
+    }
+    return impl_->evaluated;
+}
+
+void SdlAdapter::apply_rumble(bool on) {
+    Impl::Device* device = impl_->selected_device();
+    if (!device || !SDL_GameControllerGetAttached(device->handle)) { impl_->rumble_on = false; return; }
+    if (on) SDL_GameControllerRumble(device->handle, 0xFFFF, 0xFFFF, 150);
+    else if (impl_->rumble_on) SDL_GameControllerRumble(device->handle, 0, 0, 0);
+    impl_->rumble_on = on;
+}
+
+bool SdlAdapter::selected_back_pressed(const SDL_Event& event) const {
+    if (event.type != SDL_CONTROLLERBUTTONDOWN || event.cbutton.state != SDL_PRESSED ||
+        !impl_->selected || event.cbutton.which != *impl_->selected) {
+        return false;
+    }
+    const auto btn = event.cbutton.button;
+    return btn == SDL_CONTROLLER_BUTTON_BACK ||
+           btn == SDL_CONTROLLER_BUTTON_START ||
+           btn == SDL_CONTROLLER_BUTTON_GUIDE;
+}
+
+void SdlAdapter::cancel_capture() { impl_->capture.cancel(); ++impl_->config_revision; impl_->publish(); }
+
+void SdlAdapter::shutdown() {
+    if (!impl_) return;
+    impl_->capture.cancel();
+    impl_->stop_rumble();
+    for (auto& device : impl_->devices) SDL_GameControllerClose(device.handle);
+    impl_->devices.clear();
+    impl_->selected.reset();
+    impl_->publish();
+}
+
+} // namespace lambo::controls

--- a/src/controls/lambo_controls_sdl.h
+++ b/src/controls/lambo_controls_sdl.h
@@ -1,0 +1,39 @@
+#ifndef LAMBO_CONTROLS_SDL_H
+#define LAMBO_CONTROLS_SDL_H
+
+#include <cstdint>
+#include <memory>
+
+#include "lambo_controls.h"
+
+union SDL_Event;
+
+namespace lambo::controls {
+
+class SdlAdapter {
+public:
+    SdlAdapter();
+    ~SdlAdapter();
+    SdlAdapter(const SdlAdapter&) = delete;
+    SdlAdapter& operator=(const SdlAdapter&) = delete;
+
+    void open_existing();
+    void device_added(int joystick_index);
+    void device_removed(std::int32_t instance);
+    // Capture handling precedes RmlUi. True means the event is consumed.
+    bool handle_capture_event(const SDL_Event& event);
+    void process_commands();
+    EvaluatedState sample();
+    void apply_rumble(bool on);
+    bool selected_back_pressed(const SDL_Event& event) const;
+    void cancel_capture();
+    void shutdown();
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace lambo::controls
+
+#endif

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -48,6 +48,7 @@ std::atomic_bool g_widescreen_sky_match{true};
 // lose the far scenery entirely. Default-on; the emit still self-gates on the
 // record pointer being non-null, so segments without a scenery DL are unaffected.
 std::atomic_bool g_no_lod{true};
+std::atomic_bool g_show_launcher{false};
 
 // Per-circuit refinement of the global no_lod. Rationale + JSON key in
 // lambo_config.h; see that header for the ship-safe default and the
@@ -130,6 +131,7 @@ nlohmann::json to_json(const ultramodern::renderer::GraphicsConfig& c) {
         {"camera_distance_scale", g_camera_distance_scale.load()},
         {"camera_height_scale", g_camera_height_scale.load()},
         {"camera_fov_add", g_camera_fov_add.load()},
+        {"show_launcher", g_show_launcher.load()},
     };
 }
 
@@ -161,6 +163,7 @@ void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c
     double camera_distance_scale = g_camera_distance_scale.load();
     double camera_height_scale = g_camera_height_scale.load();
     double camera_fov_add = g_camera_fov_add.load();
+    bool show_launcher = g_show_launcher.load();
     from_or_default(j, "widescreen_fog_match", widescreen_fog_match);
     from_or_default(j, "widescreen_sky_match", widescreen_sky_match);
     from_or_default(j, "no_lod", no_lod);
@@ -172,6 +175,7 @@ void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c
     from_or_default(j, "camera_distance_scale", camera_distance_scale);
     from_or_default(j, "camera_height_scale", camera_height_scale);
     from_or_default(j, "camera_fov_add", camera_fov_add);
+    from_or_default(j, "show_launcher", show_launcher);
     g_widescreen_fog_match.store(widescreen_fog_match);
     g_widescreen_sky_match.store(widescreen_sky_match);
     g_no_lod.store(no_lod);
@@ -183,6 +187,7 @@ void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c
     g_camera_distance_scale.store(camera_distance_scale);
     g_camera_height_scale.store(camera_height_scale);
     g_camera_fov_add.store(camera_fov_add);
+    g_show_launcher.store(show_launcher);
     // Sanity-bound the window size: below the N64 framebuffer is useless, above 8K
     // is a typo -- either way SDL_CreateWindow would fail and the port would run
     // permanently headless, so reset to defaults instead.
@@ -531,8 +536,14 @@ void set_camera_fov_add(double v) {
     save_graphics(g_current_graphics);
 }
 
+bool show_launcher() {
+    return g_show_launcher.load();
+}
+
+void set_show_launcher(bool enabled) {
+    g_show_launcher.store(enabled);
+    save_graphics(g_current_graphics);
+}
+
 } // namespace config
 } // namespace lambo
-
-
-

--- a/src/lambo_config.h
+++ b/src/lambo_config.h
@@ -50,6 +50,12 @@ void update_saved_window_mode(ultramodern::renderer::WindowMode wm);
 struct WindowSize { int width; int height; };
 WindowSize window_size();
 
+// Startup launcher gate: false = auto-boot directly into game with in-game
+// configuration overlay available via Menu/Back/Guide/Esc; true = show launcher.
+// graphics.json key "show_launcher" (default false), overridable by LAMBO_LAUNCHER=1/0.
+bool show_launcher();
+void set_show_launcher(bool enabled);
+
 // RT64 texture-replacement paths (issue #9). Both are extra graphics.json string keys
 // (empty = feature off), overridable by env var for headless capture/testing:
 //   texture_pack  / LAMBO_TEXTURE_PACK  -- directory or .rtz to auto-load at startup.

--- a/src/lambo_input_gate.cpp
+++ b/src/lambo_input_gate.cpp
@@ -1,0 +1,63 @@
+#include "lambo_input_gate.h"
+
+#include <atomic>
+
+namespace {
+
+std::atomic<bool> g_ui_capture{false};
+std::atomic<bool> g_release_barrier{false};
+std::atomic<bool> g_release_barrier_sampled{false};
+std::atomic<uint32_t> g_guest_snapshot{0};
+
+} // namespace
+
+namespace lambo::input_gate {
+
+void clear_before_release() {
+    g_guest_snapshot.store(0, std::memory_order_release);
+    g_release_barrier_sampled.store(false, std::memory_order_release);
+    g_release_barrier.store(true, std::memory_order_release);
+}
+
+void set_ui_capture(bool capturing) {
+    const bool was_capturing = g_ui_capture.exchange(capturing, std::memory_order_acq_rel);
+    if (capturing) {
+        g_release_barrier.store(false, std::memory_order_release);
+        g_release_barrier_sampled.store(false, std::memory_order_release);
+        g_guest_snapshot.store(0, std::memory_order_release);
+        return;
+    }
+    if (was_capturing) clear_before_release();
+}
+
+bool guest_input_suppressed() {
+    return g_ui_capture.load(std::memory_order_acquire) ||
+           g_release_barrier.load(std::memory_order_acquire);
+}
+
+void publish_physical_snapshot(uint32_t snapshot) {
+    if (g_ui_capture.load(std::memory_order_acquire)) {
+        g_guest_snapshot.store(0, std::memory_order_release);
+    } else if (g_release_barrier.load(std::memory_order_acquire)) {
+        // Held UI input must not become guest input when the overlay closes. Wait
+        // for a genuinely neutral physical sample, publish that sample as neutral,
+        // then remove the barrier on the next neutral sample. Input resumes only on
+        // a later publish, so every guest read of the release frame remains neutral.
+        if (snapshot != 0) {
+            g_release_barrier_sampled.store(false, std::memory_order_release);
+        } else if (g_release_barrier_sampled.exchange(true, std::memory_order_acq_rel)) {
+            g_release_barrier.store(false, std::memory_order_release);
+        }
+        g_guest_snapshot.store(0, std::memory_order_release);
+    } else {
+        g_guest_snapshot.store(snapshot, std::memory_order_release);
+    }
+}
+
+uint32_t guest_snapshot() {
+    if (g_ui_capture.load(std::memory_order_acquire)) return 0;
+    if (g_release_barrier.load(std::memory_order_acquire)) return 0;
+    return g_guest_snapshot.load(std::memory_order_acquire);
+}
+
+} // namespace lambo::input_gate

--- a/src/lambo_input_gate.h
+++ b/src/lambo_input_gate.h
@@ -1,0 +1,16 @@
+#ifndef LAMBO_INPUT_GATE_H
+#define LAMBO_INPUT_GATE_H
+
+#include <cstdint>
+
+namespace lambo::input_gate {
+
+void set_ui_capture(bool capturing);
+bool guest_input_suppressed();
+void publish_physical_snapshot(uint32_t snapshot);
+uint32_t guest_snapshot();
+void clear_before_release();
+
+} // namespace lambo::input_gate
+
+#endif

--- a/src/lambo_menu.cpp
+++ b/src/lambo_menu.cpp
@@ -9,6 +9,7 @@
 
 #include "lambo_config.h"
 #include "lambo_log.h"
+#include "ui/lambo_ui.h"
 
 #if defined(_WIN32)
 #include <SDL_syswm.h>
@@ -37,6 +38,8 @@ HMENU g_fov_menu = nullptr;
 
 enum Command : UINT {
     CMD_FULLSCREEN = 1000,
+    CMD_SETTINGS,
+    CMD_CONTROLS,
     CMD_QUIT,
 
     CMD_RES_AUTO = 1100,
@@ -240,6 +243,8 @@ void apply_graphics_command(UINT command) {
 void dispatch(UINT command) {
     switch (command) {
         case CMD_FULLSCREEN: lambo::menu::toggle_fullscreen(); break;
+        case CMD_SETTINGS: lambo::ui::open_settings(); break;
+        case CMD_CONTROLS: lambo::ui::open_controls(); break;
         case CMD_QUIT: {
             SDL_Event quit{};
             quit.type = SDL_QUIT;
@@ -297,6 +302,8 @@ void attach(SDL_Window* window) {
     g_menu_bar = CreateMenu();
     HMENU game = g_game_menu = append_submenu(g_menu_bar, "&Game");
     append_item(game, CMD_FULLSCREEN, "&Fullscreen\tF11");
+    append_item(game, CMD_SETTINGS, "&Settings...");
+    append_item(game, CMD_CONTROLS, "&Controls...");
     AppendMenuA(game, MF_SEPARATOR, 0, nullptr);
     append_item(game, CMD_QUIT, "E&xit");
 
@@ -418,8 +425,3 @@ void toggle_fullscreen() {
 } // namespace lambo::menu
 
 #endif
-
-
-
-
-

--- a/src/lambo_menu.h
+++ b/src/lambo_menu.h
@@ -6,9 +6,8 @@ struct SDL_Window;
 
 namespace lambo::menu {
 
-// Attach the lightweight native application menu where the platform supports it
-// (currently Win32). Other platforms deliberately remain no-op until the port has
-// a renderer-integrated UI layer.
+// Attach the lightweight native quick-access menu where the platform supports it
+// (currently Win32). The cross-platform launcher owns the same settings model.
 void attach(SDL_Window* window);
 bool handle_event(const SDL_Event& event);
 void toggle_fullscreen();

--- a/src/lambo_startup.cpp
+++ b/src/lambo_startup.cpp
@@ -1,0 +1,91 @@
+#include "lambo_startup.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <string>
+#include <utility>
+
+namespace {
+
+bool env_has_value(const char* name) {
+    const char* value = std::getenv(name);
+    return value != nullptr && value[0] != '\0';
+}
+
+bool env_enabled(const char* name) {
+    const char* value = std::getenv(name);
+    if (value == nullptr || value[0] == '\0') return false;
+    std::string normalized(value);
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return normalized != "0" && normalized != "false" && normalized != "no" &&
+           normalized != "off";
+}
+
+} // namespace
+
+namespace lambo {
+
+StartupMode startup_mode_from_environment() {
+    // 1. Explicit env var override wins (for tests / CLI).
+    if (std::getenv("LAMBO_LAUNCHER") != nullptr) {
+        return env_enabled("LAMBO_LAUNCHER") ? StartupMode::InteractiveLauncher : StartupMode::Automatic;
+    }
+    // 2. Default is direct auto-boot straight into gameplay.
+    return StartupMode::Automatic;
+}
+
+StartupController::StartupController(StartupMode mode, StartGameAction start_game)
+    : mode_(mode), start_game_(std::move(start_game)) {}
+
+bool StartupController::runtime_ready() {
+    bool expected = false;
+    if (!runtime_ready_.compare_exchange_strong(expected, true,
+                                                std::memory_order_acq_rel)) {
+        return false;
+    }
+
+    if (mode_ == StartupMode::Automatic) {
+        return begin_start();
+    }
+
+    StartupState expected_state = StartupState::WaitingForRuntime;
+    state_.compare_exchange_strong(expected_state, StartupState::WaitingForPlay,
+                                   std::memory_order_acq_rel);
+    return false;
+}
+
+bool StartupController::request_play() {
+    if (mode_ != StartupMode::InteractiveLauncher ||
+        !runtime_ready_.load(std::memory_order_acquire)) {
+        return false;
+    }
+    return begin_start();
+}
+
+bool StartupController::begin_start() {
+    StartupState expected = mode_ == StartupMode::Automatic
+        ? StartupState::WaitingForRuntime
+        : StartupState::WaitingForPlay;
+    if (!state_.compare_exchange_strong(expected, StartupState::Starting,
+                                         std::memory_order_acq_rel)) {
+        return false;
+    }
+
+    if (start_game_) start_game_();
+    state_.store(StartupState::Started, std::memory_order_release);
+    return true;
+}
+
+bool StartupController::request_exit() {
+    state_.store(StartupState::Exiting, std::memory_order_release);
+    return true;
+}
+
+bool StartupController::watchdog_armed() const {
+    return mode_ == StartupMode::Automatic &&
+           state_.load(std::memory_order_acquire) != StartupState::Started;
+}
+
+} // namespace lambo

--- a/src/lambo_startup.h
+++ b/src/lambo_startup.h
@@ -1,0 +1,61 @@
+#ifndef LAMBO_STARTUP_H
+#define LAMBO_STARTUP_H
+
+#include <atomic>
+#include <functional>
+
+namespace lambo {
+
+enum class StartupMode {
+    InteractiveLauncher,
+    Automatic,
+};
+
+enum class StartupState {
+    WaitingForRuntime,
+    WaitingForPlay,
+    Starting,
+    Started,
+    Exiting,
+};
+
+// Keep all environment-driven bypass policy in one place. This is deliberately
+// independent of SDL and the renderer so probe tests can exercise it directly.
+StartupMode startup_mode_from_environment();
+
+class StartupController {
+public:
+    using StartGameAction = std::function<void()>;
+
+    explicit StartupController(StartupMode mode,
+                               StartGameAction start_game = {});
+
+    // Called once the host runtime and its window/render resources are ready.
+    // Returns true when this call initiated automatic startup.
+    bool runtime_ready();
+
+    // Requests the first graphical Play transition. Repeated requests are safe
+    // and return false after startup has begun.
+    bool request_play();
+
+    // Explicit application shutdown, including a launcher quit before the first
+    // VI, is distinct from a failed boot probe.
+    bool request_exit();
+
+    StartupMode mode() const { return mode_; }
+    StartupState state() const { return state_.load(std::memory_order_acquire); }
+    bool runtime_is_ready() const { return runtime_ready_.load(std::memory_order_acquire); }
+    bool watchdog_armed() const;
+
+private:
+    bool begin_start();
+
+    StartupMode mode_;
+    StartGameAction start_game_;
+    std::atomic<StartupState> state_{StartupState::WaitingForRuntime};
+    std::atomic<bool> runtime_ready_{false};
+};
+
+} // namespace lambo
+
+#endif

--- a/src/libultra_stubs.c
+++ b/src/libultra_stubs.c
@@ -505,8 +505,9 @@ void func_8006A7A0(uint8_t* rdram, recomp_context* ctx) {
 void func_8006A8B4(uint8_t* rdram, recomp_context* ctx) {
     uint32_t channel = (uint32_t)ctx->r4;
     uint32_t intensity = (uint32_t)ctx->r5;
+    // ROM body clamps unsigned request to max 0x50 (sltiu at, a1, 0x51).
+    // (A subsequent `and at, a1, 0x08000000` in the ROM is unreachable dead code after the clamp).
     if (intensity >= 0x51u) intensity = 0x50u;
-    if ((intensity & 0x08000000u) != 0) intensity = 0;
     ctx->r5 = intensity;
     if (channel < 4)
         MEM_W(0, (gpr)(int32_t)(0x80110F28u + channel * 4u)) = intensity;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,10 @@
 #include "lambo_gpu_advisory.h"  // issue #109: outdated-driver popup handoff
 #include "lambo_log.h"   
 #include "lambo_menu.h"
+#include "lambo_input_gate.h"
+#include "lambo_startup.h"
+#include "controls/lambo_controls_sdl.h"
+#include "ui/lambo_ui.h"
 // ultramodern's native VI API (events.cpp), used by the promote_vi_context RT64 bridge.
 extern "C" void osViSwapBuffer(uint8_t* rdram, int32_t frameBufPtr);
 extern "C" void osViSetMode(uint8_t* rdram, int32_t mode_);
@@ -112,6 +116,13 @@ static void thread_create_cb(uint8_t*, recomp_context*) {
                  g_swaps.load());
     std::fflush(nullptr);
     std::_Exit(g_first_vi.load() ? 0 : 2);
+}
+
+[[noreturn]] static void application_exit_success() {
+    LAMBO_LOG("probe", "application exit requested; status=success\n");
+    lambo::ui::shutdown();
+    std::fflush(nullptr);
+    std::_Exit(0);
 }
 
 // Set by headless::create_render_context (stub_renderer.cpp) so this retrace hook can reach RDRAM.
@@ -304,13 +315,13 @@ static void message_box_stub(const char* msg) {
 
 // Input (#68) — defined below in the input section; used by the window/pump callbacks above them.
 static void input_sample();
-static void input_open_controller(int joystick_index);
-static void input_close_controller(SDL_JoystickID which);
 static void rumble_apply();  // rumble-pak sink (#69); defined in the input section below
+static std::unique_ptr<lambo::controls::SdlAdapter> g_controls;
 
 // The SDL window, kept for main-thread window ops (fullscreen toggle). SDL window
 // state is owned by THIS thread; the renderer only ever sees the raw handle.
 static SDL_Window* g_sdl_window = nullptr;
+static lambo::StartupController* g_startup_controller = nullptr;
 
 // F11 / Alt+Enter fullscreen toggle (main thread, called from the SDL event loop).
 // SDL owns the window state; the new mode is persisted to graphics.json so the next
@@ -346,7 +357,7 @@ static ultramodern::renderer::WindowHandle create_window_stub(void* /*gfx_data*/
         }
         // Open any controller already connected at launch (ADDED events are also queued, but this
         // covers pads present before the event pump starts).
-        for (int i = 0; i < SDL_NumJoysticks(); i++) input_open_controller(i);
+        if (g_controls != nullptr) g_controls->open_existing();
         uint32_t flags = SDL_WINDOW_RESIZABLE;
 #if defined(__linux__)
         flags |= SDL_WINDOW_VULKAN;
@@ -369,6 +380,7 @@ static ultramodern::renderer::WindowHandle create_window_stub(void* /*gfx_data*/
         }
         g_sdl_window = window;
         lambo::menu::attach(window);
+        lambo::ui::set_window(window);
 #if defined(__linux__)
         LAMBO_LOG("rt64", "SDL window created (%dx%d, Vulkan surface)\n",
                      win_size.width, win_size.height);
@@ -398,31 +410,74 @@ static ultramodern::renderer::WindowHandle create_window_stub(void* /*gfx_data*/
 }
 
 static void update_gfx_stub(void* /*gfx_data*/) {
+    static bool runtime_ready_announced = false;
+    if (!runtime_ready_announced && g_startup_controller != nullptr) {
+        const bool render_ready = lambo::ui::is_initialized();
+        const bool runtime_ready = !lambo_rt64::enabled() || render_ready;
+        if (runtime_ready &&
+            (g_startup_controller->mode() == lambo::StartupMode::Automatic || render_ready)) {
+            runtime_ready_announced = true;
+            g_startup_controller->runtime_ready();
+            const char* page_env = std::getenv("LAMBO_UI_PAGE");
+            if (page_env != nullptr) {
+                const std::string page(page_env);
+                if (page == "settings") lambo::ui::open_settings();
+                else if (page == "controls") lambo::ui::open_controls();
+                else if (page == "graphics") lambo::ui::open_graphics();
+                else if (page == "enhancements") lambo::ui::open_enhancements();
+                else if (page == "haptics") lambo::ui::open_haptics();
+                else if (page == "launcher") lambo::ui::open_launcher();
+            } else if (g_startup_controller->mode() == lambo::StartupMode::InteractiveLauncher) {
+                lambo::ui::open_launcher();
+            }
+        }
+    }
+
     // Pump SDL events on the main thread so the RT64 window stays responsive under WSLg.
     if (lambo_rt64::enabled()) {
         SDL_Event event;
         while (SDL_PollEvent(&event)) {
-            if (lambo::menu::handle_event(event)) {
-                continue;
-            }
-            // Play mode has no VI cap (see quit_after_vis), so closing the window is the
-            // quit path: reuse the summary+_Exit teardown (game threads are torn down by
-            // process exit; see boot_summary_and_exit's rationale).
+            // Quit/window-close is handled before any UI or guest dispatch. In particular,
+            // a launcher close before the first VI is a successful application exit, not a
+            // failed boot probe.
             if (event.type == SDL_QUIT ||
                 (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE)) {
-                LAMBO_LOG("probe", "window closed; quitting\n");
-                boot_summary_and_exit();
+                if (g_startup_controller != nullptr) g_startup_controller->request_exit();
+                application_exit_success();
             }
-            else if (event.type == SDL_KEYDOWN && !event.key.repeat &&
-                     (event.key.keysym.sym == SDLK_F11 ||
-                      (event.key.keysym.sym == SDLK_RETURN && (event.key.keysym.mod & KMOD_ALT)))) {
+
+            // Hotplug is always consumed, even while the launcher owns input.
+            if (event.type == SDL_CONTROLLERDEVICEADDED) {
+                if (g_controls != nullptr) g_controls->device_added(event.cdevice.which);
+                continue;
+            }
+            if (event.type == SDL_CONTROLLERDEVICEREMOVED) {
+                if (g_controls != nullptr) g_controls->device_removed(event.cdevice.which);
+                lambo::ui::handle_event(event);
+                continue;
+            }
+
+            if (g_controls != nullptr && g_controls->handle_capture_event(event)) continue;
+            if (lambo::menu::handle_event(event)) continue;
+            if (lambo::ui::handle_event(event)) continue;
+
+            // Once the launcher/overlay captures input, guest and developer shortcuts are
+            // suppressed. F11 and Alt+Enter remain application-level shortcuts otherwise.
+            const bool settings_shortcut =
+                (event.type == SDL_KEYDOWN && !event.key.repeat &&
+                 (event.key.keysym.sym == SDLK_ESCAPE || event.key.keysym.sym == SDLK_F1)) ||
+                (g_controls != nullptr && g_controls->selected_back_pressed(event));
+            if (settings_shortcut &&
+                g_startup_controller != nullptr &&
+                g_startup_controller->state() == lambo::StartupState::Started &&
+                !lambo::ui::is_visible()) {
+                lambo::ui::open_settings();
+                continue;
+            }
+            if (event.type == SDL_KEYDOWN && !event.key.repeat &&
+                (event.key.keysym.sym == SDLK_F11 ||
+                 (event.key.keysym.sym == SDLK_RETURN && (event.key.keysym.mod & KMOD_ALT)))) {
                 toggle_fullscreen();
-            }
-            else if (event.type == SDL_CONTROLLERDEVICEADDED) {
-                input_open_controller(event.cdevice.which);   // which = joystick index (ADDED)
-            }
-            else if (event.type == SDL_CONTROLLERDEVICEREMOVED) {
-                input_close_controller(event.cdevice.which);  // which = instance id (REMOVED)
             }
         }
         // Severe GPU-driver advisory posted by renderer setup (issue #109): the affected
@@ -433,8 +488,10 @@ static void update_gfx_stub(void* /*gfx_data*/) {
                                      "Lamborghini Recomp - outdated graphics driver",
                                      advisory, g_sdl_window);
         }
-        // SDL_PollEvent pumped events above (implicitly SDL_GameControllerUpdate); sample the
-        // fresh keyboard+pad state into the atomic snapshot the game thread reads via get_input.
+        // Update the cross-thread capture gate before sampling physical state. The guest reads a
+        // neutral snapshot while the UI owns input, plus one neutral frame after release.
+        if (g_controls != nullptr) g_controls->process_commands();
+        lambo::input_gate::set_ui_capture(lambo::ui::captures_input());
         input_sample();
         // Apply the game thread's latest rumble-pak motor state to the physical pad (#69).
         rumble_apply();
@@ -470,10 +527,6 @@ enum {
 // N64 hardware stick maxes at roughly +-80 after calibration; games are tuned for that range,
 // so we scale full deflection to +-80 (faithfulness) rather than the full int8 +-127.
 static constexpr int   N64_STICK_MAX   = 80;
-static constexpr int   PAD_AXIS_DEADZONE = 8000;   // ~24% of int16 range (SDL recommended ~8000)
-static constexpr int   PAD_TRIG_THRESH   = 8000;   // analog trigger -> digital
-static constexpr int   PAD_CSTICK_THRESH = 12000;  // right-stick -> C-buttons
-
 static uint16_t g_held_buttons = 0;                 // LAMBO_MODERN_INPUT env override, OR'd in
 static int8_t   g_held_sx = 0, g_held_sy = 0;       // LAMBO_MODERN_INPUT stick override (harness)
 // LAMBO_INPUT_PULSE=BTNHEX:PERIOD:DUTY[:STARTVI] -- periodic button pulse for headless menu
@@ -482,14 +535,12 @@ static int8_t   g_held_sx = 0, g_held_sy = 0;       // LAMBO_MODERN_INPUT stick 
 static uint16_t g_pulse_buttons = 0;
 static int      g_pulse_period = 0, g_pulse_duty = 0, g_pulse_start = 0;
 static int      g_pulse_count = 0;   // optional 5th field: stop after N pulses (0 = unlimited)
-static std::atomic<uint32_t> g_input_snapshot{0};   // main-thread sampled, game-thread read
-static SDL_GameController* g_pad = nullptr;          // first opened controller (port 0)
 
 // --- rumble-pak sink (#69) ----------------------------------------------------------------
 // The game's SI/PIF bridge (func_8007F780 -> lambo_joybus_answer, recomp/src/libultra_stubs.c)
 // runs on the GAME thread and decodes the ROM's motor-control pak writes (joybus cmd 0x03 to
 // pak block 0xC000: payload 0x01 = motor on, 0x00 = off). SDL rumble must be driven from the
-// MAIN thread (that owns g_pad open/close), so -- exactly like input -- the game thread only
+// MAIN thread (that owns the controller registry), so -- exactly like input -- the game thread only
 // PUBLISHES an atomic request and the main-thread pump (update_gfx_stub) applies it. Declared
 // extern "C" so the C responder in libultra_stubs.c can call lambo_pak_set_rumble().
 static std::atomic<int> g_rumble_on{0};              // game-thread write, main-thread read
@@ -510,23 +561,8 @@ extern "C" void lambo_savestate_request_load(void);
 // lets it lapse. Idempotent-ish: we only issue an SDL call on an on/off EDGE plus periodic
 // refresh while on, to avoid hammering the HID layer every frame.
 static void rumble_apply() {
-    static int last = 0;
     int on = g_rumble_on.load(std::memory_order_relaxed);
-    if (g_pad == nullptr || !SDL_GameControllerGetAttached(g_pad)) { last = 0; return; }
-    if (on) {
-        SDL_GameControllerRumble(g_pad, 0xFFFF, 0xFFFF, 150);   // refresh; expiry > frame time
-    } else if (last) {
-        SDL_GameControllerRumble(g_pad, 0, 0, 0);               // off edge: stop immediately
-    }
-    last = on;
-}
-
-static int8_t pad_axis_to_n64(int v) {              // int16 SDL axis -> int8 N64 stick (deadzoned)
-    if (v > -PAD_AXIS_DEADZONE && v < PAD_AXIS_DEADZONE) return 0;
-    float f = v / 32767.0f;
-    if (f >  1.0f) f =  1.0f;
-    if (f < -1.0f) f = -1.0f;
-    return (int8_t)(f * N64_STICK_MAX);
+    if (g_controls != nullptr) g_controls->apply_rumble(on != 0);
 }
 
 // Sample SDL keyboard + gamepad on the MAIN thread and publish the atomic snapshot.
@@ -534,42 +570,11 @@ static void input_sample() {
     uint16_t b = 0;
     int sx = 0, sy = 0;
 
-    if (g_pad != nullptr && SDL_GameControllerGetAttached(g_pad)) {
-        auto down = [](SDL_GameControllerButton g) { return SDL_GameControllerGetButton(g_pad, g) != 0; };
-        // Mapping is tuned to THIS game's VERIFIED menu control scheme (not the generic
-        // Zelda64Recomp default): the ROM's menu driver (func_800030F8) confirms on A|START
-        // (andi 0x9000), cancels on B (0x4000), and moves the cursor with the ANALOG STICK only
-        // -- it tests no C-button or D-pad bit for menu nav. So the face buttons follow Xbox-native
-        // intent: A=confirm, B=cancel. The C-buttons live on X/Y + the right stick, where this
-        // game's menus never look at them, so they can't produce phantom menu input.
-        // NOTE: the *in-race* meaning of each N64 bit (throttle/brake/camera) is NOT yet ROM-verified
-        // -- the race-overlay input consumer hasn't been read. This is a physical Xbox->N64 binding,
-        // not a claim about race behaviour; revisit when state 8 becomes playable (see race.md).
-        if (down(SDL_CONTROLLER_BUTTON_A))             b |= N64_A;      // confirm (menu)
-        if (down(SDL_CONTROLLER_BUTTON_B))             b |= N64_B;      // cancel (menu)
-        if (down(SDL_CONTROLLER_BUTTON_X))             b |= N64_CL;     // West  -> C-left
-        if (down(SDL_CONTROLLER_BUTTON_Y))             b |= N64_CU;     // North -> C-up
-        if (down(SDL_CONTROLLER_BUTTON_START))         b |= N64_START;  // advance / pause
-        if (down(SDL_CONTROLLER_BUTTON_LEFTSHOULDER))  b |= N64_L;
-        if (down(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER)) b |= N64_R;
-        if (down(SDL_CONTROLLER_BUTTON_DPAD_UP))        b |= N64_DU;
-        if (down(SDL_CONTROLLER_BUTTON_DPAD_DOWN))      b |= N64_DD;
-        if (down(SDL_CONTROLLER_BUTTON_DPAD_LEFT))      b |= N64_DL;
-        if (down(SDL_CONTROLLER_BUTTON_DPAD_RIGHT))     b |= N64_DR;
-        // N64 Z on the left analog trigger (LT); N64 R also on the right trigger (RT) for racing feel.
-        if (SDL_GameControllerGetAxis(g_pad, SDL_CONTROLLER_AXIS_TRIGGERLEFT)  > PAD_TRIG_THRESH) b |= N64_Z;
-        if (SDL_GameControllerGetAxis(g_pad, SDL_CONTROLLER_AXIS_TRIGGERRIGHT) > PAD_TRIG_THRESH) b |= N64_R;
-        // Remaining C directions: right-stick click -> C-down; the right stick itself -> all four C's.
-        if (down(SDL_CONTROLLER_BUTTON_RIGHTSTICK))     b |= N64_CD;    // right-stick click
-        int rx = SDL_GameControllerGetAxis(g_pad, SDL_CONTROLLER_AXIS_RIGHTX);
-        int ry = SDL_GameControllerGetAxis(g_pad, SDL_CONTROLLER_AXIS_RIGHTY);
-        if (rx >  PAD_CSTICK_THRESH) b |= N64_CR;
-        if (rx < -PAD_CSTICK_THRESH) b |= N64_CL;
-        if (ry >  PAD_CSTICK_THRESH) b |= N64_CD;
-        if (ry < -PAD_CSTICK_THRESH) b |= N64_CU;
-        // Left analog stick -> N64 stick (SDL Y is +down, N64 stick_y is +up -> negate).
-        sx =  pad_axis_to_n64(SDL_GameControllerGetAxis(g_pad, SDL_CONTROLLER_AXIS_LEFTX));
-        sy = -pad_axis_to_n64(SDL_GameControllerGetAxis(g_pad, SDL_CONTROLLER_AXIS_LEFTY));
+    if (g_controls != nullptr) {
+        const lambo::controls::EvaluatedState controller = g_controls->sample();
+        b = controller.buttons;
+        sx = controller.stick_x;
+        sy = controller.stick_y;
     }
 
     // Keyboard fallback (always sampled; OR'd with the pad). Arrow keys steer; racing essentials
@@ -593,58 +598,42 @@ static void input_sample() {
         if (sx == 0 && kx != 0) sx = kx;               // pad stick wins if deflected
         if (sy == 0 && ky != 0) sy = ky;
 
-        // Developer warp menu (#12): F1..F6 warp straight to that circuit as a
-        // 1-player single race. Edge-detected here (main thread); consumed by
-        // lambo_warp_tick on the game thread (src/lambo_warp.c).
-        static Uint8 warp_prev[6] = {};
-        for (int i = 0; i < 6; i++) {
-            Uint8 down = ks[SDL_SCANCODE_F1 + i];
-            if (down && !warp_prev[i]) lambo_warp_request(i);
-            warp_prev[i] = down;
-        }
+        if (!lambo::input_gate::guest_input_suppressed()) {
+            // Developer warp menu (#12): F1..F6 warp straight to that circuit as a
+            // 1-player single race. Edge-detected here (main thread); consumed by
+            // lambo_warp_tick on the game thread (src/lambo_warp.c).
+            static Uint8 warp_prev[6] = {};
+            for (int i = 0; i < 6; i++) {
+                Uint8 down = ks[SDL_SCANCODE_F1 + i];
+                if (down && !warp_prev[i]) lambo_warp_request(i);
+                warp_prev[i] = down;
+            }
 
-        // Developer save-state (#22): F7 saves the current guest RAM to the state slot,
-        // F8 restores it. (F1-F6 are the warp keys above and F11 is fullscreen, so save-state
-        // uses the free F7/F8 pair.) Edge-detected here (main thread); the copy runs on the
-        // game thread at the next frame boundary (src/lambo_savestate.c).
-        static Uint8 f7_prev = 0, f8_prev = 0;
-        Uint8 f7 = ks[SDL_SCANCODE_F7], f8 = ks[SDL_SCANCODE_F8];
-        if (f7 && !f7_prev) lambo_savestate_request_save();
-        if (f8 && !f8_prev) lambo_savestate_request_load();
-        f7_prev = f7; f8_prev = f8;
+            // Developer save-state (#22): F7 saves the current guest RAM to the state slot,
+            // F8 restores it. Edge-detected here (main thread); the copy runs on the game
+            // thread at the next frame boundary (src/lambo_savestate.c).
+            static Uint8 f7_prev = 0, f8_prev = 0;
+            Uint8 f7 = ks[SDL_SCANCODE_F7], f8 = ks[SDL_SCANCODE_F8];
+            if (f7 && !f7_prev) lambo_savestate_request_save();
+            if (f8 && !f8_prev) lambo_savestate_request_load();
+            f7_prev = f7; f8_prev = f8;
+        }
     }
 
     uint32_t snap = (uint16_t)b
                   | ((uint32_t)(uint8_t)(int8_t)sx << 16)
                   | ((uint32_t)(uint8_t)(int8_t)sy << 24);
-    g_input_snapshot.store(snap, std::memory_order_relaxed);
-}
-
-// Open the first connected game controller into port 0 (idempotent; called at init + on hotplug).
-static void input_open_controller(int joystick_index) {
-    if (g_pad != nullptr) return;
-    if (!SDL_IsGameController(joystick_index)) return;
-    g_pad = SDL_GameControllerOpen(joystick_index);
-    if (g_pad != nullptr)
-        LAMBO_LOG("input", "controller connected: %s\n",
-                     SDL_GameControllerName(g_pad) ? SDL_GameControllerName(g_pad) : "(unknown)");
-}
-static void input_close_controller(SDL_JoystickID which) {
-    if (g_pad == nullptr) return;
-    SDL_Joystick* js = SDL_GameControllerGetJoystick(g_pad);
-    if (js != nullptr && SDL_JoystickInstanceID(js) == which) {
-        SDL_GameControllerClose(g_pad);
-        g_pad = nullptr;
-        LAMBO_LOG("input", "controller disconnected\n");
-    }
+    lambo::input_gate::publish_physical_snapshot(snap);
 }
 
 static void input_poll_stub() {}
 static bool input_get_input(int controller_num, uint16_t* buttons, float* x, float* y) {
     if (controller_num != 0) return false;
-    uint32_t snap = g_input_snapshot.load(std::memory_order_relaxed);
-    uint16_t b  = (uint16_t)(snap & 0xFFFF) | g_held_buttons;   // env mask always OR'd (harness knob)
-    if (g_pulse_period > 0) {                                   // scripted pulse (harness knob)
+    const bool suppressed = lambo::input_gate::guest_input_suppressed();
+    uint32_t snap = lambo::input_gate::guest_snapshot();
+    uint16_t b = suppressed ? 0 : (uint16_t)(snap & 0xFFFF);
+    if (!suppressed) b |= g_held_buttons;                       // env mask is a guest input source
+    if (!suppressed && g_pulse_period > 0) {                    // scripted pulse (harness knob)
         int vi = g_vis.load(std::memory_order_relaxed);
         if (vi >= g_pulse_start && ((vi - g_pulse_start) % g_pulse_period) < g_pulse_duty
             && (g_pulse_count == 0 || (vi - g_pulse_start) / g_pulse_period < g_pulse_count))
@@ -652,8 +641,8 @@ static bool input_get_input(int controller_num, uint16_t* buttons, float* x, flo
     }
     int8_t   sx = (int8_t)((snap >> 16) & 0xFF);
     int8_t   sy = (int8_t)((snap >> 24) & 0xFF);
-    if (sx == 0) sx = g_held_sx;                                // env stick fills in when live stick idle
-    if (sy == 0) sy = g_held_sy;
+    if (!suppressed && sx == 0) sx = g_held_sx;                  // env stick fills in when live stick idle
+    if (!suppressed && sy == 0) sy = g_held_sy;
     if (buttons) *buttons = b;
     // ultramodern does stick_x = (int8_t)(127 * x), so divide by 127 (NOT N64_STICK_MAX) to
     // preserve our authentic +-80 range through that re-scale instead of re-expanding to +-127.
@@ -717,6 +706,7 @@ int main(int argc, char** argv) {
     std::filesystem::path config_dir = lambo::config::app_config_dir();
     std::filesystem::create_directories(config_dir);
     recomp::register_config_path(config_dir);
+    g_controls = std::make_unique<lambo::controls::SdlAdapter>();
 
     recomp::GameEntry game{};
     game.rom_hash          = 0x525201d7279f34e3ULL; // XXH3_64(big-endian .z64, padded to /4)
@@ -737,30 +727,44 @@ int main(int argc, char** argv) {
     }
     LAMBO_LOG("probe", "ROM validated; rom_hash matches\n");
 
-    // recomp::start() blocks the calling thread until ultramodern::quit(), so
-    // kick the game off from a side thread once the runtime has set up.
-    std::thread starter([game_id]() {
-        std::this_thread::sleep_for(std::chrono::milliseconds(150));
+    lambo::StartupMode startup_mode = lambo::startup_mode_from_environment();
+    if (startup_mode == lambo::StartupMode::Automatic && lambo::config::show_launcher()) {
+        startup_mode = lambo::StartupMode::InteractiveLauncher;
+    }
+    lambo::StartupController startup_controller(startup_mode, []() {
         LAMBO_LOG("probe", "calling start_game\n");
-        std::u8string gid = game_id;
-        recomp::start_game(gid);
+        recomp::start_game(u8"lamborghini.us");
     });
-    starter.detach();
+    g_startup_controller = &startup_controller;
+    lambo::ui::set_startup_controller(&startup_controller);
+    lambo::ui::install_render_hooks();
+    LAMBO_LOG("probe", "startup mode: %s\n",
+              startup_mode == lambo::StartupMode::Automatic ? "automatic" : "interactive");
 
-    // Watchdog: guarantee the probe terminates and reports, even on a stall.
-    const int wd_sec = watchdog_seconds();
-    std::thread watchdog([wd_sec]() {
-        std::this_thread::sleep_for(std::chrono::seconds(wd_sec));
-        LAMBO_LOG("probe", "WATCHDOG %ds: threads=%d vis=%d first_vi=%d\n",
-                     wd_sec, g_threads.load(), g_vis.load(), (int)g_first_vi.load());
-        // Exit deterministically (same as the VI-cap path) rather than ultramodern::quit(),
-        // whose teardown munmaps RDRAM out from under the live game threads (SIGSEGV race).
-        boot_summary_and_exit();
-    });
-    watchdog.detach();
+    // Watchdog: guarantee automatic probes terminate and report. Only started for
+    // capped test probes (kQuitAfterVis != INT_MAX). Normal play mode runs unwatched.
+    if (kQuitAfterVis != INT_MAX) {
+        const int wd_sec = watchdog_seconds();
+        std::thread watchdog([&startup_controller, wd_sec]() {
+            while (!startup_controller.watchdog_armed() &&
+                   startup_controller.state() != lambo::StartupState::Exiting) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            }
+            if (startup_controller.state() == lambo::StartupState::Exiting) return;
+            std::this_thread::sleep_for(std::chrono::seconds(wd_sec));
+            if (startup_controller.state() == lambo::StartupState::Exiting) return;
+            LAMBO_LOG("probe", "WATCHDOG %ds: threads=%d vis=%d first_vi=%d\n",
+                         wd_sec, g_threads.load(), g_vis.load(), (int)g_first_vi.load());
+            // Exit deterministically (same as the VI-cap path) rather than ultramodern::quit(),
+            // whose teardown munmaps RDRAM out from under the live game threads (SIGSEGV race).
+            boot_summary_and_exit();
+        });
+        watchdog.detach();
+    }
 
     recomp::Configuration cfg{};
-    cfg.project_version = recomp::Version{1, 0, 0, std::string{}};
+    cfg.project_version = recomp::Version{
+        LAMBO_VERSION_MAJOR, LAMBO_VERSION_MINOR, LAMBO_VERSION_PATCH, std::string{}};
     cfg.rsp_callbacks.get_rsp_microcode = get_rsp_microcode_stub;
     cfg.renderer_callbacks.create_render_context = headless::create_render_context;
     cfg.gfx_callbacks.create_window = create_window_stub; // avoids start()'s no-window assert

--- a/src/ui/lambo_ui.cpp
+++ b/src/ui/lambo_ui.cpp
@@ -1,0 +1,752 @@
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include "lambo_ui.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <SDL.h>
+#include <concurrentqueue.h>
+
+#include "RmlUi/Core.h"
+#include "RmlUi/Debugger.h"
+#include "RmlUi_Platform_SDL.h"
+#include "rt64_render_hooks.h"
+
+#include "lambo_config.h"
+#include "lambo_log.h"
+#include "lambo_startup.h"
+#include "lambo_ui_input.h"
+#include "lambo_ui_controls.h"
+#include "lambo_ui_render_interface.h"
+#include "lambo_ui_settings.h"
+
+#ifndef LAMBO_VERSION
+#define LAMBO_VERSION "dev"
+#endif
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+enum class InputMode {
+    Mouse,
+    KeyboardOrController,
+};
+
+struct PageDescriptor {
+    const char* document;
+    const char* title;
+};
+
+constexpr std::array page_descriptors{
+    PageDescriptor{"launcher.rml", "Home"},
+    PageDescriptor{"settings.rml", "Settings"},
+    PageDescriptor{"pages/graphics.rml", "Graphics"},
+    PageDescriptor{"pages/enhancements.rml", "Enhancements"},
+    PageDescriptor{"pages/controls.rml", "Controls"},
+    PageDescriptor{"pages/haptics.rml", "Haptics"},
+};
+
+const PageDescriptor& page_descriptor(lambo::ui::Page page) {
+    return page_descriptors.at(static_cast<size_t>(page));
+}
+
+struct QueuedEvent {
+    SDL_Event event{};
+};
+
+class UiEventListener final : public Rml::EventListener {
+public:
+    using Callback = std::function<void(const std::string&)>;
+
+    UiEventListener(Callback callback, std::string parameter)
+        : callback_(std::move(callback)), parameter_(std::move(parameter)) {}
+
+    void ProcessEvent(Rml::Event&) override { callback_(parameter_); }
+
+private:
+    Callback callback_;
+    std::string parameter_;
+};
+
+class UiEventListenerInstancer final : public Rml::EventListenerInstancer {
+public:
+    using Callback = UiEventListener::Callback;
+
+    void register_event(const std::string& name, Callback callback) {
+        callbacks_[name] = std::move(callback);
+    }
+
+    Rml::EventListener* InstanceEventListener(const Rml::String& value,
+                                              Rml::Element*) override {
+        const size_t separator = value.find(':');
+        const std::string name = value.substr(0, separator);
+        auto callback = callbacks_.find(name);
+        if (callback == callbacks_.end()) return nullptr;
+
+        auto listener = listeners_.find(value);
+        if (listener != listeners_.end()) return listener->second.get();
+
+        const std::string parameter = separator == std::string::npos
+            ? std::string{}
+            : value.substr(separator + 1);
+        auto instance = std::make_unique<UiEventListener>(callback->second, parameter);
+        UiEventListener* result = instance.get();
+        listeners_.emplace(value, std::move(instance));
+        return result;
+    }
+
+private:
+    std::unordered_map<std::string, Callback> callbacks_;
+    std::unordered_map<std::string, std::unique_ptr<UiEventListener>> listeners_;
+};
+
+struct UiState {
+    SDL_Window* window = nullptr;
+    std::unique_ptr<SystemInterface_SDL> system_interface;
+    lambo::ui::RmlRenderInterface_RT64 render_interface;
+    Rml::Context* context = nullptr;
+    Rml::ElementDocument* document = nullptr;
+    UiEventListenerInstancer event_listener_instancer;
+    // RmlUi's memory font API retains these pointers until Rml::Shutdown.
+    std::vector<std::vector<Rml::byte>> font_data;
+    std::vector<lambo::ui::Page> pages;
+    std::unordered_map<lambo::ui::Page, std::string> focused_element_by_page;
+    lambo::ui::EntryPoint entry_point = lambo::ui::EntryPoint::Startup;
+    std::optional<lambo::ui::Page> current_page;
+    lambo::ui::ControllerNavigation controller_navigation;
+    InputMode input_mode = InputMode::Mouse;
+    std::uint64_t controls_config_revision = ~std::uint64_t{};
+    std::uint64_t controls_sample_revision = ~std::uint64_t{};
+
+    void remember_focus();
+    void restore_focus(lambo::ui::Page page);
+    void set_input_mode(InputMode mode);
+    void set_text(const char* id, const std::string& value);
+    void refresh_document_values();
+    void refresh_controls_values();
+    void load_page(lambo::ui::Page page, bool push_history);
+    void show_page(lambo::ui::Page page);
+    void hide_pages();
+    void back();
+    void process_key_down(int key, bool repeat);
+    void process_navigation_events(const std::vector<lambo::ui::NavigationEvent>& events);
+    void process_queued_events();
+
+    ~UiState() {
+        if (document != nullptr && context != nullptr) {
+            context->UnloadDocument(document);
+            document = nullptr;
+        }
+        if (context != nullptr) {
+            Rml::RemoveContext(context->GetName());
+            context = nullptr;
+        }
+        render_interface.reset();
+    }
+};
+
+std::unique_ptr<UiState> g_state;
+std::mutex g_state_mutex;
+SDL_Window* g_window = nullptr;
+std::atomic<bool> g_visible{false};
+std::atomic<bool> g_capture{false};
+std::atomic<int> g_requested_page{-1};
+std::atomic<int> g_requested_entry_point{static_cast<int>(lambo::ui::EntryPoint::Startup)};
+std::atomic<bool> g_requested_back{false};
+std::atomic<bool> g_requested_controls_route{false};
+std::atomic<lambo::StartupController*> g_startup_controller{nullptr};
+moodycamel::ConcurrentQueue<QueuedEvent> g_event_queue;
+
+std::filesystem::path asset_root() {
+    if (const char* configured = std::getenv("LAMBO_ASSET_DIR")) {
+        return std::filesystem::path(configured);
+    }
+    const auto cwd_ui = std::filesystem::current_path() / "assets" / "ui";
+    if (std::filesystem::exists(cwd_ui)) return cwd_ui;
+    if (char* base_path = SDL_GetBasePath()) {
+        const auto executable_ui = std::filesystem::path(base_path) / "assets" / "ui";
+        SDL_free(base_path);
+        if (std::filesystem::exists(executable_ui)) return executable_ui;
+    }
+    const auto executable_ui = std::filesystem::current_path() / "ui";
+    if (std::filesystem::exists(executable_ui)) return executable_ui;
+    return cwd_ui;
+}
+
+void UiState::remember_focus() {
+    if (!current_page.has_value() || context == nullptr) return;
+    if (Rml::Element* focused = context->GetFocusElement();
+        focused != nullptr && !focused->GetId().empty()) {
+        focused_element_by_page[*current_page] = focused->GetId();
+    }
+}
+
+void UiState::restore_focus(lambo::ui::Page page) {
+    if (document == nullptr) return;
+    Rml::Element* focus = nullptr;
+    if (const auto saved = focused_element_by_page.find(page);
+        saved != focused_element_by_page.end()) {
+        focus = document->GetElementById(saved->second);
+    }
+    if (focus == nullptr) focus = document->GetElementById("autofocus");
+    if (focus != nullptr) focus->Focus();
+}
+
+void UiState::set_input_mode(InputMode mode) {
+    input_mode = mode;
+    if (document == nullptr) return;
+    document->SetClass("mouse-active", mode == InputMode::Mouse);
+    document->SetClass("controller-active", mode == InputMode::KeyboardOrController);
+    if (mode == InputMode::KeyboardOrController && context->GetFocusElement() == nullptr &&
+        current_page.has_value()) {
+        restore_focus(*current_page);
+    }
+}
+
+void UiState::set_text(const char* id, const std::string& value) {
+    if (document == nullptr) return;
+    if (Rml::Element* element = document->GetElementById(id)) {
+        element->SetInnerRML(value);
+    }
+}
+
+void UiState::refresh_document_values() {
+    if (document == nullptr) return;
+    set_text("version", std::string("v") + LAMBO_VERSION);
+    const auto values = lambo::ui::settings_snapshot();
+    set_text("graphics-resolution", values.resolution);
+    set_text("graphics-supersampling", values.supersampling);
+    set_text("graphics-aspect", values.aspect_ratio);
+    set_text("graphics-hud", values.hud_layout);
+    set_text("graphics-refresh", values.refresh_rate);
+    set_text("graphics-msaa", values.msaa);
+    set_text("graphics-hpfb", values.framebuffer_precision);
+    set_text("graphics-api", values.graphics_api);
+    set_text("enhancement-fog", values.widescreen_fog);
+    set_text("enhancement-sky", values.widescreen_sky);
+    set_text("enhancement-lod", values.lod_removal);
+    set_text("enhancement-distance", values.draw_distance);
+    set_text("enhancement-fog-density", values.fog_density);
+    for (size_t circuit = 0; circuit < values.circuit_visibility.size(); ++circuit) {
+        const std::string id = "enhancement-circuit-" + std::to_string(circuit + 1);
+        set_text(id.c_str(), values.circuit_visibility[circuit]);
+    }
+    refresh_controls_values();
+}
+
+void UiState::refresh_controls_values() {
+    if (document == nullptr || current_page != lambo::ui::Page::Controls) return;
+    const auto snapshot = lambo::controls::ui_snapshot();
+    const auto view = lambo::ui::controls_view(snapshot);
+    if (snapshot.config_revision != controls_config_revision) {
+        controls_config_revision = snapshot.config_revision;
+        set_text("controls-controller-list", view.controller_list);
+        set_text("controls-selected-name", view.selected_name);
+        set_text("controls-selected-status", view.selected_status);
+        set_text("controls-selected-layout", view.selected_layout);
+        set_text("controls-selected-guid", view.selected_guid);
+        set_text("controls-bindings", view.bindings);
+        set_text("controls-persistence-status", view.persistence_status);
+        set_text("controls-warnings", view.warnings);
+        set_text("controls-capture-message", view.capture_message);
+        if (Rml::Element* reset = document->GetElementById("controls-reset-profile")) {
+            if (snapshot.read_only || !snapshot.selected_instance) reset->SetAttribute("disabled", "disabled");
+            else reset->RemoveAttribute("disabled");
+        }
+        if (Rml::Element* modal = document->GetElementById("controls-capture-modal"))
+            modal->SetClass("visible", view.capture_visible);
+        if (Rml::Element* modal = document->GetElementById("controls-conflict-modal"))
+            modal->SetClass("visible", view.conflict_visible);
+        if (view.conflict_visible) {
+            if (Rml::Element* accept = document->GetElementById("controls-conflict-accept"))
+                accept->Focus();
+        }
+    }
+    if (snapshot.sample_revision != controls_sample_revision) {
+        controls_sample_revision = snapshot.sample_revision;
+        set_text("controls-raw-preview", view.raw_preview);
+        set_text("controls-evaluated-preview", view.evaluated_preview);
+    }
+}
+
+void UiState::load_page(lambo::ui::Page page, bool push_history) {
+    if (context == nullptr) return;
+    remember_focus();
+    if (current_page == lambo::ui::Page::Controls)
+        lambo::controls::enqueue_command({lambo::controls::CommandKind::CaptureCancel});
+    if (document != nullptr) {
+        context->UnloadDocument(document);
+        document = nullptr;
+    }
+
+    const PageDescriptor& descriptor = page_descriptor(page);
+    const std::filesystem::path path = asset_root() / descriptor.document;
+    document = context->LoadDocument(path.string());
+    if (document == nullptr) {
+        LAMBO_LOG("ui", "failed to load %s\n", path.string().c_str());
+        g_visible.store(false, std::memory_order_release);
+        g_capture.store(false, std::memory_order_release);
+        current_page.reset();
+        return;
+    }
+    document->Show();
+    document->PullToFront();
+    current_page = page;
+    if (page == lambo::ui::Page::Controls) {
+        controls_config_revision = ~std::uint64_t{};
+        controls_sample_revision = ~std::uint64_t{};
+    }
+    if (push_history) pages.push_back(page);
+    refresh_document_values();
+    restore_focus(page);
+    set_input_mode(input_mode);
+    g_visible.store(true, std::memory_order_release);
+    g_capture.store(true, std::memory_order_release);
+    LAMBO_LOG("ui", "opened %s page\n", descriptor.title);
+}
+
+void UiState::show_page(lambo::ui::Page page) {
+    load_page(page, true);
+}
+
+void UiState::hide_pages() {
+    remember_focus();
+    if (current_page == lambo::ui::Page::Controls)
+        lambo::controls::enqueue_command({lambo::controls::CommandKind::CaptureCancel});
+    if (document != nullptr) {
+        context->UnloadDocument(document);
+        document = nullptr;
+    }
+    pages.clear();
+    current_page.reset();
+    controller_navigation.reset();
+    g_visible.store(false, std::memory_order_release);
+    g_capture.store(false, std::memory_order_release);
+}
+
+void UiState::back() {
+    if (current_page == lambo::ui::Page::Controls) {
+        const auto snapshot = lambo::controls::ui_snapshot();
+        if (snapshot.capture_phase != lambo::controls::CapturePhase::Idle) {
+            lambo::controls::enqueue_command({lambo::controls::CommandKind::CaptureCancel});
+            return;
+        }
+    }
+    if (pages.empty()) return;
+    if (pages.size() > 1) {
+        pages.pop_back();
+        load_page(pages.back(), false);
+        return;
+    }
+    if (entry_point == lambo::ui::EntryPoint::InGameOverlay) hide_pages();
+}
+
+void process_action(const std::string& action, const std::string& parameter) {
+    if (action == "play") {
+        auto* controller = g_startup_controller.load(std::memory_order_acquire);
+        if (controller != nullptr && controller->request_play()) {
+            if (g_state != nullptr) g_state->hide_pages();
+            LAMBO_LOG("ui", "Play accepted; launcher hidden\n");
+        }
+    } else if (action == "quit") {
+        if (auto* controller = g_startup_controller.load(std::memory_order_acquire)) {
+            controller->request_exit();
+        }
+        SDL_Event event{};
+        event.type = SDL_QUIT;
+        SDL_PushEvent(&event);
+    } else if (action == "settings") {
+        if (g_state != nullptr) g_state->show_page(lambo::ui::Page::Settings);
+    } else if (action == "page") {
+        if (g_state == nullptr) return;
+        if (parameter == "settings") g_state->show_page(lambo::ui::Page::Settings);
+        else if (parameter == "graphics") g_state->show_page(lambo::ui::Page::Graphics);
+        else if (parameter == "enhancements") g_state->show_page(lambo::ui::Page::Enhancements);
+        else if (parameter == "controls") g_state->show_page(lambo::ui::Page::Controls);
+        else if (parameter == "haptics") g_state->show_page(lambo::ui::Page::Haptics);
+    } else if (action == "back") {
+        if (g_state != nullptr) g_state->back();
+    } else if (action == "setting") {
+        const auto setting = lambo::ui::setting_action_from_name(parameter);
+        if (setting.has_value() && lambo::ui::apply_setting_action(*setting) && g_state != nullptr) {
+            g_state->refresh_document_values();
+        }
+    } else if (action == "control") {
+        lambo::ui::apply_control_action(parameter);
+    }
+}
+
+void install_event_handlers(UiState& state) {
+    state.event_listener_instancer.register_event("play", [](const std::string& p) { process_action("play", p); });
+    state.event_listener_instancer.register_event("quit", [](const std::string&) { process_action("quit", ""); });
+    state.event_listener_instancer.register_event("settings", [](const std::string&) { process_action("settings", ""); });
+    state.event_listener_instancer.register_event("page", [](const std::string& p) { process_action("page", p); });
+    state.event_listener_instancer.register_event("back", [](const std::string&) { process_action("back", ""); });
+    state.event_listener_instancer.register_event("setting", [](const std::string& p) { process_action("setting", p); });
+    state.event_listener_instancer.register_event("control", [](const std::string& p) { process_action("control", p); });
+}
+
+void init_hook(RT64::RenderInterface* interface, RT64::RenderDevice* device) {
+    std::lock_guard lock(g_state_mutex);
+    if (g_state != nullptr || g_window == nullptr) return;
+
+    auto state = std::make_unique<UiState>();
+    state->window = g_window;
+    state->system_interface = std::make_unique<SystemInterface_SDL>();
+    state->system_interface->SetWindow(g_window);
+    state->render_interface.init(interface, device);
+    Rml::SetSystemInterface(state->system_interface.get());
+    Rml::SetRenderInterface(state->render_interface.get_rml_interface());
+    install_event_handlers(*state);
+    if (!Rml::Initialise()) {
+        LAMBO_LOG("ui", "RmlUi initialisation failed\n");
+        return;
+    }
+    Rml::Factory::RegisterEventListenerInstancer(&state->event_listener_instancer);
+
+    int width = 0, height = 0;
+    SDL_GetWindowSizeInPixels(g_window, &width, &height);
+    state->context = Rml::CreateContext("lamborghini", {width, height});
+    if (state->context == nullptr) {
+        LAMBO_LOG("ui", "RmlUi context creation failed\n");
+        Rml::Shutdown();
+        return;
+    }
+    const auto fonts = asset_root() / "fonts";
+    const auto bundled_fonts = std::filesystem::current_path() / "lib" / "RmlUi" / "Samples" / "assets";
+    state->font_data.reserve(2);
+    const auto load_font = [&](const char* filename, Rml::Style::FontWeight weight) {
+        const auto configured_path = fonts / filename;
+        const auto fallback_path = bundled_fonts / filename;
+        const std::filesystem::path* use_path = nullptr;
+        if (std::filesystem::exists(configured_path)) {
+            use_path = &configured_path;
+        } else if (std::filesystem::exists(fallback_path)) {
+            use_path = &fallback_path;
+        } else {
+            LAMBO_LOG("ui", "font %s not found (configured=%s, fallback=%s)\n",
+                filename, configured_path.string().c_str(), fallback_path.string().c_str());
+            return;
+        }
+        std::ifstream file(*use_path, std::ios::binary);
+        state->font_data.emplace_back(std::istreambuf_iterator<char>(file),
+                                      std::istreambuf_iterator<char>{});
+        const auto& data = state->font_data.back();
+        const bool ok = !data.empty() && Rml::LoadFontFace(
+            data, "Lato", Rml::Style::FontStyle::Normal, weight, false);
+        LAMBO_LOG("ui", "font %s: %s (path=%s)\n",
+            filename, ok ? "loaded" : "FAILED", use_path->string().c_str());
+    };
+    load_font("LatoLatin-Regular.ttf", Rml::Style::FontWeight::Normal);
+    load_font("LatoLatin-Bold.ttf", Rml::Style::FontWeight::Bold);
+    g_state = std::move(state);
+    LAMBO_LOG("ui", "RmlUi render hooks initialised\n");
+}
+
+std::optional<lambo::ui::NavigationKey> navigation_key_from_button(uint8_t button) {
+    using lambo::ui::NavigationKey;
+    switch (button) {
+        case SDL_CONTROLLER_BUTTON_A: return NavigationKey::Activate;
+        case SDL_CONTROLLER_BUTTON_B: return NavigationKey::Back;
+        case SDL_CONTROLLER_BUTTON_DPAD_UP: return NavigationKey::Up;
+        case SDL_CONTROLLER_BUTTON_DPAD_DOWN: return NavigationKey::Down;
+        case SDL_CONTROLLER_BUTTON_DPAD_LEFT: return NavigationKey::Left;
+        case SDL_CONTROLLER_BUTTON_DPAD_RIGHT: return NavigationKey::Right;
+        default: return std::nullopt;
+    }
+}
+
+int sdl_key_from_navigation(lambo::ui::NavigationKey key) {
+    using lambo::ui::NavigationKey;
+    switch (key) {
+        case NavigationKey::Activate: return SDLK_RETURN;
+        case NavigationKey::Back: return SDLK_ESCAPE;
+        case NavigationKey::Up: return SDLK_UP;
+        case NavigationKey::Down: return SDLK_DOWN;
+        case NavigationKey::Left: return SDLK_LEFT;
+        case NavigationKey::Right: return SDLK_RIGHT;
+        case NavigationKey::None: case NavigationKey::Count: return SDLK_UNKNOWN;
+    }
+    return SDLK_UNKNOWN;
+}
+
+void UiState::process_key_down(int key, bool repeat) {
+    if (context == nullptr) return;
+    set_input_mode(InputMode::KeyboardOrController);
+    if (context->GetFocusElement() == nullptr && current_page.has_value()) {
+        restore_focus(*current_page);
+    }
+    if (key == SDLK_ESCAPE) {
+        if (!repeat) back();
+        return;
+    }
+    context->ProcessKeyDown(RmlSDL::ConvertKey(key), RmlSDL::GetKeyModifierState());
+}
+
+void UiState::process_navigation_events(
+    const std::vector<lambo::ui::NavigationEvent>& events) {
+    using lambo::ui::NavigationEventType;
+    using lambo::ui::NavigationKey;
+    for (const auto& event : events) {
+        if (event.type == NavigationEventType::Press) {
+            set_input_mode(InputMode::KeyboardOrController);
+            if (context != nullptr && context->GetFocusElement() == nullptr && current_page.has_value()) {
+                restore_focus(*current_page);
+            }
+        }
+        if (event.key == NavigationKey::Back) {
+            if (event.type == NavigationEventType::Press) back();
+            continue;
+        }
+        const int key = sdl_key_from_navigation(event.key);
+        if (key == SDLK_UNKNOWN) continue;
+        if (event.type == NavigationEventType::Press) {
+            context->ProcessKeyDown(RmlSDL::ConvertKey(key), 0);
+        } else {
+            context->ProcessKeyUp(RmlSDL::ConvertKey(key), 0);
+        }
+    }
+}
+
+void UiState::process_queued_events() {
+    QueuedEvent queued{};
+    while (g_event_queue.try_dequeue(queued)) {
+        SDL_Event& event = queued.event;
+        if (context == nullptr) continue;
+        switch (event.type) {
+            case SDL_KEYDOWN:
+                process_key_down(event.key.keysym.sym, event.key.repeat != 0);
+                break;
+            case SDL_KEYUP:
+                context->ProcessKeyUp(RmlSDL::ConvertKey(event.key.keysym.sym),
+                                      RmlSDL::GetKeyModifierState());
+                break;
+            case SDL_CONTROLLERBUTTONDOWN: {
+                if (const auto key = navigation_key_from_button(event.cbutton.button)) {
+                    process_navigation_events(controller_navigation.button_down(*key, Clock::now()));
+                }
+                break;
+            }
+            case SDL_CONTROLLERBUTTONUP: {
+                if (const auto key = navigation_key_from_button(event.cbutton.button)) {
+                    process_navigation_events(controller_navigation.button_up(*key, Clock::now()));
+                }
+                break;
+            }
+            case SDL_CONTROLLERAXISMOTION: {
+                std::optional<lambo::ui::NavigationAxis> axis;
+                if (event.caxis.axis == SDL_CONTROLLER_AXIS_LEFTX) {
+                    axis = lambo::ui::NavigationAxis::Horizontal;
+                } else if (event.caxis.axis == SDL_CONTROLLER_AXIS_LEFTY) {
+                    axis = lambo::ui::NavigationAxis::Vertical;
+                }
+                if (axis.has_value()) {
+                    process_navigation_events(
+                        controller_navigation.axis_motion(*axis, event.caxis.value, Clock::now()));
+                }
+                break;
+            }
+            case SDL_CONTROLLERDEVICEREMOVED:
+                controller_navigation.reset();
+                break;
+            case SDL_MOUSEMOTION:
+            case SDL_MOUSEBUTTONDOWN:
+            case SDL_MOUSEBUTTONUP:
+            case SDL_MOUSEWHEEL:
+                set_input_mode(InputMode::Mouse);
+                RmlSDL::InputEventHandler(context, event);
+                break;
+            case SDL_TEXTINPUT:
+                set_input_mode(InputMode::KeyboardOrController);
+                RmlSDL::InputEventHandler(context, event);
+                break;
+            default:
+                RmlSDL::InputEventHandler(context, event);
+                break;
+        }
+    }
+    process_navigation_events(controller_navigation.update(Clock::now()));
+}
+
+void draw_hook(RT64::RenderCommandList* command_list,
+               RT64::RenderFramebuffer* swap_chain_framebuffer) {
+    std::lock_guard lock(g_state_mutex);
+    if (g_state == nullptr || g_state->context == nullptr || swap_chain_framebuffer == nullptr) return;
+
+    const int requested = g_requested_page.exchange(-1, std::memory_order_acq_rel);
+    if (requested >= 0) {
+        g_state->entry_point = static_cast<lambo::ui::EntryPoint>(
+            g_requested_entry_point.load(std::memory_order_acquire));
+        g_state->pages.clear();
+        if (requested == static_cast<int>(lambo::ui::Page::Controls) &&
+            g_requested_controls_route.exchange(false, std::memory_order_acq_rel)) {
+            if (g_state->entry_point == lambo::ui::EntryPoint::Startup)
+                g_state->pages = {lambo::ui::Page::Home, lambo::ui::Page::Settings};
+            else
+                g_state->pages = {lambo::ui::Page::Settings};
+        }
+        g_state->show_page(static_cast<lambo::ui::Page>(requested));
+    }
+    if (g_requested_back.exchange(false, std::memory_order_acq_rel)) g_state->back();
+    g_state->process_queued_events();
+    if (!g_visible.load(std::memory_order_acquire)) return;
+    g_state->refresh_controls_values();
+
+    const int width = swap_chain_framebuffer->getWidth();
+    const int height = swap_chain_framebuffer->getHeight();
+    g_state->context->SetDimensions({width, height});
+    g_state->context->SetDensityIndependentPixelRatio(height / 1080.0f);
+    g_state->context->Update();
+    g_state->render_interface.start(command_list, width, height);
+    g_state->context->Render();
+    g_state->render_interface.end(command_list, swap_chain_framebuffer);
+}
+
+void deinit_hook() {
+    std::lock_guard lock(g_state_mutex);
+    lambo::controls::enqueue_command({lambo::controls::CommandKind::CaptureCancel});
+    g_state.reset();
+    g_visible.store(false, std::memory_order_release);
+    g_capture.store(false, std::memory_order_release);
+}
+
+} // namespace
+
+namespace lambo::ui {
+
+void set_window(SDL_Window* window) { g_window = window; }
+
+void install_render_hooks() {
+    RT64::SetRenderHooks(init_hook, draw_hook, deinit_hook);
+}
+
+void set_startup_controller(lambo::StartupController* controller) {
+    g_startup_controller.store(controller, std::memory_order_release);
+}
+
+bool handle_event(const SDL_Event& event) {
+    if (!g_capture.load(std::memory_order_acquire)) return false;
+    switch (event.type) {
+        case SDL_MOUSEMOTION:
+        case SDL_MOUSEBUTTONDOWN:
+        case SDL_MOUSEBUTTONUP:
+        case SDL_MOUSEWHEEL:
+            SDL_ShowCursor(SDL_ENABLE);
+            g_event_queue.enqueue(QueuedEvent{event});
+            return true;
+        case SDL_KEYDOWN:
+        case SDL_TEXTINPUT:
+        case SDL_CONTROLLERBUTTONDOWN:
+            SDL_ShowCursor(SDL_DISABLE);
+            g_event_queue.enqueue(QueuedEvent{event});
+            return true;
+        case SDL_KEYUP:
+        case SDL_CONTROLLERBUTTONUP:
+            g_event_queue.enqueue(QueuedEvent{event});
+            return true;
+        case SDL_CONTROLLERAXISMOTION:
+            if ((event.caxis.axis == SDL_CONTROLLER_AXIS_LEFTX ||
+                 event.caxis.axis == SDL_CONTROLLER_AXIS_LEFTY) &&
+                lambo::ui::navigation_axis_active(event.caxis.value)) {
+                SDL_ShowCursor(SDL_DISABLE);
+            }
+            g_event_queue.enqueue(QueuedEvent{event});
+            return true;
+        case SDL_CONTROLLERDEVICEREMOVED:
+            g_event_queue.enqueue(QueuedEvent{event});
+            return true;
+        case SDL_WINDOWEVENT:
+            g_event_queue.enqueue(QueuedEvent{event});
+            return true;
+        default:
+            return false;
+    }
+}
+
+void open_launcher() {
+    g_requested_entry_point.store(static_cast<int>(EntryPoint::Startup), std::memory_order_release);
+    SDL_ShowCursor(SDL_ENABLE);
+    g_capture.store(true, std::memory_order_release);
+    g_requested_controls_route.store(false, std::memory_order_release);
+    g_requested_page.store(static_cast<int>(Page::Home), std::memory_order_release);
+}
+
+void open_settings() {
+    g_requested_entry_point.store(static_cast<int>(EntryPoint::InGameOverlay), std::memory_order_release);
+    SDL_ShowCursor(SDL_ENABLE);
+    g_capture.store(true, std::memory_order_release);
+    g_requested_controls_route.store(false, std::memory_order_release);
+    g_requested_page.store(static_cast<int>(Page::Settings), std::memory_order_release);
+}
+
+void open_controls() {
+    auto* startup = g_startup_controller.load(std::memory_order_acquire);
+    const EntryPoint entry = startup != nullptr && startup->state() == lambo::StartupState::Started
+        ? EntryPoint::InGameOverlay : EntryPoint::Startup;
+    g_requested_entry_point.store(static_cast<int>(entry), std::memory_order_release);
+    SDL_ShowCursor(SDL_ENABLE);
+    g_capture.store(true, std::memory_order_release);
+    g_requested_controls_route.store(true, std::memory_order_release);
+    g_requested_page.store(static_cast<int>(Page::Controls), std::memory_order_release);
+}
+
+void open_graphics() {
+    g_requested_entry_point.store(static_cast<int>(EntryPoint::Startup), std::memory_order_release);
+    SDL_ShowCursor(SDL_ENABLE);
+    g_capture.store(true, std::memory_order_release);
+    g_requested_controls_route.store(false, std::memory_order_release);
+    g_requested_page.store(static_cast<int>(Page::Graphics), std::memory_order_release);
+}
+
+void open_enhancements() {
+    g_requested_entry_point.store(static_cast<int>(EntryPoint::Startup), std::memory_order_release);
+    SDL_ShowCursor(SDL_ENABLE);
+    g_capture.store(true, std::memory_order_release);
+    g_requested_controls_route.store(false, std::memory_order_release);
+    g_requested_page.store(static_cast<int>(Page::Enhancements), std::memory_order_release);
+}
+
+void open_haptics() {
+    g_requested_entry_point.store(static_cast<int>(EntryPoint::Startup), std::memory_order_release);
+    SDL_ShowCursor(SDL_ENABLE);
+    g_capture.store(true, std::memory_order_release);
+    g_requested_controls_route.store(false, std::memory_order_release);
+    g_requested_page.store(static_cast<int>(Page::Haptics), std::memory_order_release);
+}
+
+void close_top_page() {
+    g_requested_back.store(true, std::memory_order_release);
+}
+
+bool is_initialized() {
+    std::lock_guard lock(g_state_mutex);
+    return g_state != nullptr && g_state->context != nullptr;
+}
+bool is_visible() { return g_visible.load(std::memory_order_acquire); }
+bool captures_input() { return g_capture.load(std::memory_order_acquire); }
+
+void shutdown() {
+    RT64::SetRenderHooks(nullptr, nullptr, nullptr);
+    deinit_hook();
+    Rml::Debugger::Shutdown();
+    Rml::Shutdown();
+}
+
+} // namespace lambo::ui

--- a/src/ui/lambo_ui.h
+++ b/src/ui/lambo_ui.h
@@ -1,0 +1,47 @@
+#ifndef LAMBO_UI_H
+#define LAMBO_UI_H
+
+#include <cstdint>
+
+union SDL_Event;
+struct SDL_Window;
+
+namespace lambo {
+class StartupController;
+}
+
+namespace lambo::ui {
+
+enum class Page {
+    Home,
+    Settings,
+    Graphics,
+    Enhancements,
+    Controls,
+    Haptics,
+};
+
+enum class EntryPoint {
+    Startup,
+    InGameOverlay,
+};
+
+void set_window(SDL_Window* window);
+void install_render_hooks();
+void set_startup_controller(lambo::StartupController* controller);
+bool handle_event(const SDL_Event& event);
+void open_launcher();
+void open_settings();
+void open_controls();
+void open_graphics();
+void open_enhancements();
+void open_haptics();
+void close_top_page();
+bool is_initialized();
+bool is_visible();
+bool captures_input();
+void shutdown();
+
+} // namespace lambo::ui
+
+#endif

--- a/src/ui/lambo_ui_controls.cpp
+++ b/src/ui/lambo_ui_controls.cpp
@@ -1,0 +1,291 @@
+#include "lambo_ui_controls.h"
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <cstdio>
+#include <sstream>
+#include <vector>
+
+namespace {
+
+using namespace lambo::controls;
+
+std::vector<std::string_view> split(std::string_view value) {
+    std::vector<std::string_view> result;
+    while (true) {
+        const std::size_t separator = value.find(':');
+        result.push_back(value.substr(0, separator));
+        if (separator == std::string_view::npos) return result;
+        value.remove_prefix(separator + 1);
+    }
+}
+
+template <typename Number>
+std::optional<Number> number(std::string_view value) {
+    Number result{};
+    const auto parsed = std::from_chars(value.data(), value.data() + value.size(), result);
+    if (parsed.ec != std::errc{} || parsed.ptr != value.data() + value.size()) return std::nullopt;
+    return result;
+}
+
+const char* layout_name(ControllerLayout layout) {
+    switch (layout) {
+        case ControllerLayout::Xbox: return "Xbox";
+        case ControllerLayout::PlayStation: return "PlayStation";
+        case ControllerLayout::Nintendo: return "Nintendo";
+        case ControllerLayout::Generic: return "Generic";
+    }
+    return "Generic";
+}
+
+std::string source_label(const DigitalSource& source) {
+    if (const auto* button = std::get_if<ButtonSource>(&source)) {
+        return "Button " + std::string(button_name(button->button));
+    }
+    const auto& half = std::get<AxisHalfSource>(source);
+    return std::string(axis_name(half.axis)) +
+        (half.direction == AxisDirection::Positive ? " +" : " -");
+}
+
+} // namespace
+
+namespace lambo::ui {
+
+std::string escape_rml(std::string_view text) {
+    std::string result;
+    result.reserve(text.size());
+    for (const char c : text) {
+        switch (c) {
+            case '&': result += "&amp;"; break;
+            case '<': result += "&lt;"; break;
+            case '>': result += "&gt;"; break;
+            case '"': result += "&quot;"; break;
+            case '\'': result += "&#39;"; break;
+            default: result += c; break;
+        }
+    }
+    return result;
+}
+
+namespace {
+
+struct TargetMeta {
+    Target target;
+    const char* badge_class;
+    const char* badge_text;
+    const char* name;
+};
+
+constexpr std::array<TargetMeta, 6> buttons_targets{{
+    {Target::A, "n64-badge-a", "A", "A Button"},
+    {Target::B, "n64-badge-b", "B", "B Button"},
+    {Target::Start, "n64-badge-start", "START", "Start"},
+    {Target::Z, "n64-badge-z", "Z", "Z Trigger"},
+    {Target::L, "n64-badge-shoulder", "L", "L Shoulder"},
+    {Target::R, "n64-badge-shoulder", "R", "R Shoulder"},
+}};
+
+constexpr std::array<TargetMeta, 4> cbuttons_targets{{
+    {Target::CUp, "n64-badge-c", "C-U", "C-Up"},
+    {Target::CDown, "n64-badge-c", "C-D", "C-Down"},
+    {Target::CLeft, "n64-badge-c", "C-L", "C-Left"},
+    {Target::CRight, "n64-badge-c", "C-R", "C-Right"},
+}};
+
+constexpr std::array<TargetMeta, 4> dpad_targets{{
+    {Target::DpadUp, "n64-badge-dpad", "D-U", "D-Pad Up"},
+    {Target::DpadDown, "n64-badge-dpad", "D-D", "D-Pad Down"},
+    {Target::DpadLeft, "n64-badge-dpad", "D-L", "D-Pad Left"},
+    {Target::DpadRight, "n64-badge-dpad", "D-R", "D-Pad Right"},
+}};
+
+constexpr std::array<TargetMeta, 2> stick_targets{{
+    {Target::StickX, "n64-badge-stick", "X", "N64 Stick X"},
+    {Target::StickY, "n64-badge-stick", "Y", "N64 Stick Y"},
+}};
+
+static_assert(buttons_targets.size() + cbuttons_targets.size() + dpad_targets.size() + stick_targets.size() ==
+              static_cast<std::size_t>(Target::Count));
+
+void render_mapper_row(std::ostringstream& out, const TargetMeta& meta,
+                       const UiSnapshot& snapshot, const char* disabled) {
+    const Target target = meta.target;
+    const std::size_t index = static_cast<std::size_t>(target);
+    const std::string_view tname = target_name(target);
+
+    out << "<div class=\"mapper-row\">"
+        << "<div class=\"mapper-label-col\">"
+        << "<span class=\"n64-badge " << meta.badge_class << "\">" << meta.badge_text << "</span>"
+        << "<span class=\"mapper-target-name\">" << meta.name << "</span>"
+        << "</div>";
+
+    if (index < digital_target_count) {
+        const auto& sources = snapshot.profile.digital[index];
+        out << "<button" << disabled << " class=\"mapper-slot-btn\" onclick=\"control:add:" << tname << "\">";
+        if (sources.empty()) {
+            out << "<span class=\"mapper-slot-val slot-empty\">None (Click)</span>";
+        } else {
+            out << "<span class=\"mapper-slot-val\">" << escape_rml(source_label(sources[0])) << "</span>";
+        }
+        out << "</button>";
+    } else {
+        const auto& source = snapshot.profile.analog[index - digital_target_count];
+        out << "<button" << disabled << " class=\"mapper-slot-btn\" onclick=\"control:add:" << tname << "\">"
+            << "<span class=\"mapper-slot-val\">Axis " << axis_name(source.axis) << "</span>"
+            << "</button>";
+    }
+    out << "</div>";
+}
+
+} // namespace
+
+std::optional<Command> control_action_from_name(std::string_view action) {
+    if (action.starts_with("control:")) action.remove_prefix(8);
+    const auto fields = split(action);
+    if (fields.empty()) return std::nullopt;
+    Command command{};
+    if (fields[0] == "select" && fields.size() == 2) {
+        const auto instance = number<std::int32_t>(fields[1]);
+        if (!instance || *instance < 0) return std::nullopt;
+        command.kind = CommandKind::Select; command.instance = *instance; return command;
+    }
+    if (fields[0] == "reset-profile" && fields.size() == 1) {
+        command.kind = CommandKind::ResetProfile; return command;
+    }
+    if (fields[0] == "conflict-accept" && fields.size() == 1) {
+        command.kind = CommandKind::ConflictAccept; return command;
+    }
+    if (fields[0] == "capture-cancel" && fields.size() == 1) {
+        command.kind = CommandKind::CaptureCancel; return command;
+    }
+    if (fields.size() < 2) return std::nullopt;
+    const auto target = target_from_name(fields[1]);
+    if (!target) return std::nullopt;
+    command.target = *target;
+    if (fields[0] == "add" && fields.size() == 2) command.kind = CommandKind::Add;
+    else if (fields[0] == "reset-target" && fields.size() == 2) command.kind = CommandKind::ResetTarget;
+    else if (fields[0] == "invert" && fields.size() == 2 &&
+             (*target == Target::StickX || *target == Target::StickY)) command.kind = CommandKind::Invert;
+    else if (fields[0] == "remove" && fields.size() == 3) {
+        if (static_cast<std::size_t>(*target) >= digital_target_count) return std::nullopt;
+        const auto index = number<std::size_t>(fields[2]); if (!index) return std::nullopt;
+        command.kind = CommandKind::Remove; command.binding_index = *index;
+    } else if (fields[0] == "threshold" && fields.size() == 4) {
+        if (static_cast<std::size_t>(*target) >= digital_target_count) return std::nullopt;
+        const auto index = number<std::size_t>(fields[2]); const auto value = number<int>(fields[3]);
+        if (!index || !value || *value < 0 || *value > 32767) return std::nullopt;
+        command.kind = CommandKind::Threshold; command.binding_index = *index; command.value = *value;
+    } else if (fields[0] == "deadzone" && fields.size() == 3 &&
+               (*target == Target::StickX || *target == Target::StickY)) {
+        const auto value = number<int>(fields[2]);
+        if (!value || *value < 0 || *value > 32767) return std::nullopt;
+        command.kind = CommandKind::Deadzone; command.value = *value;
+    } else return std::nullopt;
+    return command;
+}
+
+bool apply_control_action(std::string_view action) {
+    const auto command = control_action_from_name(action);
+    if (!command) return false;
+    enqueue_command(*command);
+    return true;
+}
+
+ControlsView controls_view(const UiSnapshot& snapshot) {
+    ControlsView view{};
+    std::ostringstream controllers;
+    for (const auto& controller : snapshot.controllers) {
+        controllers << "<button class=\"controller-choice" << (controller.active ? " active" : "")
+                    << "\" onclick=\"control:select:" << controller.instance << "\">"
+                    << escape_rml(controller.name) << "</button>";
+        if (controller.active) {
+            view.selected_name = escape_rml(controller.name);
+            view.selected_status = "Connected / active";
+            view.selected_layout = layout_name(controller.layout);
+            view.selected_guid = escape_rml(controller.guid);
+        }
+    }
+    view.controller_list = controllers.str();
+    if (!snapshot.selected_instance) {
+        view.selected_name = "No controller";
+        view.selected_status = "Keyboard remains available";
+        view.selected_layout = "-";
+        view.selected_guid = "-";
+    }
+
+    std::ostringstream bindings;
+    const char* disabled = snapshot.read_only || !snapshot.selected_instance ? " disabled=\"disabled\"" : "";
+
+    bindings << "<div class=\"mapper-grid columns\">";
+
+    // Column 1: BUTTONS & TRIGGERS
+    bindings << "<div class=\"column mapper-section\">"
+             << "<span class=\"mapper-section-title\">BUTTONS &amp; TRIGGERS</span>";
+    for (const auto& meta : buttons_targets) {
+        render_mapper_row(bindings, meta, snapshot, disabled);
+    }
+    bindings << "</div>";
+
+    // Column 2: C-BUTTONS
+    bindings << "<div class=\"column mapper-section\">"
+             << "<span class=\"mapper-section-title\">C-BUTTONS</span>";
+    for (const auto& meta : cbuttons_targets) {
+        render_mapper_row(bindings, meta, snapshot, disabled);
+    }
+    bindings << "</div>";
+
+    // Column 3: DIGITAL PAD
+    bindings << "<div class=\"column mapper-section\">"
+             << "<span class=\"mapper-section-title\">DIGITAL PAD</span>";
+    for (const auto& meta : dpad_targets) {
+        render_mapper_row(bindings, meta, snapshot, disabled);
+    }
+    bindings << "</div>";
+
+    // Column 4: ANALOG STICK
+    bindings << "<div class=\"column mapper-section\">"
+             << "<span class=\"mapper-section-title\">ANALOG STICK</span>";
+    for (const auto& meta : stick_targets) {
+        render_mapper_row(bindings, meta, snapshot, disabled);
+    }
+    bindings << "</div>";
+
+    bindings << "</div>";
+    view.bindings = bindings.str();
+
+    std::ostringstream raw;
+    raw << "Buttons: ";
+    bool any_button = false;
+    for (std::size_t i = 0; i < static_cast<std::size_t>(LogicalButton::Count); ++i) {
+        if (!snapshot.raw.buttons[i]) continue;
+        if (any_button) raw << ", ";
+        raw << button_name(static_cast<LogicalButton>(i));
+        any_button = true;
+    }
+    if (!any_button) raw << "none";
+    raw << " | Axes: ";
+    for (std::size_t i = 0; i < static_cast<std::size_t>(LogicalAxis::Count); ++i) {
+        if (i) raw << " | "; raw << axis_name(static_cast<LogicalAxis>(i)) << '=' << snapshot.raw.axes[i];
+    }
+    view.raw_preview = raw.str();
+    view.evaluated_preview = "Buttons 0x";
+    char mask[5]{}; std::snprintf(mask, sizeof(mask), "%04x", snapshot.evaluated.buttons);
+    view.evaluated_preview += mask;
+    view.evaluated_preview += " / Stick (" + std::to_string(snapshot.evaluated.stick_x) + ", " +
+                              std::to_string(snapshot.evaluated.stick_y) + ")";
+    view.persistence_status = escape_rml(snapshot.status + " - " + snapshot.config_path.string());
+    for (const auto& warning : snapshot.warnings) view.warnings += "<p>" + escape_rml(warning) + "</p>";
+    view.capture_visible = snapshot.capture_phase != CapturePhase::Idle &&
+                           snapshot.capture_phase != CapturePhase::Conflict;
+    view.conflict_visible = snapshot.capture_phase == CapturePhase::Conflict;
+    if (snapshot.capture_target) {
+        view.capture_message = "Binding " + std::string(target_label(*snapshot.capture_target));
+        if (snapshot.capture_phase == CapturePhase::WaitingForNeutral) view.capture_message += ": release all controls";
+        else if (snapshot.capture_phase == CapturePhase::Listening) view.capture_message += ": press a button or move an axis";
+        else if (snapshot.capture_phase == CapturePhase::WaitingForRelease) view.capture_message += ": release the control";
+    }
+    return view;
+}
+
+} // namespace lambo::ui

--- a/src/ui/lambo_ui_controls.h
+++ b/src/ui/lambo_ui_controls.h
@@ -1,0 +1,35 @@
+#ifndef LAMBO_UI_CONTROLS_H
+#define LAMBO_UI_CONTROLS_H
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "controls/lambo_controls.h"
+
+namespace lambo::ui {
+
+struct ControlsView {
+    std::string controller_list;
+    std::string selected_name;
+    std::string selected_status;
+    std::string selected_layout;
+    std::string selected_guid;
+    std::string bindings;
+    std::string raw_preview;
+    std::string evaluated_preview;
+    std::string persistence_status;
+    std::string warnings;
+    std::string capture_message;
+    bool capture_visible{};
+    bool conflict_visible{};
+};
+
+std::optional<lambo::controls::Command> control_action_from_name(std::string_view action);
+bool apply_control_action(std::string_view action);
+ControlsView controls_view(const lambo::controls::UiSnapshot& snapshot);
+std::string escape_rml(std::string_view text);
+
+} // namespace lambo::ui
+
+#endif

--- a/src/ui/lambo_ui_input.cpp
+++ b/src/ui/lambo_ui_input.cpp
@@ -1,0 +1,113 @@
+#include "lambo_ui_input.h"
+
+#include <cstdlib>
+
+namespace lambo::ui {
+
+namespace {
+
+constexpr auto initial_repeat_delay = std::chrono::milliseconds(500);
+constexpr auto repeat_interval = std::chrono::milliseconds(50);
+constexpr int axis_dead_zone = 9000;
+
+size_t index_of(NavigationKey key) {
+    return static_cast<size_t>(key);
+}
+
+bool repeatable(NavigationKey key) {
+    return key == NavigationKey::Up || key == NavigationKey::Down ||
+           key == NavigationKey::Left || key == NavigationKey::Right;
+}
+
+NavigationKey axis_key(NavigationAxis axis, int value) {
+    if (!navigation_axis_active(value)) return NavigationKey::None;
+    if (axis == NavigationAxis::Horizontal) {
+        return value > 0 ? NavigationKey::Right : NavigationKey::Left;
+    }
+    return value > 0 ? NavigationKey::Down : NavigationKey::Up;
+}
+
+} // namespace
+
+bool navigation_axis_active(int value) {
+    return std::abs(value) >= axis_dead_zone;
+}
+
+std::vector<NavigationEvent> ControllerNavigation::button_down(NavigationKey key, TimePoint now) {
+    if (key == NavigationKey::None || key == NavigationKey::Count) return {};
+    const size_t index = index_of(key);
+    if (button_held_[index]) return {};
+    button_held_[index] = true;
+    return press_source(key, now);
+}
+
+std::vector<NavigationEvent> ControllerNavigation::button_up(NavigationKey key, TimePoint now) {
+    if (key == NavigationKey::None || key == NavigationKey::Count) return {};
+    const size_t index = index_of(key);
+    if (!button_held_[index]) return {};
+    button_held_[index] = false;
+    return release_source(key, now);
+}
+
+std::vector<NavigationEvent> ControllerNavigation::axis_motion(NavigationAxis axis, int value,
+                                                               TimePoint now) {
+    const size_t axis_index = static_cast<size_t>(axis);
+    const NavigationKey previous = axis_keys_[axis_index];
+    const NavigationKey next = axis_key(axis, value);
+    if (previous == next) return {};
+
+    std::vector<NavigationEvent> events;
+    if (previous != NavigationKey::None) {
+        auto released = release_source(previous, now);
+        events.insert(events.end(), released.begin(), released.end());
+    }
+    axis_keys_[axis_index] = next;
+    if (next != NavigationKey::None) {
+        auto pressed = press_source(next, now);
+        events.insert(events.end(), pressed.begin(), pressed.end());
+    }
+    return events;
+}
+
+std::vector<NavigationEvent> ControllerNavigation::update(TimePoint now) {
+    if (repeating_key_ == NavigationKey::None || now < next_repeat_) return {};
+    next_repeat_ = now + repeat_interval;
+    return {{NavigationEventType::Press, repeating_key_}};
+}
+
+void ControllerNavigation::reset() {
+    button_held_.fill(false);
+    source_counts_.fill(0);
+    axis_keys_.fill(NavigationKey::None);
+    repeating_key_ = NavigationKey::None;
+    next_repeat_ = {};
+}
+
+std::vector<NavigationEvent> ControllerNavigation::press_source(NavigationKey key, TimePoint now) {
+    const size_t index = index_of(key);
+    if (source_counts_[index]++ != 0) return {};
+    if (repeatable(key)) {
+        repeating_key_ = key;
+        next_repeat_ = now + initial_repeat_delay;
+    }
+    return {{NavigationEventType::Press, key}};
+}
+
+std::vector<NavigationEvent> ControllerNavigation::release_source(NavigationKey key, TimePoint now) {
+    const size_t index = index_of(key);
+    if (source_counts_[index] == 0 || --source_counts_[index] != 0) return {};
+    if (repeating_key_ == key) {
+        repeating_key_ = NavigationKey::None;
+        for (NavigationKey candidate : {NavigationKey::Up, NavigationKey::Down,
+                                        NavigationKey::Left, NavigationKey::Right}) {
+            if (source_counts_[index_of(candidate)] != 0) {
+                repeating_key_ = candidate;
+                next_repeat_ = now + initial_repeat_delay;
+                break;
+            }
+        }
+    }
+    return {{NavigationEventType::Release, key}};
+}
+
+} // namespace lambo::ui

--- a/src/ui/lambo_ui_input.h
+++ b/src/ui/lambo_ui_input.h
@@ -1,0 +1,68 @@
+#ifndef LAMBO_UI_INPUT_H
+#define LAMBO_UI_INPUT_H
+
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace lambo::ui {
+
+enum class NavigationKey : uint8_t {
+    None,
+    Activate,
+    Back,
+    Up,
+    Down,
+    Left,
+    Right,
+    Count,
+};
+
+enum class NavigationEventType : uint8_t {
+    Press,
+    Release,
+};
+
+struct NavigationEvent {
+    NavigationEventType type;
+    NavigationKey key;
+
+    bool operator==(const NavigationEvent&) const = default;
+};
+
+enum class NavigationAxis : uint8_t {
+    Horizontal,
+    Vertical,
+};
+
+bool navigation_axis_active(int value);
+
+class ControllerNavigation {
+public:
+    using Clock = std::chrono::steady_clock;
+    using TimePoint = Clock::time_point;
+
+    std::vector<NavigationEvent> button_down(NavigationKey key, TimePoint now);
+    std::vector<NavigationEvent> button_up(NavigationKey key, TimePoint now);
+    std::vector<NavigationEvent> axis_motion(NavigationAxis axis, int value, TimePoint now);
+    std::vector<NavigationEvent> update(TimePoint now);
+    void reset();
+
+private:
+    static constexpr size_t key_count = static_cast<size_t>(NavigationKey::Count);
+
+    std::vector<NavigationEvent> press_source(NavigationKey key, TimePoint now);
+    std::vector<NavigationEvent> release_source(NavigationKey key, TimePoint now);
+
+    std::array<bool, key_count> button_held_{};
+    std::array<uint8_t, key_count> source_counts_{};
+    std::array<NavigationKey, 2> axis_keys_{NavigationKey::None, NavigationKey::None};
+    NavigationKey repeating_key_ = NavigationKey::None;
+    TimePoint next_repeat_{};
+};
+
+} // namespace lambo::ui
+
+#endif

--- a/src/ui/lambo_ui_render_interface.cpp
+++ b/src/ui/lambo_ui_render_interface.cpp
@@ -1,0 +1,712 @@
+#ifdef _WIN32
+#define _CRT_SECURE_NO_WARNINGS
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <fstream>
+#include <filesystem>
+
+#include <concurrentqueue.h>
+
+#include "rt64_render_hooks.h"
+#include "rt64_render_interface_builders.h"
+#include "rt64_texture_cache.h"
+
+#include "RmlUi/Core/RenderInterfaceCompatibility.h"
+
+#include "lambo_ui_render_interface.h"
+
+#include "InterfaceVS.hlsl.spirv.h"
+#include "InterfacePS.hlsl.spirv.h"
+
+#ifdef _WIN32
+#   include "InterfaceVS.hlsl.dxil.h"
+#   include "InterfacePS.hlsl.dxil.h"
+#elif defined(__APPLE__)
+#   include "InterfaceVS.hlsl.metal.h"
+#   include "InterfacePS.hlsl.metal.h"
+#endif
+
+#ifdef _WIN32
+#    define GET_SHADER_BLOB(name, format) \
+        ((format) == RT64::RenderShaderFormat::SPIRV ? name##BlobSPIRV : \
+        (format) == RT64::RenderShaderFormat::DXIL ? name##BlobDXIL : nullptr)
+#    define GET_SHADER_SIZE(name, format) \
+        ((format) == RT64::RenderShaderFormat::SPIRV ? std::size(name##BlobSPIRV) : \
+        (format) == RT64::RenderShaderFormat::DXIL ? std::size(name##BlobDXIL) : 0)
+#elif defined(__APPLE__)
+#    define GET_SHADER_BLOB(name, format) \
+((format) == RT64::RenderShaderFormat::SPIRV ? name##BlobSPIRV : \
+(format) == RT64::RenderShaderFormat::METAL ? name##BlobMSL : nullptr)
+#    define GET_SHADER_SIZE(name, format) \
+((format) == RT64::RenderShaderFormat::SPIRV ? std::size(name##BlobSPIRV) : \
+(format) == RT64::RenderShaderFormat::METAL ? std::size(name##BlobMSL) : 0)
+#else
+#    define GET_SHADER_BLOB(name, format) \
+        ((format) == RT64::RenderShaderFormat::SPIRV ? name##BlobSPIRV : nullptr)
+#    define GET_SHADER_SIZE(name, format) \
+        ((format) == RT64::RenderShaderFormat::SPIRV ? std::size(name##BlobSPIRV) : 0)
+#endif
+
+// TODO deduplicate from rt64_common.h
+void CalculateTextureRowWidthPadding(uint32_t rowPitch, uint32_t &rowWidth, uint32_t &rowPadding) {
+    const int RowMultiple = 256;
+    rowWidth = rowPitch;
+    rowPadding = (rowWidth % RowMultiple) ? RowMultiple - (rowWidth % RowMultiple) : 0;
+    rowWidth += rowPadding;
+}
+
+struct RmlPushConstants {
+    Rml::Matrix4f transform;
+    Rml::Vector2f translation;
+};
+
+struct TextureHandle {
+    std::unique_ptr<RT64::RenderTexture> texture;
+    std::unique_ptr<RT64::RenderDescriptorSet> set;
+    bool transitioned = false;
+};
+
+template <typename T>
+T from_bytes_le(const char* input) {
+    return *reinterpret_cast<const T*>(input);
+}
+
+enum class ImageType {
+    File,
+    RGBA32
+};
+
+struct ImageFromBytes {
+    ImageType type;
+    // Encoded files carry their own dimensions; raw RGBA data does not.
+    uint32_t width;
+    uint32_t height;
+    std::string name;
+    std::vector<char> bytes;
+};
+
+namespace lambo::ui {
+class RmlRenderInterface_RT64_impl : public Rml::RenderInterfaceCompatibility {
+    struct DynamicBuffer {
+        std::unique_ptr<RT64::RenderBuffer> buffer_{};
+        uint32_t size_ = 0;
+        uint32_t bytes_used_ = 0;
+        uint8_t* mapped_data_ = nullptr;
+        RT64::RenderBufferFlags flags_ = RT64::RenderBufferFlag::NONE;
+    };
+
+    static constexpr uint32_t per_frame_descriptor_set = 0;
+    static constexpr uint32_t per_draw_descriptor_set = 1;
+
+    static constexpr uint32_t initial_upload_buffer_size = 1024 * 1024;
+    static constexpr uint32_t initial_vertex_buffer_size = 512 * sizeof(Rml::Vertex);
+    static constexpr uint32_t initial_index_buffer_size = 1024 * sizeof(int);
+    static constexpr RT64::RenderFormat RmlTextureFormat = RT64::RenderFormat::R8G8B8A8_UNORM;
+    static constexpr RT64::RenderFormat RmlTextureFormatBgra = RT64::RenderFormat::B8G8R8A8_UNORM;
+    static constexpr RT64::RenderFormat SwapChainFormat = RT64::RenderFormat::B8G8R8A8_UNORM;
+    static constexpr uint32_t RmlTextureFormatBytesPerPixel = RenderFormatSize(RmlTextureFormat);
+    static_assert(RenderFormatSize(RmlTextureFormatBgra) == RmlTextureFormatBytesPerPixel);
+    RT64::RenderInterface* interface_;
+    RT64::RenderDevice* device_;
+    int scissor_x_ = 0;
+    int scissor_y_ = 0;
+    int scissor_width_ = 0;
+    int scissor_height_ = 0;
+    int window_width_ = 0;
+    int window_height_ = 0;
+    RT64::RenderMultisampling multisampling_ = RT64::RenderMultisampling();
+    Rml::Matrix4f projection_mtx_ = Rml::Matrix4f::Identity();
+    Rml::Matrix4f transform_ = Rml::Matrix4f::Identity();
+    Rml::Matrix4f mvp_ = Rml::Matrix4f::Identity();
+    std::unordered_map<Rml::TextureHandle, TextureHandle> textures_{};
+    // Handles 0 and 1 are stable white/transparent fallback textures.
+    Rml::TextureHandle texture_count_ = 2;
+    DynamicBuffer upload_buffer_;
+    DynamicBuffer vertex_buffer_;
+    DynamicBuffer index_buffer_;
+    std::unique_ptr<RT64::RenderSampler> nearestSampler_{};
+    std::unique_ptr<RT64::RenderSampler> linearSampler_{};
+    std::unique_ptr<RT64::RenderShader> vertex_shader_{};
+    std::unique_ptr<RT64::RenderShader> pixel_shader_{};
+    std::unique_ptr<RT64::RenderDescriptorSet> sampler_set_{};
+    std::unique_ptr<RT64::RenderDescriptorSetBuilder> texture_set_builder_{};
+    std::unique_ptr<RT64::RenderPipelineLayout> layout_{};
+    std::unique_ptr<RT64::RenderPipeline> pipeline_{};
+    std::unique_ptr<RT64::RenderPipeline> pipeline_ms_{};
+    std::unique_ptr<RT64::RenderTexture> screen_texture_ms_{};
+    std::unique_ptr<RT64::RenderTexture> screen_texture_{};
+    std::unique_ptr<RT64::RenderFramebuffer> screen_framebuffer_{};
+    std::unique_ptr<RT64::RenderDescriptorSet> screen_descriptor_set_{};
+    std::unique_ptr<RT64::RenderBuffer> screen_vertex_buffer_{};
+    std::unique_ptr<RT64::RenderCommandQueue> copy_command_queue_{};
+    std::unique_ptr<RT64::RenderCommandList> copy_command_list_{};
+    std::unique_ptr<RT64::RenderBuffer> copy_buffer_{};
+    std::unique_ptr<RT64::RenderCommandFence> copy_command_fence_;
+    uint64_t copy_buffer_size_ = 0;
+    uint64_t screen_vertex_buffer_size_ = 0;
+    uint32_t gTexture_descriptor_index;
+    RT64::RenderInputSlot vertex_slot_{ 0, sizeof(Rml::Vertex) };
+    RT64::RenderCommandList* list_ = nullptr;
+    bool scissor_enabled_ = false;
+    std::vector<std::unique_ptr<RT64::RenderBuffer>> stale_buffers_{};
+    moodycamel::ConcurrentQueue<ImageFromBytes> image_from_bytes_queue;
+    std::unordered_map<std::string, ImageFromBytes> image_from_bytes_map;
+public:
+    RmlRenderInterface_RT64_impl(RT64::RenderInterface* interface, RT64::RenderDevice* device) {
+        interface_ = interface;
+        device_ = device;
+
+        // Enable 4X MSAA if supported by the device.
+        const RT64::RenderSampleCounts desired_sample_count = RT64::RenderSampleCount::COUNT_8;
+        if (device_->getSampleCountsSupported(SwapChainFormat) & desired_sample_count) {
+            multisampling_.sampleCount = desired_sample_count;
+        }
+
+        vertex_buffer_.flags_ = RT64::RenderBufferFlag::VERTEX;
+        index_buffer_.flags_ = RT64::RenderBufferFlag::INDEX;
+
+        // Create the texture upload buffer, vertex buffer and index buffer
+        resize_dynamic_buffer(upload_buffer_, initial_upload_buffer_size, false);
+        resize_dynamic_buffer(vertex_buffer_, initial_vertex_buffer_size, false);
+        resize_dynamic_buffer(index_buffer_, initial_index_buffer_size, false);
+
+        // Describe the vertex format
+        std::vector<RT64::RenderInputElement> vertex_elements{};
+        vertex_elements.emplace_back(RT64::RenderInputElement{ "POSITION", 0, 0, RT64::RenderFormat::R32G32_FLOAT, 0, offsetof(Rml::Vertex, position) });
+        vertex_elements.emplace_back(RT64::RenderInputElement{ "COLOR", 0, 1, RT64::RenderFormat::R8G8B8A8_UNORM, 0, offsetof(Rml::Vertex, colour) });
+        vertex_elements.emplace_back(RT64::RenderInputElement{ "TEXCOORD", 0, 2, RT64::RenderFormat::R32G32_FLOAT, 0, offsetof(Rml::Vertex, tex_coord) });
+
+        // Create a nearest sampler and a linear sampler
+        RT64::RenderSamplerDesc samplerDesc;
+        samplerDesc.minFilter = RT64::RenderFilter::NEAREST;
+        samplerDesc.magFilter = RT64::RenderFilter::NEAREST;
+        samplerDesc.addressU = RT64::RenderTextureAddressMode::CLAMP;
+        samplerDesc.addressV = RT64::RenderTextureAddressMode::CLAMP;
+        samplerDesc.addressW = RT64::RenderTextureAddressMode::CLAMP;
+        nearestSampler_ = device_->createSampler(samplerDesc);
+
+        samplerDesc.minFilter = RT64::RenderFilter::LINEAR;
+        samplerDesc.magFilter = RT64::RenderFilter::LINEAR;
+        linearSampler_ = device_->createSampler(samplerDesc);
+
+        // Create the shaders
+        RT64::RenderShaderFormat shaderFormat = interface_->getCapabilities().shaderFormat;
+
+        vertex_shader_ = device_->createShader(GET_SHADER_BLOB(InterfaceVS, shaderFormat), GET_SHADER_SIZE(InterfaceVS, shaderFormat), "VSMain", shaderFormat);
+        pixel_shader_ = device_->createShader(GET_SHADER_BLOB(InterfacePS, shaderFormat), GET_SHADER_SIZE(InterfacePS, shaderFormat), "PSMain", shaderFormat);
+
+
+        // Create the descriptor set that contains the sampler
+        RT64::RenderDescriptorSetBuilder sampler_set_builder{};
+        sampler_set_builder.begin();
+        sampler_set_builder.addImmutableSampler(1, linearSampler_.get());
+        sampler_set_builder.addConstantBuffer(3, 1); // Workaround D3D12 crash due to an empty RT64 descriptor set
+        sampler_set_builder.end();
+        sampler_set_ = sampler_set_builder.create(device_);
+
+        // Create a builder for the descriptor sets that will contain textures
+        texture_set_builder_ = std::make_unique<RT64::RenderDescriptorSetBuilder>();
+        texture_set_builder_->begin();
+        gTexture_descriptor_index = texture_set_builder_->addTexture(2);
+        texture_set_builder_->end();
+
+        // Create the pipeline layout
+        RT64::RenderPipelineLayoutBuilder layout_builder{};
+        layout_builder.begin(false, true);
+        layout_builder.addPushConstant(0, 0, sizeof(RmlPushConstants), RT64::RenderShaderStageFlag::VERTEX);
+        // Add the descriptor set for descriptors changed once per frame.
+        layout_builder.addDescriptorSet(sampler_set_builder);
+        // Add the descriptor set for descriptors changed once per draw.
+        layout_builder.addDescriptorSet(*texture_set_builder_);
+        layout_builder.end();
+        layout_ = layout_builder.create(device_);
+
+        // Create the pipeline description
+        RT64::RenderGraphicsPipelineDesc pipeline_desc{};
+        // Set up alpha blending for non-premultiplied alpha. RmlUi recommends using premultiplied alpha normally,
+        // but that would require preprocessing all input files, which would be difficult for user-provided content (such as mods).
+        // This blending setup produces similar results as premultipled alpha but for normal assets as it multiplies during blending and
+        // computes the output alpha value the same way that a premultipled alpha blender would.
+        pipeline_desc.renderTargetBlend[0] = RT64::RenderBlendDesc {
+            .blendEnabled = true,
+            .srcBlend = RT64::RenderBlend::SRC_ALPHA,
+            .dstBlend = RT64::RenderBlend::INV_SRC_ALPHA,
+            .blendOp = RT64::RenderBlendOperation::ADD,
+            .srcBlendAlpha = RT64::RenderBlend::ONE,
+            .dstBlendAlpha = RT64::RenderBlend::INV_SRC_ALPHA,
+            .blendOpAlpha = RT64::RenderBlendOperation::ADD,
+        };
+        pipeline_desc.renderTargetFormat[0] = SwapChainFormat; // TODO: Use whatever format the swap chain was created with.
+        pipeline_desc.renderTargetCount = 1;
+        pipeline_desc.cullMode = RT64::RenderCullMode::NONE;
+        pipeline_desc.inputSlots = &vertex_slot_;
+        pipeline_desc.inputSlotsCount = 1;
+        pipeline_desc.inputElements = vertex_elements.data();
+        pipeline_desc.inputElementsCount = uint32_t(vertex_elements.size());
+        pipeline_desc.pipelineLayout = layout_.get();
+        pipeline_desc.primitiveTopology = RT64::RenderPrimitiveTopology::TRIANGLE_LIST;
+        pipeline_desc.vertexShader = vertex_shader_.get();
+        pipeline_desc.pixelShader = pixel_shader_.get();
+
+        pipeline_ = device_->createGraphicsPipeline(pipeline_desc);
+
+        if (multisampling_.sampleCount > 1) {
+            pipeline_desc.multisampling = multisampling_;
+            pipeline_ms_ = device_->createGraphicsPipeline(pipeline_desc);
+
+            // Create the descriptor set for the screen drawer.
+            RT64::RenderDescriptorRange screen_descriptor_range(RT64::RenderDescriptorRangeType::TEXTURE, 2, 1);
+            screen_descriptor_set_ = device_->createDescriptorSet(RT64::RenderDescriptorSetDesc(&screen_descriptor_range, 1));
+
+            // Create vertex buffer for the screen drawer (full-screen triangle).
+            screen_vertex_buffer_size_ = sizeof(Rml::Vertex) * 3;
+            screen_vertex_buffer_ = device_->createBuffer(RT64::RenderBufferDesc::VertexBuffer(screen_vertex_buffer_size_, RT64::RenderHeapType::UPLOAD));
+            Rml::Vertex *vertices = (Rml::Vertex *)(screen_vertex_buffer_->map());
+            const Rml::ColourbPremultiplied white(255, 255, 255, 255);
+            vertices[0] = Rml::Vertex{ Rml::Vector2f(-1.0f, 1.0f), white, Rml::Vector2f(0.0f, 0.0f) };
+            vertices[1] = Rml::Vertex{ Rml::Vector2f(-1.0f, -3.0f), white, Rml::Vector2f(0.0f, 2.0f) };
+            vertices[2] = Rml::Vertex{ Rml::Vector2f(3.0f, 1.0f), white, Rml::Vector2f(2.0f, 0.0f) };
+            screen_vertex_buffer_->unmap();
+        }
+
+        copy_command_queue_ = device->createCommandQueue(RT64::RenderCommandListType::COPY);
+        // The pinned RT64/Plume queue creates a list for the queue's type; newer
+        // RT64 revisions expose an explicit type parameter here.
+        copy_command_list_ = copy_command_queue_->createCommandList();
+        copy_command_fence_ = device->createCommandFence();
+    }
+
+    void reset_dynamic_buffer(DynamicBuffer &dynamic_buffer) {
+        assert(dynamic_buffer.mapped_data_ == nullptr);
+        dynamic_buffer.bytes_used_ = 0;
+        dynamic_buffer.mapped_data_ = reinterpret_cast<uint8_t*>(dynamic_buffer.buffer_->map());
+    }
+
+    void end_dynamic_buffer(DynamicBuffer &dynamic_buffer) {
+        assert(dynamic_buffer.mapped_data_ != nullptr);
+        dynamic_buffer.buffer_->unmap();
+        dynamic_buffer.mapped_data_ = nullptr;
+    }
+
+    void resize_dynamic_buffer(DynamicBuffer &dynamic_buffer, uint32_t new_size, bool map = true) {
+        if (dynamic_buffer.mapped_data_ != nullptr) {
+            dynamic_buffer.buffer_->unmap();
+        }
+
+        // The submitted command list may still reference the old allocation.
+        if (dynamic_buffer.buffer_ != nullptr) {
+            stale_buffers_.emplace_back(std::move(dynamic_buffer.buffer_));
+        }
+
+        dynamic_buffer.buffer_ = device_->createBuffer(RT64::RenderBufferDesc::UploadBuffer(new_size, dynamic_buffer.flags_));
+        dynamic_buffer.size_ = new_size;
+        dynamic_buffer.bytes_used_ = 0;
+
+        if (map) {
+            dynamic_buffer.mapped_data_ = reinterpret_cast<uint8_t*>(dynamic_buffer.buffer_->map());
+        }
+    }
+
+    uint32_t allocate_dynamic_data(DynamicBuffer &dynamic_buffer, uint32_t num_bytes) {
+        // Check if there's enough remaining room in the buffer to allocate the requested bytes.
+        uint32_t total_bytes = num_bytes + dynamic_buffer.bytes_used_;
+
+        if (total_bytes > dynamic_buffer.size_) {
+            // There isn't, so mark the current buffer as stale and allocate a new one with 50% more space than the required amount.
+            resize_dynamic_buffer(dynamic_buffer, total_bytes + total_bytes / 2);
+        }
+
+        // Record the current end of the buffer to return.
+        uint32_t offset = dynamic_buffer.bytes_used_;
+
+        // Bump the buffer's end forward by the number of bytes allocated.
+        dynamic_buffer.bytes_used_ += num_bytes;
+
+        return offset;
+    }
+
+    uint32_t allocate_dynamic_data_aligned(DynamicBuffer &dynamic_buffer, uint32_t num_bytes, uint32_t alignment) {
+        // Check if there's enough remaining room in the buffer to allocate the requested bytes.
+        uint32_t total_bytes = num_bytes + dynamic_buffer.bytes_used_;
+
+        // Determine the amount of padding needed to meet the target alignment.
+        uint32_t padding_bytes = ((dynamic_buffer.bytes_used_ + alignment - 1) / alignment) * alignment - dynamic_buffer.bytes_used_;
+
+        // If there isn't enough room to allocate the required bytes plus the padding then resize the buffer and allocate from the start of the new one.
+        if (total_bytes + padding_bytes > dynamic_buffer.size_) {
+            resize_dynamic_buffer(dynamic_buffer, total_bytes + total_bytes / 2);
+
+            dynamic_buffer.bytes_used_ += num_bytes;
+
+            return 0;
+        }
+
+        return allocate_dynamic_data(dynamic_buffer, padding_bytes + num_bytes) + padding_bytes;
+    }
+
+    void RenderGeometry(Rml::Vertex* vertices, int num_vertices, int* indices, int num_indices, Rml::TextureHandle texture, const Rml::Vector2f& translation) override {
+        if (!textures_.contains(texture)) {
+            if (texture == 0) {
+                Rml::byte white_pixel[] = { 255, 255, 255, 255 };
+                create_texture(0, white_pixel, Rml::Vector2i{ 1, 1 });
+            }
+            else if (texture == 1) {
+                Rml::byte transparent_pixel[] = { 0, 0, 0, 0 };
+                create_texture(1, transparent_pixel, Rml::Vector2i{ 1, 1 });
+            }
+            else {
+                assert(false && "Rendered without texture!");
+            }
+        }
+
+        // Copy the vertex and index data into the mapped buffers.
+        uint32_t vert_size_bytes = num_vertices * sizeof(*vertices);
+        uint32_t index_size_bytes = num_indices * sizeof(*indices);
+        uint32_t vertex_buffer_offset = allocate_dynamic_data(vertex_buffer_, vert_size_bytes);
+        uint32_t index_buffer_offset = allocate_dynamic_data(index_buffer_, index_size_bytes);
+        memcpy(vertex_buffer_.mapped_data_ + vertex_buffer_offset, vertices, vert_size_bytes);
+        memcpy(index_buffer_.mapped_data_ + index_buffer_offset, indices, index_size_bytes);
+
+        list_->setViewports(RT64::RenderViewport{ 0, 0, float(window_width_), float(window_height_) });
+        if (scissor_enabled_) {
+            list_->setScissors(RT64::RenderRect{
+                scissor_x_,
+                scissor_y_,
+                (scissor_width_ + scissor_x_),
+                (scissor_height_ + scissor_y_) });
+        }
+        else {
+            list_->setScissors(RT64::RenderRect{ 0, 0, window_width_, window_height_ });
+        }
+
+        RT64::RenderIndexBufferView index_view{index_buffer_.buffer_->at(index_buffer_offset), index_size_bytes, RT64::RenderFormat::R32_UINT};
+        list_->setIndexBuffer(&index_view);
+        RT64::RenderVertexBufferView vertex_view{vertex_buffer_.buffer_->at(vertex_buffer_offset), vert_size_bytes};
+        list_->setVertexBuffers(0, &vertex_view, 1, &vertex_slot_);
+
+        TextureHandle &texture_handle = textures_.at(texture);
+        if (!texture_handle.transitioned) {
+            // Prepare the texture for being read from a pixel shader.
+            list_->barriers(RT64::RenderBarrierStage::GRAPHICS, RT64::RenderTextureBarrier(texture_handle.texture.get(), RT64::RenderTextureLayout::SHADER_READ));
+            texture_handle.transitioned = true;
+        }
+
+        list_->setGraphicsDescriptorSet(texture_handle.set.get(), 1);
+
+        RmlPushConstants constants{
+            .transform = mvp_,
+            .translation = translation
+        };
+
+        list_->setGraphicsPushConstants(0, &constants);
+
+        list_->drawIndexedInstanced(num_indices, 1, 0, 0, 0);
+    }
+
+    void EnableScissorRegion(bool enable) override {
+        scissor_enabled_ = enable;
+    }
+
+    void SetScissorRegion(int x, int y, int width, int height) override {
+        scissor_x_ = x;
+        scissor_y_ = y;
+        scissor_width_ = width;
+        scissor_height_ = height;
+    }
+
+    bool LoadTexture(Rml::TextureHandle& texture_handle, Rml::Vector2i& texture_dimensions, const Rml::String& source) override {
+        flush_image_from_bytes_queue();
+
+        auto it = image_from_bytes_map.find(source);
+        if (it == image_from_bytes_map.end()) {
+            // Return a transparent texture if the image can't be found.
+            texture_handle = 1;
+            texture_dimensions.x = 1;
+            texture_dimensions.y = 1;
+            return true;
+        }
+
+        RT64::Texture* texture = nullptr;
+        std::unique_ptr<RT64::RenderBuffer> texture_buffer;
+        ImageFromBytes& img = it->second;
+        copy_command_list_->begin();
+
+        switch (img.type) {
+            case ImageType::RGBA32:
+                {
+                    uint32_t rowPitch = img.width * 4;
+                    size_t byteCount = img.height * rowPitch;
+                    texture = new RT64::Texture();
+                    RT64::TextureCache::setRGBA32(texture, device_, copy_command_list_.get(), reinterpret_cast<const uint8_t*>(img.bytes.data()), byteCount, img.width, img.height, rowPitch, texture_buffer, nullptr);
+                }
+                break;
+            case ImageType::File:
+                {
+                    // TODO: This data copy can be avoided when RT64::TextureCache::loadTextureFromBytes's function is updated to only take a pointer and size as the input.
+                    std::vector<uint8_t> data_copy(img.bytes.data(), img.bytes.data() + img.bytes.size());
+                    texture = RT64::TextureCache::loadTextureFromBytes(device_, copy_command_list_.get(), data_copy, texture_buffer);
+                }
+                break;
+        }
+
+        copy_command_list_->end();
+        copy_command_queue_->executeCommandLists(copy_command_list_.get(), copy_command_fence_.get());
+        copy_command_queue_->waitForCommandFence(copy_command_fence_.get());
+
+        if (texture == nullptr) {
+            return false;
+        }
+
+        texture_handle = texture_count_++;
+        texture_dimensions.x = texture->width;
+        texture_dimensions.y = texture->height;
+
+        std::unique_ptr<RT64::RenderDescriptorSet> set = texture_set_builder_->create(device_);
+        set->setTexture(gTexture_descriptor_index, texture->texture.get(), RT64::RenderTextureLayout::SHADER_READ);
+        textures_.emplace(texture_handle, TextureHandle{ std::move(texture->texture), std::move(set), false });
+        delete texture;
+
+        return true;
+    }
+
+    bool GenerateTexture(Rml::TextureHandle& texture_handle, const Rml::byte* source, const Rml::Vector2i& source_dimensions) override {
+        if (source_dimensions.x == 0 || source_dimensions.y == 0) {
+            texture_handle = 0;
+            return true;
+        }
+
+        texture_handle = texture_count_++;
+        return create_texture(texture_handle, source, source_dimensions);
+    }
+
+    bool create_texture(Rml::TextureHandle texture_handle, const Rml::byte* source, const Rml::Vector2i& source_dimensions, bool flip_y = false, bool bgra = false) {
+        std::unique_ptr<RT64::RenderTexture> texture =
+            device_->createTexture(RT64::RenderTextureDesc::Texture2D(source_dimensions.x, source_dimensions.y, 1, bgra ? RmlTextureFormatBgra : RmlTextureFormat));
+
+        if (texture != nullptr) {
+            uint32_t image_size_bytes = source_dimensions.x * source_dimensions.y * RmlTextureFormatBytesPerPixel;
+
+            // RT64 texture-copy rows must be aligned to 256 bytes.
+            uint32_t row_pitch = source_dimensions.x * RmlTextureFormatBytesPerPixel;
+            uint32_t row_byte_width, row_byte_padding;
+            CalculateTextureRowWidthPadding(row_pitch, row_byte_width, row_byte_padding);
+            uint32_t row_width = row_byte_width / RmlTextureFormatBytesPerPixel;
+
+            uint32_t uploaded_size_bytes = row_byte_width * source_dimensions.y;
+
+            if (uploaded_size_bytes > copy_buffer_size_) {
+                copy_buffer_size_ = (uploaded_size_bytes * 3) / 2;
+                copy_buffer_ = device_->createBuffer(RT64::RenderBufferDesc::UploadBuffer(copy_buffer_size_));
+            }
+
+            uint8_t* dst_data = (uint8_t *)(copy_buffer_->map());
+            if (row_byte_padding == 0) {
+                // Copy row-by-row if the image is flipped.
+                if (flip_y) {
+                    for (int row = 0; row < source_dimensions.y; row++) {
+                        memcpy(dst_data + row_byte_width * (source_dimensions.y - row - 1), source + row_byte_width * row, row_byte_width);
+                    }
+                }
+                // Directly copy if no padding is needed and the image isn't flipped.
+                else {
+                    memcpy(dst_data, source, image_size_bytes);
+                }
+            }
+            // Otherwise pad each row as necessary.
+            else {
+                const Rml::byte *src_data = flip_y ? source + row_pitch * (source_dimensions.y - 1) : source;
+                uint32_t src_stride = flip_y ? -row_pitch : row_pitch;
+
+                for (int row = 0; row < source_dimensions.y; row++) {
+                    memcpy(dst_data, src_data, row_pitch);
+                    src_data += src_stride;
+                    dst_data += row_byte_width;
+                }
+            }
+
+            copy_buffer_->unmap();
+
+            copy_command_list_->begin();
+
+            copy_command_list_->barriers(RT64::RenderBarrierStage::COPY, RT64::RenderTextureBarrier(texture.get(), RT64::RenderTextureLayout::COPY_DEST));
+
+            copy_command_list_->copyTextureRegion(
+                RT64::RenderTextureCopyLocation::Subresource(texture.get()),
+                RT64::RenderTextureCopyLocation::PlacedFootprint(copy_buffer_.get(), RmlTextureFormat, source_dimensions.x, source_dimensions.y, 1, row_width));
+
+            copy_command_list_->end();
+            copy_command_queue_->executeCommandLists(copy_command_list_.get(), copy_command_fence_.get());
+            copy_command_queue_->waitForCommandFence(copy_command_fence_.get());
+
+            std::unique_ptr<RT64::RenderDescriptorSet> set = texture_set_builder_->create(device_);
+
+            set->setTexture(gTexture_descriptor_index, texture.get(), RT64::RenderTextureLayout::SHADER_READ);
+
+            textures_.emplace(texture_handle, TextureHandle{ std::move(texture), std::move(set), false });
+
+            return true;
+        }
+
+        return false;
+    }
+
+	void ReleaseTexture(Rml::TextureHandle texture) override {
+        if (texture > 1) {
+            // Textures #0 and #1 are reserved and should never be released.
+            textures_.erase(texture);
+        }
+    }
+
+    void SetTransform(const Rml::Matrix4f* transform) override {
+        transform_ = transform ? *transform : Rml::Matrix4f::Identity();
+        recalculate_mvp();
+    }
+
+    void recalculate_mvp() {
+        mvp_ = projection_mtx_ * transform_;
+    }
+
+    void start(RT64::RenderCommandList* list, int image_width, int image_height) {
+        list_ = list;
+
+        if (multisampling_.sampleCount > 1) {
+            if (window_width_ != image_width || window_height_ != image_height) {
+                screen_framebuffer_.reset();
+                screen_texture_ = device_->createTexture(RT64::RenderTextureDesc::ColorTarget(image_width, image_height, SwapChainFormat));
+                screen_texture_ms_ = device_->createTexture(RT64::RenderTextureDesc::ColorTarget(image_width, image_height, SwapChainFormat, multisampling_));
+                const RT64::RenderTexture *color_attachment = screen_texture_ms_.get();
+                screen_framebuffer_ = device_->createFramebuffer(RT64::RenderFramebufferDesc(&color_attachment, 1));
+                screen_descriptor_set_->setTexture(0, screen_texture_.get(), RT64::RenderTextureLayout::SHADER_READ);
+            }
+
+            list_->setPipeline(pipeline_ms_.get());
+        }
+        else {
+            list_->setPipeline(pipeline_.get());
+        }
+
+        list_->setGraphicsPipelineLayout(layout_.get());
+        // Bind the set for descriptors that don't change across draws
+        list_->setGraphicsDescriptorSet(sampler_set_.get(), 0);
+
+        window_width_ = image_width;
+        window_height_ = image_height;
+
+        projection_mtx_ = Rml::Matrix4f::ProjectOrtho(0.0f, float(image_width), float(image_height), 0.0f, -10000, 10000);
+        recalculate_mvp();
+
+        // The following code assumes command lists aren't double buffered.
+        // Clear out any stale buffers from the last command list.
+        stale_buffers_.clear();
+
+        // Reset buffers.
+        reset_dynamic_buffer(upload_buffer_);
+        reset_dynamic_buffer(vertex_buffer_);
+        reset_dynamic_buffer(index_buffer_);
+
+        // Set an internal texture as the render target if MSAA is enabled.
+        if (multisampling_.sampleCount > 1) {
+            list->barriers(RT64::RenderBarrierStage::GRAPHICS, RT64::RenderTextureBarrier(screen_texture_ms_.get(), RT64::RenderTextureLayout::COLOR_WRITE));
+            list->setFramebuffer(screen_framebuffer_.get());
+            list->clearColor(0, RT64::RenderColor(0.0f, 0.0f, 0.0f, 0.0f));
+        }
+    }
+
+    void end(RT64::RenderCommandList* list, RT64::RenderFramebuffer* framebuffer) {
+        // Draw the texture were rendered the UI in to the swap chain framebuffer if MSAA is enabled.
+        if (multisampling_.sampleCount > 1) {
+            RT64::RenderTextureBarrier before_resolve_barriers[] = {
+                RT64::RenderTextureBarrier(screen_texture_ms_.get(), RT64::RenderTextureLayout::RESOLVE_SOURCE),
+                RT64::RenderTextureBarrier(screen_texture_.get(), RT64::RenderTextureLayout::RESOLVE_DEST)
+            };
+
+            list->barriers(RT64::RenderBarrierStage::COPY, before_resolve_barriers, uint32_t(std::size(before_resolve_barriers)));
+            list->resolveTexture(screen_texture_.get(), screen_texture_ms_.get());
+            list->barriers(RT64::RenderBarrierStage::GRAPHICS, RT64::RenderTextureBarrier(screen_texture_.get(), RT64::RenderTextureLayout::SHADER_READ));
+            list->setFramebuffer(framebuffer);
+            list->setPipeline(pipeline_.get());
+            list->setGraphicsPipelineLayout(layout_.get());
+            list->setGraphicsDescriptorSet(sampler_set_.get(), 0);
+            list->setGraphicsDescriptorSet(screen_descriptor_set_.get(), 1);
+            list->setScissors(RT64::RenderRect{ 0, 0, window_width_, window_height_ });
+            RT64::RenderVertexBufferView vertex_view(screen_vertex_buffer_.get(), screen_vertex_buffer_size_);
+            list->setVertexBuffers(0, &vertex_view, 1, &vertex_slot_);
+
+            RmlPushConstants constants{
+                .transform = Rml::Matrix4f::Identity(),
+                .translation = Rml::Vector2f(0.0f, 0.0f)
+            };
+
+            list_->setGraphicsPushConstants(0, &constants);
+            list->drawInstanced(3, 1, 0, 0);
+        }
+
+        end_dynamic_buffer(upload_buffer_);
+        end_dynamic_buffer(vertex_buffer_);
+        end_dynamic_buffer(index_buffer_);
+
+        list_ = nullptr;
+    }
+
+    void queue_image_from_bytes_file(const std::string &src, const std::vector<char> &bytes) {
+        // Width and height aren't used for file images, so set them to 0.
+        image_from_bytes_queue.enqueue(ImageFromBytes{ .type = ImageType::File, .width = 0, .height = 0, .name = src, .bytes = bytes });
+    }
+
+    void queue_image_from_bytes_rgba32(const std::string &src, const std::vector<char> &bytes, uint32_t width, uint32_t height) {
+        image_from_bytes_queue.enqueue(ImageFromBytes{ .type = ImageType::RGBA32, .width = width, .height = height, .name = src, .bytes = bytes });
+    }
+
+    void flush_image_from_bytes_queue() {
+        ImageFromBytes image_from_bytes;
+        while (image_from_bytes_queue.try_dequeue(image_from_bytes)) {
+            // We can move the name into the map since the name in the actual entry is no longer needed.
+            // After that, move the entry itself into the map.
+            image_from_bytes_map.emplace(std::move(image_from_bytes.name), std::move(image_from_bytes));
+        }
+    }
+};
+} // namespace lambo::ui
+
+lambo::ui::RmlRenderInterface_RT64::RmlRenderInterface_RT64() = default;
+lambo::ui::RmlRenderInterface_RT64::~RmlRenderInterface_RT64() = default;
+
+void lambo::ui::RmlRenderInterface_RT64::reset() {
+    impl.reset();
+}
+
+void lambo::ui::RmlRenderInterface_RT64::init(RT64::RenderInterface* interface, RT64::RenderDevice* device) {
+    impl = std::make_unique<RmlRenderInterface_RT64_impl>(interface, device);
+}
+
+Rml::RenderInterface* lambo::ui::RmlRenderInterface_RT64::get_rml_interface() {
+    if (impl) {
+        return impl->GetAdaptedInterface();
+    }
+    return nullptr;
+}
+
+void lambo::ui::RmlRenderInterface_RT64::start(RT64::RenderCommandList* list, int image_width, int image_height) {
+    assert(static_cast<bool>(impl));
+
+    impl->start(list, image_width, image_height);
+}
+
+void lambo::ui::RmlRenderInterface_RT64::end(RT64::RenderCommandList* list, RT64::RenderFramebuffer* framebuffer) {
+    assert(static_cast<bool>(impl));
+
+    impl->end(list, framebuffer);
+}
+
+void lambo::ui::RmlRenderInterface_RT64::queue_image_from_bytes_file(const std::string &src, const std::vector<char> &bytes) {
+    assert(static_cast<bool>(impl));
+
+    impl->queue_image_from_bytes_file(src, bytes);
+}
+
+void lambo::ui::RmlRenderInterface_RT64::queue_image_from_bytes_rgba32(const std::string &src, const std::vector<char> &bytes, uint32_t width, uint32_t height) {
+    assert(static_cast<bool>(impl));
+
+    impl->queue_image_from_bytes_rgba32(src, bytes, width, height);
+}

--- a/src/ui/lambo_ui_render_interface.h
+++ b/src/ui/lambo_ui_render_interface.h
@@ -1,0 +1,42 @@
+#ifndef __UI_RENDERER_H__
+#define __UI_RENDERER_H__
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/rt64_plume.h"
+
+// The pinned RT64 revision exposes Plume's render interfaces through a using
+// directive, while newer revisions place the same names directly in RT64.
+// Preserve the latter spelling for the UI adapter on both revisions.
+namespace RT64 {
+    using namespace plume;
+}
+
+namespace Rml {
+    class RenderInterface;
+}
+
+namespace lambo::ui {
+    class RmlRenderInterface_RT64_impl;
+
+    class RmlRenderInterface_RT64 {
+    private:
+        std::unique_ptr<RmlRenderInterface_RT64_impl> impl;
+    public:
+        RmlRenderInterface_RT64();
+        ~RmlRenderInterface_RT64();
+        void reset();
+        void init(RT64::RenderInterface* interface, RT64::RenderDevice* device);
+        Rml::RenderInterface* get_rml_interface();
+
+        void start(RT64::RenderCommandList* list, int image_width, int image_height);
+        void end(RT64::RenderCommandList* list, RT64::RenderFramebuffer* framebuffer);
+        void queue_image_from_bytes_file(const std::string &src, const std::vector<char> &bytes);
+        void queue_image_from_bytes_rgba32(const std::string &src, const std::vector<char> &bytes, uint32_t width, uint32_t height);
+    };
+} // namespace lambo::ui
+
+#endif

--- a/src/ui/lambo_ui_settings.cpp
+++ b/src/ui/lambo_ui_settings.cpp
@@ -1,0 +1,241 @@
+#include "lambo_ui_settings.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <iterator>
+#include <string>
+#include <utility>
+
+#include "lambo_config.h"
+
+namespace {
+
+using lambo::ui::SettingAction;
+
+constexpr auto setting_bindings = std::to_array<std::pair<std::string_view, SettingAction>>({
+    {"res:next", SettingAction::ResolutionNext},
+    {"ss:next", SettingAction::SupersamplingNext},
+    {"aspect:next", SettingAction::AspectNext},
+    {"hud:next", SettingAction::HudNext},
+    {"rate:next", SettingAction::RefreshNext},
+    {"msaa:next", SettingAction::MsaaNext},
+    {"hpfb:next", SettingAction::HpfbNext},
+    {"api:next", SettingAction::ApiNext},
+    {"fog:toggle", SettingAction::FogMatchToggle},
+    {"sky:toggle", SettingAction::SkyMatchToggle},
+    {"lod:toggle", SettingAction::NoLodToggle},
+    {"circuit:1", SettingAction::Circuit1Toggle},
+    {"circuit:2", SettingAction::Circuit2Toggle},
+    {"circuit:3", SettingAction::Circuit3Toggle},
+    {"circuit:4", SettingAction::Circuit4Toggle},
+    {"circuit:5", SettingAction::Circuit5Toggle},
+    {"circuit:6", SettingAction::Circuit6Toggle},
+    {"distance:next", SettingAction::DrawDistanceNext},
+    {"fogdensity:next", SettingAction::FogDensityNext},
+});
+
+template <typename T, size_t Size>
+T next_value(T current, const std::array<T, Size>& values) {
+    const auto position = std::find(values.begin(), values.end(), current);
+    if (position == values.end() || std::next(position) == values.end()) return values.front();
+    return *std::next(position);
+}
+
+template <size_t Size>
+double next_number(double current, const std::array<double, Size>& values) {
+    const auto position = std::find_if(values.begin(), values.end(), [current](double value) {
+        return std::abs(value - current) < 0.001;
+    });
+    if (position == values.end() || std::next(position) == values.end()) return values.front();
+    return *std::next(position);
+}
+
+const char* resolution_name(ultramodern::renderer::Resolution value) {
+    using ultramodern::renderer::Resolution;
+    switch (value) {
+        case Resolution::Auto: return "Automatic";
+        case Resolution::Original2x: return "Original 2x";
+        case Resolution::Original: return "Original";
+        default: return "Unknown";
+    }
+}
+
+const char* aspect_name(ultramodern::renderer::AspectRatio value) {
+    using ultramodern::renderer::AspectRatio;
+    switch (value) {
+        case AspectRatio::Original: return "Original 4:3";
+        case AspectRatio::Expand: return "Expand";
+        case AspectRatio::Manual: return "Manual";
+        default: return "Unknown";
+    }
+}
+
+const char* hud_name(ultramodern::renderer::HUDRatioMode value) {
+    using ultramodern::renderer::HUDRatioMode;
+    switch (value) {
+        case HUDRatioMode::Original: return "Original 4:3";
+        case HUDRatioMode::Clamp16x9: return "Clamp to 16:9";
+        case HUDRatioMode::Full: return "Full width";
+        default: return "Unknown";
+    }
+}
+
+std::string refresh_name(const ultramodern::renderer::GraphicsConfig& cfg) {
+    using ultramodern::renderer::RefreshRate;
+    if (cfg.rr_option == RefreshRate::Original) return "Original";
+    if (cfg.rr_option == RefreshRate::Display) return "Display";
+    if (cfg.rr_option == RefreshRate::Manual) return std::to_string(cfg.rr_manual_value) + " Hz";
+    return "Unknown";
+}
+
+const char* msaa_name(ultramodern::renderer::Antialiasing value) {
+    using ultramodern::renderer::Antialiasing;
+    switch (value) {
+        case Antialiasing::None: return "Off";
+        case Antialiasing::MSAA2X: return "2x";
+        case Antialiasing::MSAA4X: return "4x";
+        case Antialiasing::MSAA8X: return "8x";
+        default: return "Unknown";
+    }
+}
+
+const char* hpfb_name(ultramodern::renderer::HighPrecisionFramebuffer value) {
+    using ultramodern::renderer::HighPrecisionFramebuffer;
+    switch (value) {
+        case HighPrecisionFramebuffer::Auto: return "Automatic";
+        case HighPrecisionFramebuffer::On: return "On";
+        case HighPrecisionFramebuffer::Off: return "Off";
+        default: return "Unknown";
+    }
+}
+
+const char* api_name(ultramodern::renderer::GraphicsApi value) {
+    using ultramodern::renderer::GraphicsApi;
+    switch (value) {
+        case GraphicsApi::Auto: return "Automatic";
+        case GraphicsApi::D3D12: return "Direct3D 12";
+        case GraphicsApi::Vulkan: return "Vulkan";
+        case GraphicsApi::Metal: return "Metal";
+        default: return "Unknown";
+    }
+}
+
+std::string multiplier_name(double value) {
+    if (value <= 0.0) return "Unlimited";
+    const int tenths = static_cast<int>(std::lround(value * 10.0));
+    if (tenths % 10 == 0) return std::to_string(tenths / 10) + "x";
+    return std::to_string(tenths / 10) + "." + std::to_string(tenths % 10) + "x";
+}
+
+} // namespace
+
+namespace lambo::ui {
+
+std::optional<SettingAction> setting_action_from_name(std::string_view name) {
+    for (const auto& [binding, action] : setting_bindings) {
+        if (binding == name) return action;
+    }
+    return std::nullopt;
+}
+
+bool apply_setting_action(SettingAction action) {
+    using namespace ultramodern::renderer;
+    auto cfg = lambo::config::current_graphics();
+
+    switch (action) {
+        case SettingAction::ResolutionNext:
+            cfg.res_option = next_value(cfg.res_option,
+                std::array{Resolution::Auto, Resolution::Original, Resolution::Original2x}); break;
+        case SettingAction::SupersamplingNext:
+            cfg.ds_option = cfg.ds_option < 1 || cfg.ds_option >= 4 ? 1 : cfg.ds_option + 1; break;
+        case SettingAction::AspectNext:
+            cfg.ar_option = next_value(cfg.ar_option, std::array{AspectRatio::Expand, AspectRatio::Original}); break;
+        case SettingAction::HudNext:
+            cfg.hr_option = next_value(cfg.hr_option,
+                std::array{HUDRatioMode::Clamp16x9, HUDRatioMode::Full, HUDRatioMode::Original}); break;
+        case SettingAction::RefreshNext:
+            if (cfg.rr_option == RefreshRate::Original) cfg.rr_option = RefreshRate::Display;
+            else if (cfg.rr_option == RefreshRate::Display) { cfg.rr_option = RefreshRate::Manual; cfg.rr_manual_value = 30; }
+            else {
+                constexpr std::array rates{30, 60, 90, 120, 144, 165, 240};
+                const auto position = std::find(rates.begin(), rates.end(), cfg.rr_manual_value);
+                if (position == rates.end()) {
+                    const auto next_rate = std::upper_bound(rates.begin(), rates.end(), cfg.rr_manual_value);
+                    if (next_rate == rates.end()) cfg.rr_option = RefreshRate::Original;
+                    else cfg.rr_manual_value = *next_rate;
+                }
+                else if (std::next(position) == rates.end()) cfg.rr_option = RefreshRate::Original;
+                else cfg.rr_manual_value = *std::next(position);
+            }
+            break;
+        case SettingAction::MsaaNext:
+            cfg.msaa_option = next_value(cfg.msaa_option, std::array{
+                Antialiasing::None, Antialiasing::MSAA2X, Antialiasing::MSAA4X, Antialiasing::MSAA8X}); break;
+        case SettingAction::HpfbNext:
+            cfg.hpfb_option = next_value(cfg.hpfb_option, std::array{
+                HighPrecisionFramebuffer::Auto, HighPrecisionFramebuffer::On, HighPrecisionFramebuffer::Off}); break;
+        case SettingAction::ApiNext:
+#if defined(_WIN32)
+            cfg.api_option = next_value(cfg.api_option,
+                std::array{GraphicsApi::Auto, GraphicsApi::D3D12, GraphicsApi::Vulkan});
+#elif defined(__APPLE__)
+            cfg.api_option = next_value(cfg.api_option,
+                std::array{GraphicsApi::Auto, GraphicsApi::Metal});
+#else
+            cfg.api_option = next_value(cfg.api_option,
+                std::array{GraphicsApi::Auto, GraphicsApi::Vulkan});
+#endif
+            break;
+        case SettingAction::FogMatchToggle:
+            lambo::config::set_widescreen_fog_match(!lambo::config::widescreen_fog_match()); return true;
+        case SettingAction::SkyMatchToggle:
+            lambo::config::set_widescreen_sky_match(!lambo::config::widescreen_sky_match()); return true;
+        case SettingAction::NoLodToggle:
+            lambo::config::set_no_lod(!lambo::config::no_lod()); return true;
+        case SettingAction::Circuit1Toggle: case SettingAction::Circuit2Toggle:
+        case SettingAction::Circuit3Toggle: case SettingAction::Circuit4Toggle:
+        case SettingAction::Circuit5Toggle: case SettingAction::Circuit6Toggle: {
+            const int circuit = static_cast<int>(action) - static_cast<int>(SettingAction::Circuit1Toggle);
+            lambo::config::set_no_lod_circuit(circuit, !lambo::config::no_lod_circuit(circuit));
+            return true;
+        }
+        case SettingAction::DrawDistanceNext:
+            lambo::config::set_global_draw_distance(next_number(
+                lambo::config::global_draw_distance(), std::array{1.0, 1.5, 2.0, 3.0, 0.0})); return true;
+        case SettingAction::FogDensityNext:
+            lambo::config::set_global_fog_scale(next_number(
+                lambo::config::global_fog_scale(), std::array{0.0, 0.5, 0.75, 1.0, 1.5, 2.0})); return true;
+    }
+
+    lambo::config::apply_graphics(cfg);
+    return true;
+}
+
+SettingsSnapshot settings_snapshot() {
+    const auto cfg = lambo::config::current_graphics();
+    SettingsSnapshot result{
+        resolution_name(cfg.res_option),
+        std::to_string(cfg.ds_option) + "x",
+        aspect_name(cfg.ar_option),
+        hud_name(cfg.hr_option),
+        refresh_name(cfg),
+        msaa_name(cfg.msaa_option),
+        hpfb_name(cfg.hpfb_option),
+        api_name(cfg.api_option),
+        lambo::config::widescreen_fog_match() ? "Enabled" : "Disabled",
+        lambo::config::widescreen_sky_match() ? "Enabled" : "Disabled",
+        lambo::config::no_lod() ? "Enabled" : "Disabled",
+        multiplier_name(lambo::config::global_draw_distance()),
+        {},
+        {},
+    };
+    const int fog_percent = static_cast<int>(std::lround(lambo::config::global_fog_scale() * 100.0));
+    result.fog_density = fog_percent == 0 ? "Off" : std::to_string(fog_percent) + "%";
+    for (int circuit = 0; circuit < 6; ++circuit) {
+        result.circuit_visibility[circuit] = lambo::config::no_lod_circuit(circuit) ? "Enabled" : "Disabled";
+    }
+    return result;
+}
+
+} // namespace lambo::ui

--- a/src/ui/lambo_ui_settings.h
+++ b/src/ui/lambo_ui_settings.h
@@ -1,0 +1,56 @@
+#ifndef LAMBO_UI_SETTINGS_H
+#define LAMBO_UI_SETTINGS_H
+
+#include <array>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace lambo::ui {
+
+enum class SettingAction {
+    ResolutionNext,
+    SupersamplingNext,
+    AspectNext,
+    HudNext,
+    RefreshNext,
+    MsaaNext,
+    HpfbNext,
+    ApiNext,
+    FogMatchToggle,
+    SkyMatchToggle,
+    NoLodToggle,
+    Circuit1Toggle,
+    Circuit2Toggle,
+    Circuit3Toggle,
+    Circuit4Toggle,
+    Circuit5Toggle,
+    Circuit6Toggle,
+    DrawDistanceNext,
+    FogDensityNext,
+};
+
+struct SettingsSnapshot {
+    std::string resolution;
+    std::string supersampling;
+    std::string aspect_ratio;
+    std::string hud_layout;
+    std::string refresh_rate;
+    std::string msaa;
+    std::string framebuffer_precision;
+    std::string graphics_api;
+    std::string widescreen_fog;
+    std::string widescreen_sky;
+    std::string lod_removal;
+    std::string draw_distance;
+    std::string fog_density;
+    std::array<std::string, 6> circuit_visibility;
+};
+
+std::optional<SettingAction> setting_action_from_name(std::string_view name);
+bool apply_setting_action(SettingAction action);
+SettingsSnapshot settings_snapshot();
+
+} // namespace lambo::ui
+
+#endif

--- a/src/ui/rt64_render_interface_builders.h
+++ b/src/ui/rt64_render_interface_builders.h
@@ -1,0 +1,14 @@
+#ifndef LAMBO_RT64_RENDER_INTERFACE_BUILDERS_H
+#define LAMBO_RT64_RENDER_INTERFACE_BUILDERS_H
+
+// RT64's pinned revision keeps the descriptor/pipeline builders in Plume's
+// namespace. Newer RT64 revisions re-export them from RT64; keep this small
+// compatibility bridge local to the RmlUi renderer adapter.
+#include "plume_render_interface_builders.h"
+
+namespace RT64 {
+using plume::RenderDescriptorSetBuilder;
+using plume::RenderPipelineLayoutBuilder;
+}
+
+#endif

--- a/tests/test_controls.cpp
+++ b/tests/test_controls.cpp
@@ -1,0 +1,201 @@
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <thread>
+#include <atomic>
+
+#include "json/json.hpp"
+
+#include "controls/lambo_controls.h"
+#include "ultramodern/config.hpp"
+
+namespace ultramodern::renderer {
+void set_graphics_config(const GraphicsConfig&) {}
+}
+
+namespace {
+int failures = 0;
+void expect(bool condition, const std::string& message) {
+    if (!condition) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+
+std::filesystem::path temporary_path(const char* name) {
+    return std::filesystem::temp_directory_path() / name;
+}
+}
+
+int main() {
+    using namespace lambo::controls;
+    Profile profile = default_profile();
+    RawState raw{};
+
+    const std::array button_cases{
+        std::pair{LogicalButton::A, std::uint16_t{0x8000}},
+        std::pair{LogicalButton::B, std::uint16_t{0x4000}},
+        std::pair{LogicalButton::Start, std::uint16_t{0x1000}},
+        std::pair{LogicalButton::LeftShoulder, std::uint16_t{0x0020}},
+        std::pair{LogicalButton::RightShoulder, std::uint16_t{0x0010}},
+        std::pair{LogicalButton::DpadUp, std::uint16_t{0x0800}},
+        std::pair{LogicalButton::DpadDown, std::uint16_t{0x0400}},
+        std::pair{LogicalButton::DpadLeft, std::uint16_t{0x0200}},
+        std::pair{LogicalButton::DpadRight, std::uint16_t{0x0100}},
+        std::pair{LogicalButton::Y, std::uint16_t{0x0008}},
+        std::pair{LogicalButton::RightStick, std::uint16_t{0x0004}},
+        std::pair{LogicalButton::X, std::uint16_t{0x0002}},
+    };
+    for (const auto& [button, expected] : button_cases) {
+        raw = {};
+        raw.buttons[static_cast<std::size_t>(button)] = true;
+        expect(evaluate(profile, raw).buttons == expected,
+               "default button parity for " + std::string(button_name(button)));
+    }
+
+    raw = {};
+    raw.axes[static_cast<std::size_t>(LogicalAxis::TriggerLeft)] = 7999;
+    expect(evaluate(profile, raw).buttons == 0, "trigger is inactive below 8000");
+    raw.axes[static_cast<std::size_t>(LogicalAxis::TriggerLeft)] = 8000;
+    expect(evaluate(profile, raw).buttons == 0, "trigger threshold is strict at 8000");
+    raw.axes[static_cast<std::size_t>(LogicalAxis::TriggerLeft)] = 8001;
+    expect(evaluate(profile, raw).buttons == 0x2000, "left trigger maps to Z above threshold");
+    raw = {};
+    raw.axes[static_cast<std::size_t>(LogicalAxis::RightX)] = 11999;
+    expect(evaluate(profile, raw).buttons == 0, "C axis is inactive below 12000");
+    raw.axes[static_cast<std::size_t>(LogicalAxis::RightX)] = 12000;
+    expect(evaluate(profile, raw).buttons == 0, "C threshold is strict at 12000");
+    raw.axes[static_cast<std::size_t>(LogicalAxis::RightX)] = 12001;
+    expect(evaluate(profile, raw).buttons == 0x0001, "right X maps to C Right");
+    raw.axes[static_cast<std::size_t>(LogicalAxis::RightX)] = -12001;
+    expect(evaluate(profile, raw).buttons == 0x0002, "negative right X maps to C Left");
+    raw = {};
+    raw.axes[static_cast<std::size_t>(LogicalAxis::RightY)] = 12001;
+    expect(evaluate(profile, raw).buttons == 0x0004, "positive right Y maps to C Down");
+    raw.axes[static_cast<std::size_t>(LogicalAxis::RightY)] = -12001;
+    expect(evaluate(profile, raw).buttons == 0x0008, "negative right Y maps to C Up");
+    raw = {};
+    raw.axes[static_cast<std::size_t>(LogicalAxis::TriggerRight)] = 8001;
+    expect(evaluate(profile, raw).buttons == 0x0010, "right trigger is the second R source");
+
+    raw = {};
+    raw.axes[static_cast<std::size_t>(LogicalAxis::LeftX)] = 7999;
+    raw.axes[static_cast<std::size_t>(LogicalAxis::LeftY)] = 7999;
+    expect(evaluate(profile, raw).stick_x == 0 && evaluate(profile, raw).stick_y == 0,
+           "values strictly inside deadzone are neutral");
+    raw.axes[static_cast<std::size_t>(LogicalAxis::LeftX)] = 8000;
+    expect(evaluate(profile, raw).stick_x == 19, "deadzone boundary is not rescaled");
+    raw.axes[static_cast<std::size_t>(LogicalAxis::LeftX)] = 32767;
+    raw.axes[static_cast<std::size_t>(LogicalAxis::LeftY)] = 32767;
+    expect(evaluate(profile, raw).stick_x == 80 && evaluate(profile, raw).stick_y == -80,
+           "full range and Y inversion match legacy evaluator");
+    raw.axes[static_cast<std::size_t>(LogicalAxis::LeftX)] = std::numeric_limits<std::int16_t>::min();
+    expect(evaluate(profile, raw).stick_x == -80, "-32768 clamps safely to -80");
+
+    raw = {};
+    raw.buttons[static_cast<std::size_t>(LogicalButton::RightShoulder)] = true;
+    raw.axes[static_cast<std::size_t>(LogicalAxis::TriggerRight)] = 20000;
+    expect(evaluate(profile, raw).buttons == 0x0010, "multiple sources OR without duplicating target");
+
+    expect(canonicalize_guid("030000005E0400008E02000014010000") ==
+           std::optional<std::string>{"030000005e0400008e02000014010000"},
+           "GUID is canonical lowercase");
+    expect(!canonicalize_guid("not-a-guid"), "invalid GUID is rejected");
+
+    const auto path = temporary_path("lambo-controls-test.json");
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+    expect(load_config(path).status == LoadStatus::Missing, "missing file uses in-memory defaults");
+
+    ControlsConfig config{};
+    config.preferred_controller_guid = "030000005e0400008e02000014010000";
+    profile_for_guid(config, config.preferred_controller_guid).digital[0].clear();
+    config.preserved_document = R"({"version":1,"unknown_root":{"keep":true},"profiles":{"030000005e0400008e02000014010000":{"unknown_profile":7,"digital":{"b":[{"type":"button","button":"b","vendor_note":"keep"}]}}}})";
+    expect(save_config(config, path).saved, "controls config saves atomically");
+    auto loaded = load_config(path);
+    expect(loaded.status == LoadStatus::Loaded, "saved config reloads");
+    expect(profile_for_guid(loaded.config, config.preferred_controller_guid).digital[0].empty(),
+           "explicit empty binding remains unbound");
+    std::ifstream saved_file(path);
+    nlohmann::json saved; saved_file >> saved;
+    expect(saved["unknown_root"]["keep"] == true, "unknown root fields survive rewrite");
+    expect(saved["profiles"][config.preferred_controller_guid]["unknown_profile"] == 7,
+           "unknown profile fields survive rewrite");
+    expect(saved["profiles"][config.preferred_controller_guid]["digital"]["b"][0]["vendor_note"] == "keep",
+           "unknown binding fields survive rewrite");
+
+    const std::string guid = config.preferred_controller_guid;
+    { std::ofstream partial(path, std::ios::trunc); partial <<
+        R"({"version":1,"profiles":{"030000005e0400008e02000014010000":{"digital":{"a":[{"type":"button","button":"b"},{"type":"broken"}],"z":"invalid","c_right":[]},"analog":{"stick_x":{"axis":"missing","invert":false,"deadzone":8000}}}}})"; }
+    auto partial = load_config(path);
+    const Profile& partial_profile = profile_for_guid(partial.config, guid);
+    expect(partial_profile.digital[0] == DigitalBindings{ButtonSource{LogicalButton::B}},
+           "invalid individual binding is rejected without losing valid siblings");
+    expect(partial_profile.digital[2] == default_profile().digital[2],
+           "invalid target container falls back only that target");
+    expect(partial_profile.digital[13].empty(), "explicit empty partial target remains unbound");
+    expect(partial_profile.analog[0] == default_profile().analog[0],
+           "invalid analog binding falls back only that stick");
+    expect(!partial.warnings.empty(), "invalid and cross-target bindings produce warnings");
+
+    ControlsConfig shared{};
+    Profile& first_identical = profile_for_guid(shared, guid);
+    first_identical.digital[0].clear();
+    expect(profile_for_guid(shared, guid).digital[0].empty(),
+           "identical GUID controllers intentionally share one profile");
+
+    const auto blocked = temporary_path("lambo-controls-save-blocked");
+    std::filesystem::remove_all(blocked, ec);
+    std::filesystem::create_directory(blocked, ec);
+    expect(!save_config(config, blocked).saved, "atomic replacement failure is reported truthfully");
+    expect(std::filesystem::is_directory(blocked), "failed save leaves the original destination intact");
+    std::filesystem::remove_all(blocked, ec);
+
+    { std::ofstream malformed(path, std::ios::trunc); malformed << "{broken"; }
+    const std::string malformed_bytes = "{broken";
+    auto malformed = load_config(path);
+    expect(malformed.status == LoadStatus::Malformed && malformed.config.read_only,
+           "malformed document becomes read-only defaults");
+    expect(!save_config(malformed.config, path).saved, "read-only malformed config is untouched");
+    std::ifstream unchanged(path); std::string unchanged_bytes((std::istreambuf_iterator<char>(unchanged)), {});
+    expect(unchanged_bytes == malformed_bytes, "malformed bytes remain unchanged");
+
+    { std::ofstream future(path, std::ios::trunc); future << R"({"version":2,"future":true})"; }
+    auto future = load_config(path);
+    expect(future.status == LoadStatus::FutureVersion && future.config.read_only,
+           "future document becomes read-only defaults");
+
+    { std::ofstream oversized(path, std::ios::trunc); oversized <<
+        R"({"version":1,"profiles":{"030000005e0400008e02000014010000":{"digital":{"z":[{"type":"axis","axis":"trigger_left","direction":"positive","threshold":999999999999999999999999}]}}}})"; }
+    auto oversized = load_config(path);
+    expect(oversized.status == LoadStatus::Loaded &&
+           profile_for_guid(oversized.config, guid).digital[2].empty(),
+           "out-of-range binding integers are rejected without aborting the load");
+
+    std::atomic<bool> publishing{true};
+    std::thread publisher([&] {
+        for (std::uint64_t revision = 1; revision <= 1000; ++revision) {
+            UiSnapshot snapshot{};
+            snapshot.config_revision = revision;
+            snapshot.sample_revision = revision;
+            publish_ui_snapshot(std::move(snapshot));
+        }
+        publishing.store(false);
+    });
+    std::thread reader([&] {
+        while (publishing.load()) {
+            const auto snapshot = ui_snapshot();
+            expect(snapshot.profile.digital.size() == digital_target_count,
+                   "UI snapshot copy remains complete under concurrency");
+        }
+    });
+    std::thread commands_a([] {
+        for (int i = 0; i < 100; ++i) enqueue_command({CommandKind::ResetProfile});
+    });
+    std::thread commands_b([] {
+        for (int i = 0; i < 100; ++i) enqueue_command({CommandKind::CaptureCancel});
+    });
+    publisher.join(); reader.join(); commands_a.join(); commands_b.join();
+    expect(take_commands().size() == 200, "command queue is lossless under concurrent writers");
+    std::filesystem::remove(path, ec);
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_controls_capture.cpp
+++ b/tests/test_controls_capture.cpp
@@ -1,0 +1,101 @@
+#include <iostream>
+#include <string>
+
+#include "controls/lambo_controls.h"
+#include "ultramodern/config.hpp"
+
+namespace ultramodern::renderer {
+void set_graphics_config(const GraphicsConfig&) {}
+}
+
+namespace {
+int failures = 0;
+void expect(bool condition, const std::string& message) {
+    if (!condition) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+}
+
+int main() {
+    using namespace lambo::controls;
+    constexpr std::int32_t selected = 42;
+    Profile profile = default_profile();
+    Capture capture;
+    RawState raw{};
+
+    capture.begin(Target::A, selected);
+    capture.button_event(selected, LogicalButton::A, true); // activation event
+    expect(capture.phase() == CapturePhase::WaitingForNeutral,
+           "activation event cannot self-bind");
+    raw.buttons[static_cast<std::size_t>(LogicalButton::A)] = true;
+    capture.sample(raw, profile);
+    raw = {};
+    capture.sample(raw, profile);
+    expect(capture.phase() == CapturePhase::WaitingForNeutral,
+           "one neutral sample does not arm capture");
+    capture.sample(raw, profile);
+    expect(capture.phase() == CapturePhase::Listening, "two neutral samples arm capture");
+
+    capture.axis_event(selected, LogicalAxis::RightX, 15999);
+    expect(capture.phase() == CapturePhase::Listening, "axis jitter below activation is ignored");
+    capture.axis_event(selected + 1, LogicalAxis::RightX, 20000);
+    expect(capture.phase() == CapturePhase::Listening, "wrong controller cannot bind");
+    capture.axis_event(selected, LogicalAxis::RightX, 20000);
+    expect(capture.phase() == CapturePhase::WaitingForRelease, "signed axis candidate captured");
+    raw.axes[static_cast<std::size_t>(LogicalAxis::RightX)] = 20000;
+    capture.sample(raw, profile);
+    raw = {};
+    capture.sample(raw, profile);
+    expect(capture.phase() == CapturePhase::WaitingForRelease,
+           "one release-neutral sample does not commit");
+    expect(capture.sample(raw, profile) == CaptureResult::Conflict,
+           "cross-target duplicate requires confirmation");
+    expect(capture.accept_conflict(profile) == CaptureResult::Committed,
+           "keep-both confirmation commits duplicate");
+    expect(profile.digital[0].size() == 2, "confirmed binding is appended");
+
+    capture.begin(Target::B, selected);
+    capture.sample(raw, profile); capture.sample(raw, profile);
+    capture.button_event(selected, LogicalButton::B, true);
+    raw.buttons[static_cast<std::size_t>(LogicalButton::B)] = true;
+    capture.sample(raw, profile);
+    raw = {};
+    capture.sample(raw, profile);
+    expect(capture.sample(raw, profile) == CaptureResult::Noop,
+           "face B is bindable and exact duplicate is a no-op");
+
+    capture.begin(Target::Z, selected);
+    capture.sample(raw, profile); capture.sample(raw, profile);
+    capture.axis_event(selected, LogicalAxis::LeftX, -16000);
+    expect(capture.phase() == CapturePhase::WaitingForRelease,
+           "negative axis crossing at the activation threshold is captured");
+    raw.axes[static_cast<std::size_t>(LogicalAxis::LeftX)] = -16000;
+    capture.sample(raw, profile);
+    raw = {};
+    capture.sample(raw, profile);
+    expect(capture.sample(raw, profile) == CaptureResult::Committed,
+           "negative signed half commits after release");
+    expect(std::get<AxisHalfSource>(profile.digital[2].back()).direction == AxisDirection::Negative,
+           "captured negative half retains its direction");
+
+    capture.begin(Target::A, selected);
+    capture.sample(raw, profile); capture.sample(raw, profile);
+    expect(capture.button_event(selected, LogicalButton::Back, true) == CaptureResult::Cancelled,
+           "controller Back cancels capture");
+
+    capture.begin(Target::StickX, selected);
+    capture.sample(raw, profile); capture.sample(raw, profile);
+    capture.axis_event(selected, LogicalAxis::RightY, -20000);
+    raw.axes[static_cast<std::size_t>(LogicalAxis::RightY)] = -20000;
+    capture.sample(raw, profile);
+    raw = {};
+    capture.sample(raw, profile);
+    expect(capture.sample(raw, profile) == CaptureResult::Committed,
+           "analog candidate commits after release");
+    expect(profile.analog[0] == AnalogSource{LogicalAxis::RightY, false, 8000},
+           "stick X capture stores its orientation and deadzone separately");
+
+    capture.begin(Target::A, selected);
+    expect(capture.cancel() == CaptureResult::Cancelled && !capture.active(),
+           "disconnect/page-exit cancellation is non-mutating");
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_controls_sdl.cpp
+++ b/tests/test_controls_sdl.cpp
@@ -1,0 +1,36 @@
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+
+#include <SDL.h>
+
+#include "controls/lambo_controls_sdl.h"
+#include "ultramodern/config.hpp"
+
+namespace ultramodern::renderer {
+void set_graphics_config(const GraphicsConfig&) {}
+}
+
+int main() {
+    const auto path = std::filesystem::temp_directory_path() /
+        ("lambo-controls-sdl-" + std::to_string(
+            std::chrono::steady_clock::now().time_since_epoch().count()) + ".json");
+#ifdef _WIN32
+    _putenv_s("LAMBO_CONTROLS_CONFIG", path.string().c_str());
+#else
+    setenv("LAMBO_CONTROLS_CONFIG", path.string().c_str(), 1);
+#endif
+    lambo::controls::SdlAdapter adapter;
+    adapter.open_existing();
+    adapter.process_commands();
+    const auto state = adapter.sample();
+    const auto snapshot = lambo::controls::ui_snapshot();
+    bool ok = state == lambo::controls::EvaluatedState{} &&
+              !snapshot.selected_instance.has_value() && snapshot.controllers.empty();
+    if (!ok) std::cerr << "FAIL: missing-controller adapter state is not neutral\n";
+    adapter.shutdown();
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+    return ok ? 0 : 1;
+}

--- a/tests/test_input_gate.cpp
+++ b/tests/test_input_gate.cpp
@@ -1,0 +1,64 @@
+#include <iostream>
+
+#include "lambo_input_gate.h"
+
+namespace {
+int failures = 0;
+void expect(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+}
+
+int main() {
+    constexpr uint32_t physical = 0x76543210;
+    lambo::input_gate::set_ui_capture(false);
+    lambo::input_gate::publish_physical_snapshot(physical);
+    expect(lambo::input_gate::guest_snapshot() == physical,
+           "physical state is published when capture is disabled");
+
+    lambo::input_gate::set_ui_capture(true);
+    lambo::input_gate::publish_physical_snapshot(0xFFFFFFFFu);
+    expect(lambo::input_gate::guest_input_suppressed(),
+           "capture reports guest input suppression");
+    expect(lambo::input_gate::guest_snapshot() == 0,
+           "captured input publishes a neutral snapshot");
+
+    lambo::input_gate::set_ui_capture(false);
+    lambo::input_gate::publish_physical_snapshot(0xFFFFFFFFu);
+    expect(lambo::input_gate::guest_input_suppressed(),
+           "capture release starts a neutral release barrier");
+    expect(lambo::input_gate::guest_snapshot() == 0,
+           "first frame after capture is neutral");
+    expect(lambo::input_gate::guest_input_suppressed(),
+           "the neutral barrier covers all reads in that frame");
+    lambo::input_gate::publish_physical_snapshot(0x00010000u);
+    expect(lambo::input_gate::guest_snapshot() == 0,
+           "held analog input also remains suppressed");
+    lambo::input_gate::publish_physical_snapshot(0);
+    expect(lambo::input_gate::guest_input_suppressed(),
+           "first neutral sample is published under the barrier");
+    lambo::input_gate::publish_physical_snapshot(0);
+    expect(!lambo::input_gate::guest_input_suppressed(),
+           "a later neutral sample releases the barrier");
+    expect(lambo::input_gate::guest_snapshot() == 0,
+           "barrier release sample remains neutral");
+    lambo::input_gate::publish_physical_snapshot(physical);
+    expect(lambo::input_gate::guest_snapshot() == physical,
+           "physical state resumes on a later sample");
+
+    lambo::input_gate::set_ui_capture(true);
+    lambo::input_gate::set_ui_capture(false);
+    lambo::input_gate::publish_physical_snapshot(0);
+    lambo::input_gate::set_ui_capture(true);
+    lambo::input_gate::publish_physical_snapshot(physical);
+    expect(lambo::input_gate::guest_snapshot() == 0,
+           "reopening during release barrier remains suppressed");
+    lambo::input_gate::set_ui_capture(false);
+    lambo::input_gate::publish_physical_snapshot(0);
+    lambo::input_gate::publish_physical_snapshot(0);
+
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_live_config.cpp
+++ b/tests/test_live_config.cpp
@@ -101,6 +101,10 @@ int main() {
     expect(lambo::config::camera_height_scale() == 0.2, "camera height scale clamps low");
     expect(lambo::config::camera_fov_add() == 60.0, "camera FOV delta clamps high");
 
+    lambo::config::set_show_launcher(true);
+    expect(lambo::config::show_launcher() == true, "show_launcher toggle updates snapshot");
+    expect(read_json(path).at("show_launcher") == true, "show_launcher persists to json");
+
     std::error_code ec;
     std::filesystem::remove_all(dir, ec);
     return failures == 0 ? 0 : 1;

--- a/tests/test_startup.cpp
+++ b/tests/test_startup.cpp
@@ -1,0 +1,83 @@
+#include <cstdlib>
+#include <iostream>
+
+#include "lambo_startup.h"
+
+namespace {
+int failures = 0;
+void expect(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+void set_environment(const char* name, const char* value) {
+#if defined(_WIN32)
+    _putenv_s(name, value != nullptr ? value : "");
+#else
+    if (value != nullptr) setenv(name, value, 1);
+    else unsetenv(name);
+#endif
+}
+
+void clear_startup_environment() {
+    constexpr const char* variables[] = {
+        "CI",
+        "LAMBO_HEADLESS",
+        "LAMBO_LIGHTING_SELFTEST",
+        "LAMBO_WARP",
+        "LAMBO_MODERN_INPUT",
+        "LAMBO_INPUT_PULSE",
+        "LAMBO_MODERN_MAX_VIS",
+        "LAMBO_CRASH_TEST",
+        "LAMBO_SELFTEST",
+        "LAMBO_LAUNCHER",
+    };
+    for (const char* variable : variables) set_environment(variable, nullptr);
+}
+}
+
+int main() {
+    clear_startup_environment();
+    expect(lambo::startup_mode_from_environment() == lambo::StartupMode::Automatic,
+           "ordinary graphical startup uses automatic boot");
+
+    set_environment("LAMBO_LAUNCHER", "1");
+    expect(lambo::startup_mode_from_environment() == lambo::StartupMode::InteractiveLauncher,
+           "LAMBO_LAUNCHER selects interactive launcher mode");
+    set_environment("LAMBO_LAUNCHER", nullptr);
+
+    int starts = 0;
+    lambo::StartupController interactive(lambo::StartupMode::InteractiveLauncher,
+                                         [&] { ++starts; });
+    expect(interactive.state() == lambo::StartupState::WaitingForRuntime,
+           "graphical startup initially waits for runtime");
+    expect(!interactive.request_play(), "Play cannot start before runtime readiness");
+    expect(!interactive.watchdog_armed(), "idle interactive launcher has no watchdog");
+    expect(!interactive.runtime_ready(), "interactive runtime readiness waits for Play");
+    expect(interactive.state() == lambo::StartupState::WaitingForPlay,
+           "interactive runtime enters WaitingForPlay");
+    expect(interactive.request_play(), "first Play starts the game");
+    expect(!interactive.request_play(), "repeated Play is idempotent");
+    expect(starts == 1, "start action is called exactly once");
+    expect(interactive.state() == lambo::StartupState::Started,
+           "interactive startup reaches Started");
+
+    int automatic_starts = 0;
+    lambo::StartupController automatic(lambo::StartupMode::Automatic,
+                                       [&] { ++automatic_starts; });
+    expect(automatic.watchdog_armed(), "automatic mode keeps the watchdog armed");
+    expect(automatic.runtime_ready(), "automatic mode starts when runtime is ready");
+    expect(automatic_starts == 1, "automatic startup calls start action once");
+    expect(!automatic.runtime_ready(), "duplicate runtime readiness is ignored");
+
+    lambo::StartupController quit(lambo::StartupMode::InteractiveLauncher);
+    quit.runtime_ready();
+    expect(quit.request_exit(), "launcher quit transitions to Exiting");
+    expect(quit.state() == lambo::StartupState::Exiting,
+           "launcher quit has an explicit exit state");
+    expect(!quit.request_play(), "Play after quit cannot start the game");
+
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_ui_assets.py
+++ b/tests/test_ui_assets.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> None:
+    repo = Path(sys.argv[1]).resolve()
+    ui_root = repo / "assets" / "ui"
+    required_documents = {
+        "launcher.rml",
+        "settings.rml",
+        "pages/graphics.rml",
+        "pages/enhancements.rml",
+        "pages/controls.rml",
+        "pages/haptics.rml",
+    }
+
+    for relative in required_documents:
+        require((ui_root / relative).is_file(), f"missing required UI document: {relative}")
+
+    setting_actions: set[str] = set()
+    page_actions: set[str] = set()
+    for document_path in ui_root.rglob("*.rml"):
+        document = ET.parse(document_path)
+        for element in document.iter():
+            href = element.attrib.get("href")
+            if href:
+                target = (document_path.parent / href).resolve()
+                require(target.is_relative_to(ui_root), f"reference escapes UI assets: {href}")
+                require(target.is_file(), f"missing reference from {document_path.name}: {href}")
+            onclick = element.attrib.get("onclick", "")
+            if onclick.startswith("setting:"):
+                setting_actions.add(onclick.removeprefix("setting:"))
+            elif onclick.startswith("page:"):
+                page_actions.add(onclick.removeprefix("page:"))
+
+    expected_settings = {
+        "res:next", "ss:next", "aspect:next", "hud:next", "rate:next",
+        "msaa:next", "hpfb:next", "api:next",
+        "fog:toggle", "sky:toggle", "lod:toggle",
+        "circuit:1", "circuit:2", "circuit:3", "circuit:4", "circuit:5", "circuit:6",
+        "distance:next", "fogdensity:next",
+    }
+    require(setting_actions == expected_settings,
+            f"setting actions differ: missing={expected_settings - setting_actions}, "
+            f"unexpected={setting_actions - expected_settings}")
+    require({"graphics", "enhancements", "controls", "haptics"} <= page_actions,
+            "settings hub is missing a stable route identifier")
+
+    graphics = ET.parse(ui_root / "pages" / "graphics.rml")
+    graphics_controls = [element for element in graphics.iter("button")
+                         if element.attrib.get("onclick", "").startswith("setting:")]
+    require(len(graphics_controls) == 8,
+            "graphics must expose one control per setting, not one button per value")
+    for value_id in ("graphics-resolution", "graphics-supersampling", "graphics-aspect",
+                     "graphics-hud", "graphics-refresh", "graphics-msaa", "graphics-hpfb",
+                     "graphics-api"):
+        require(any(element.attrib.get("id") == value_id for element in graphics.iter()),
+                f"graphics control is missing current-value target: {value_id}")
+
+    settings = ET.parse(ui_root / "settings.rml")
+    unavailable = [element for element in settings.iter("button")
+                   if element.attrib.get("disabled") == "disabled"]
+    require(len(unavailable) == 1 and
+            {element.attrib.get("onclick") for element in unavailable} ==
+            {"page:haptics"},
+            "only the unfinished Haptics page may remain disabled")
+
+    controls = ET.parse(ui_root / "pages" / "controls.rml")
+    controls_ids = {element.attrib.get("id") for element in controls.iter() if element.attrib.get("id")}
+    required_control_ids = {
+        "controls-controller-list", "controls-selected-name", "controls-selected-status",
+        "controls-selected-layout", "controls-selected-guid", "controls-bindings",
+        "controls-raw-preview", "controls-evaluated-preview", "controls-persistence-status",
+        "controls-warnings", "controls-capture-modal", "controls-capture-message",
+        "controls-conflict-modal",
+    }
+    require(required_control_ids <= controls_ids,
+            f"Controls page is missing state targets: {required_control_ids - controls_ids}")
+    control_actions = {element.attrib.get("onclick") for element in controls.iter()
+                       if element.attrib.get("onclick", "").startswith("control:")}
+    require({"control:reset-profile", "control:capture-cancel", "control:conflict-accept"}
+            <= control_actions, "Controls page is missing modal/profile actions")
+    controls_source = (repo / "src" / "ui" / "lambo_ui_controls.cpp").read_text(encoding="utf-8")
+    require("Target::Count" in controls_source and "target_name(target)" in controls_source,
+            "Controls rows must be generated from the complete typed target set")
+    domain_source = (repo / "src" / "controls" / "lambo_controls.cpp").read_text(encoding="utf-8")
+    for target in ("a", "b", "z", "start", "l", "r", "dpad_up", "dpad_down",
+                   "dpad_left", "dpad_right", "c_up", "c_down", "c_left", "c_right",
+                   "stick_x", "stick_y"):
+        require(f'"{target}"' in domain_source,
+                f"Controls generation does not cover target {target}")
+
+    graphics_text = (ui_root / "pages" / "graphics.rml").read_text(encoding="utf-8")
+    require("saved for the next launch" in graphics_text and "do not apply immediately" in graphics_text,
+            "graphics API must not pretend to apply live")
+
+    enhancements_text = (ui_root / "pages" / "enhancements.rml").read_text(encoding="utf-8")
+    require(enhancements_text.index('class="help"') < enhancements_text.index('class="columns"'),
+            "enhancement guidance must sit above both columns to keep their controls aligned")
+
+    launcher = (ui_root / "launcher.rml").read_text(encoding="utf-8")
+    require("v1.0.0" not in launcher, "launcher must not hardcode a release version")
+    require('onclick="play:game"' in launcher,
+            "Play must use the same explicit custom-event form as other launcher actions")
+
+    cmake = (repo / "CMakeLists.txt").read_text(encoding="utf-8")
+    require("copy_directory" in cmake and "assets/ui" in cmake,
+            "UI asset directory is not packaged beside the executable")
+    main_source = (repo / "src" / "main.cpp").read_text(encoding="utf-8")
+    for component in ("MAJOR", "MINOR", "PATCH"):
+        macro = f"LAMBO_VERSION_{component}"
+        require(macro in cmake and macro in main_source,
+                f"launcher and runtime must share CMake's {component.lower()} version")
+    for font in ("LatoLatin-Regular.ttf", "LatoLatin-Bold.ttf"):
+        require((repo / "lib" / "RmlUi" / "Samples" / "assets" / font).is_file(),
+                f"missing pinned font source: {font}")
+        require(font in cmake, f"font is not included in the packaging command: {font}")
+
+    rcss = (ui_root / "lambo.rcss").read_text(encoding="utf-8")
+    require("position: absolute" in rcss and "left: 7%" in rcss and "top: 7%" in rcss,
+            "panel layout must bypass RmlUi's padded percentage-width behavior")
+    require("font-family: Lato" in rcss, "UI stylesheet must request the registered font family")
+    semantic_rule = re.search(r"h1,\s*h2,\s*p,\s*\.summary,\s*\.footer\s*\{([^}]*)\}",
+                              rcss, re.DOTALL)
+    require(semantic_rule is not None and "display: block" in semantic_rule.group(1),
+            "semantic text elements must not collapse into RmlUi's inline default")
+    require(semantic_rule is not None and "width: 100%" in semantic_rule.group(1),
+            "semantic text elements must fill the panel instead of using min-content width")
+    columns_rule = re.search(r"\.columns\s*\{([^}]*)\}", rcss, re.DOTALL)
+    require(columns_rule is not None and "width: 100%" in columns_rule.group(1),
+            "settings columns must fill the panel before percentage children are resolved")
+    panel_rule = re.search(r"\.panel\s*\{([^}]*)\}", rcss, re.DOTALL)
+    require(panel_rule is not None and "overflow-y: auto" in panel_rule.group(1),
+            "only overflowing settings pages should create a vertical scrollbar")
+    scrollbar_rule = re.search(r"scrollbarvertical\s*\{([^}]*)\}", rcss, re.DOTALL)
+    require(scrollbar_rule is not None and "width:" in scrollbar_rule.group(1),
+            "RmlUi scrollbars need an explicit width or they consume the content area")
+    ui_source = (repo / "src" / "ui" / "lambo_ui.cpp").read_text(encoding="utf-8")
+    require('data, "Lato"' in ui_source,
+            "fonts must be registered explicitly under the stylesheet family name")
+    require("font_data" in ui_source and "font_data.reserve(2)" in ui_source,
+            "memory-loaded font bytes must outlive RmlUi font rasterization")
+    workflow = (repo / ".github" / "workflows" / "build-release.yml").read_text(encoding="utf-8")
+    require("cp -r build/assets dist/" in workflow,
+            "Linux release archive must include packaged UI assets")
+    require("'build\\assets'" in workflow and "'build\\freetype.dll'" in workflow,
+            "Windows release archive must include UI assets and the font runtime")
+    for reference in re.findall(r"url\(['\"]?([^)'\"]+)", rcss):
+        require((ui_root / reference).is_file(), f"missing RCSS reference: {reference}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ui_controls.cpp
+++ b/tests/test_ui_controls.cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+#include <string>
+
+#include "ui/lambo_ui_controls.h"
+#include "ultramodern/config.hpp"
+
+namespace ultramodern::renderer {
+void set_graphics_config(const GraphicsConfig&) {}
+}
+
+namespace {
+int failures = 0;
+void expect(bool condition, const char* message) {
+    if (!condition) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+}
+
+int main() {
+    using namespace lambo::controls;
+    using namespace lambo::ui;
+    expect(control_action_from_name("control:select:42")->kind == CommandKind::Select,
+           "select action parses");
+    expect(control_action_from_name("add:c_up")->target == Target::CUp, "add target parses");
+    expect(control_action_from_name("remove:a:2")->binding_index == 2, "remove index parses");
+    expect(control_action_from_name("threshold:z:0:9000")->value == 9000, "threshold parses");
+    expect(control_action_from_name("deadzone:stick_x:7000")->value == 7000, "deadzone parses");
+    expect(control_action_from_name("invert:stick_y")->kind == CommandKind::Invert, "invert parses");
+    expect(!control_action_from_name("select:not-a-number"), "malformed number is rejected");
+    expect(!control_action_from_name("invert:a"), "digital invert is rejected");
+    expect(!control_action_from_name("remove:a:2:extra"), "extra fields are rejected");
+    expect(escape_rml("<bad & \"name\">") == "&lt;bad &amp; &quot;name&quot;&gt;",
+           "dynamic RML is escaped");
+
+    UiSnapshot snapshot{};
+    snapshot.controllers.push_back({42, "030000005e0400008e02000014010000",
+                                    "Pad <One>", ControllerLayout::Xbox, true});
+    snapshot.selected_instance = 42;
+    snapshot.selected_guid = snapshot.controllers[0].guid;
+    snapshot.status = "Saved";
+    snapshot.config_path = "controls.json";
+    const ControlsView view = controls_view(snapshot);
+    expect(view.controller_list.find("Pad &lt;One&gt;") != std::string::npos,
+           "controller name is escaped in generated rows");
+    expect(view.bindings.find("control:add:a") != std::string::npos,
+           "generated bindings reference typed actions");
+    expect(view.bindings.find("N64 Stick X") != std::string::npos,
+           "all targets include analog sticks");
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_ui_input.cpp
+++ b/tests/test_ui_input.cpp
@@ -1,0 +1,91 @@
+#include <chrono>
+#include <iostream>
+#include <vector>
+
+#include "ui/lambo_ui_input.h"
+
+namespace {
+
+int failures = 0;
+
+void expect(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+void expect_events(const std::vector<lambo::ui::NavigationEvent>& actual,
+                   std::initializer_list<lambo::ui::NavigationEvent> expected,
+                   const char* message) {
+    expect(actual == std::vector<lambo::ui::NavigationEvent>(expected), message);
+}
+
+} // namespace
+
+int main() {
+    using namespace std::chrono_literals;
+    using lambo::ui::NavigationAxis;
+    using lambo::ui::NavigationEvent;
+    using lambo::ui::NavigationEventType;
+    using lambo::ui::NavigationKey;
+
+    constexpr NavigationEvent down_press{NavigationEventType::Press, NavigationKey::Down};
+    constexpr NavigationEvent down_release{NavigationEventType::Release, NavigationKey::Down};
+    const lambo::ui::ControllerNavigation::TimePoint start{};
+    expect(!lambo::ui::navigation_axis_active(8999),
+           "stick jitter remains below the navigation dead zone");
+    expect(lambo::ui::navigation_axis_active(9000),
+           "stick motion at the dead-zone boundary is meaningful navigation");
+
+    lambo::ui::ControllerNavigation buttons;
+    expect_events(buttons.button_down(NavigationKey::Down, start), {down_press},
+                  "D-pad press emits one navigation press");
+    expect_events(buttons.button_down(NavigationKey::Down, start), {},
+                  "duplicate D-pad down is ignored");
+    expect_events(buttons.update(start + 499ms), {},
+                  "D-pad does not repeat before the initial delay");
+    expect_events(buttons.update(start + 500ms), {down_press},
+                  "D-pad repeats after the initial delay");
+    expect_events(buttons.button_up(NavigationKey::Down, start + 600ms), {down_release},
+                  "D-pad release emits a navigation release");
+    expect_events(buttons.update(start + 1s), {},
+                  "released D-pad input never repeats");
+
+    lambo::ui::ControllerNavigation axis;
+    expect_events(axis.axis_motion(NavigationAxis::Vertical, 16000, start), {down_press},
+                  "stick crossing the dead zone presses Down");
+    expect_events(axis.axis_motion(NavigationAxis::Vertical, 0, start + 10ms), {down_release},
+                  "stick returning to neutral releases Down");
+    expect_events(axis.update(start + 1s), {},
+                  "neutral stick input never repeats");
+
+    lambo::ui::ControllerNavigation activation;
+    constexpr NavigationEvent activate_press{NavigationEventType::Press, NavigationKey::Activate};
+    constexpr NavigationEvent activate_release{NavigationEventType::Release, NavigationKey::Activate};
+    expect_events(activation.button_down(NavigationKey::Activate, start), {activate_press},
+                  "A presses Activate once");
+    expect_events(activation.update(start + 1s), {},
+                  "Activate is not a repeatable navigation key");
+    activation.reset();
+    expect_events(activation.button_down(NavigationKey::Activate, start + 2s), {activate_press},
+                  "closing the UI clears held controller state before reopening");
+    expect_events(activation.button_up(NavigationKey::Activate, start + 2s), {activate_release},
+                  "A release clears Activate");
+
+    lambo::ui::ControllerNavigation chord;
+    constexpr NavigationEvent right_press{NavigationEventType::Press, NavigationKey::Right};
+    constexpr NavigationEvent right_release{NavigationEventType::Release, NavigationKey::Right};
+    expect_events(chord.button_down(NavigationKey::Down, start), {down_press},
+                  "first chord direction is pressed");
+    expect_events(chord.button_down(NavigationKey::Right, start + 10ms), {right_press},
+                  "second chord direction is pressed");
+    expect_events(chord.button_up(NavigationKey::Right, start + 20ms), {right_release},
+                  "releasing the latest chord direction emits its release");
+    expect_events(chord.update(start + 519ms), {},
+                  "remaining chord direction receives a fresh repeat delay");
+    expect_events(chord.update(start + 520ms), {down_press},
+                  "remaining held direction resumes repeating");
+
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_ui_settings.cpp
+++ b/tests/test_ui_settings.cpp
@@ -1,0 +1,188 @@
+#include <array>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include "json/json.hpp"
+#include "lambo_config.h"
+#include "ui/lambo_ui_settings.h"
+
+namespace {
+
+int failures = 0;
+
+void expect(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+void set_environment(const char* name, const char* value) {
+#if defined(_WIN32)
+    _putenv_s(name, value != nullptr ? value : "");
+#else
+    if (value != nullptr) setenv(name, value, 1);
+    else unsetenv(name);
+#endif
+}
+
+nlohmann::json read_json(const std::filesystem::path& path) {
+    std::ifstream input(path);
+    nlohmann::json result;
+    input >> result;
+    return result;
+}
+
+} // namespace
+
+namespace ultramodern::renderer {
+void set_graphics_config(const GraphicsConfig&) {}
+}
+
+int main() {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto directory = std::filesystem::temp_directory_path() /
+                           ("lambo-ui-settings-test-" + std::to_string(unique));
+    const auto config_path = directory / "graphics.json";
+    set_environment("LAMBO_GRAPHICS_CONFIG", config_path.string().c_str());
+    set_environment("LAMBO_FOG_MATCH_1P", nullptr);
+    set_environment("LAMBO_SKY_MATCH_1P", nullptr);
+    set_environment("LAMBO_NO_LOD", nullptr);
+
+    lambo::config::load_and_apply_graphics();
+
+    constexpr std::array binding_names{
+        "res:next", "ss:next", "aspect:next", "hud:next", "rate:next",
+        "msaa:next", "hpfb:next", "api:next",
+        "fog:toggle", "sky:toggle", "lod:toggle",
+        "circuit:1", "circuit:2", "circuit:3", "circuit:4", "circuit:5", "circuit:6",
+        "distance:next", "fogdensity:next",
+    };
+    for (const char* name : binding_names) {
+        expect(lambo::ui::setting_action_from_name(name).has_value(),
+               "every documented setting binding parses");
+    }
+    expect(!lambo::ui::setting_action_from_name("unknown:setting").has_value(),
+           "unknown setting bindings are rejected");
+
+    const auto apply = [](const char* name) {
+        const auto action = lambo::ui::setting_action_from_name(name);
+        return action.has_value() && lambo::ui::apply_setting_action(*action);
+    };
+
+    auto custom_refresh = lambo::config::current_graphics();
+    custom_refresh.rr_option = ultramodern::renderer::RefreshRate::Manual;
+    custom_refresh.rr_manual_value = 75;
+    lambo::config::apply_graphics(custom_refresh);
+    expect(apply("rate:next") && lambo::config::current_graphics().rr_manual_value == 90,
+           "refresh cycle advances a custom manual value to the next preset");
+    lambo::config::apply_graphics(lambo::config::default_graphics_config());
+
+    expect(apply("res:next") && apply("ss:next") && apply("aspect:next") &&
+           apply("hud:next") && apply("rate:next") && apply("msaa:next") &&
+           apply("hpfb:next") && apply("api:next"),
+           "graphics cycle bindings apply through the typed settings seam");
+    const auto graphics = lambo::config::current_graphics();
+    using namespace ultramodern::renderer;
+    expect(graphics.res_option == Resolution::Original, "resolution cycle updates config");
+    expect(graphics.ds_option == 2, "supersampling cycle updates config");
+    expect(graphics.ar_option == AspectRatio::Original, "aspect cycle updates config");
+    expect(graphics.hr_option == HUDRatioMode::Full, "HUD cycle updates config");
+    expect(graphics.rr_option == RefreshRate::Manual && graphics.rr_manual_value == 30,
+           "refresh cycle updates config");
+    expect(graphics.msaa_option == Antialiasing::MSAA4X, "MSAA cycle updates config");
+    expect(graphics.hpfb_option == HighPrecisionFramebuffer::On,
+           "framebuffer precision cycle updates config");
+#if defined(_WIN32)
+    expect(graphics.api_option == GraphicsApi::D3D12, "graphics API cycle updates config");
+#elif defined(__APPLE__)
+    expect(graphics.api_option == GraphicsApi::Metal, "graphics API cycle updates config");
+#else
+    expect(graphics.api_option == GraphicsApi::Vulkan, "graphics API cycle updates config");
+#endif
+
+    expect(apply("fog:toggle") && apply("sky:toggle") && apply("lod:toggle") &&
+           apply("circuit:6") && apply("distance:next") && apply("fogdensity:next"),
+           "enhancement bindings apply through the typed settings seam");
+    expect(!lambo::config::widescreen_fog_match(), "fog match toggles live");
+    expect(!lambo::config::widescreen_sky_match(), "sky match toggles live");
+    expect(!lambo::config::no_lod(), "LOD removal toggles live");
+    expect(lambo::config::no_lod_circuit(5), "per-circuit visibility toggles live");
+    expect(lambo::config::global_draw_distance() == 2.0, "draw-distance cycle applies live");
+    expect(lambo::config::global_fog_scale() == 1.5, "fog-density cycle applies live");
+
+    const auto snapshot = lambo::ui::settings_snapshot();
+    expect(snapshot.resolution == "Original", "settings snapshot presents resolution");
+    expect(snapshot.refresh_rate == "30 Hz", "settings snapshot presents refresh rate");
+    expect(snapshot.msaa == "4x", "settings snapshot presents MSAA");
+    expect(snapshot.circuit_visibility[5] == "Enabled",
+           "settings snapshot presents every circuit");
+    expect(snapshot.draw_distance == "2x", "settings snapshot presents draw distance");
+    expect(snapshot.fog_density == "150%", "settings snapshot presents fog density");
+
+    using SnapshotStringMember = std::string lambo::ui::SettingsSnapshot::*;
+    const auto expect_cycle_wraps = [&](const char* binding, int steps, const std::string& initial,
+                                        SnapshotStringMember member,
+                                        const char* message) {
+        for (int step = 0; step < steps; ++step) expect(apply(binding), message);
+        expect(lambo::ui::settings_snapshot().*member == initial, message);
+    };
+    expect_cycle_wraps("res:next", 3, snapshot.resolution,
+                       &lambo::ui::SettingsSnapshot::resolution, "resolution cycle wraps");
+    expect_cycle_wraps("ss:next", 4, snapshot.supersampling,
+                       &lambo::ui::SettingsSnapshot::supersampling, "supersampling cycle wraps");
+    expect_cycle_wraps("aspect:next", 2, snapshot.aspect_ratio,
+                       &lambo::ui::SettingsSnapshot::aspect_ratio, "aspect cycle wraps");
+    expect_cycle_wraps("hud:next", 3, snapshot.hud_layout,
+                       &lambo::ui::SettingsSnapshot::hud_layout, "HUD cycle wraps");
+    expect_cycle_wraps("rate:next", 9, snapshot.refresh_rate,
+                       &lambo::ui::SettingsSnapshot::refresh_rate, "refresh cycle wraps");
+    expect_cycle_wraps("msaa:next", 4, snapshot.msaa,
+                       &lambo::ui::SettingsSnapshot::msaa, "MSAA cycle wraps");
+    expect_cycle_wraps("hpfb:next", 3, snapshot.framebuffer_precision,
+                       &lambo::ui::SettingsSnapshot::framebuffer_precision,
+                       "framebuffer precision cycle wraps");
+#if defined(_WIN32)
+    constexpr int api_cycle_size = 3;
+#else
+    constexpr int api_cycle_size = 2;
+#endif
+    expect_cycle_wraps("api:next", api_cycle_size, snapshot.graphics_api,
+                       &lambo::ui::SettingsSnapshot::graphics_api, "graphics API cycle wraps");
+    expect_cycle_wraps("distance:next", 5, snapshot.draw_distance,
+                       &lambo::ui::SettingsSnapshot::draw_distance, "draw-distance cycle wraps");
+    expect_cycle_wraps("fogdensity:next", 6, snapshot.fog_density,
+                       &lambo::ui::SettingsSnapshot::fog_density, "fog-density cycle wraps");
+
+    const auto persisted = read_json(config_path);
+#if defined(_WIN32)
+    expect(persisted.at("api_option") == "D3D12", "graphics API persists");
+#elif defined(__APPLE__)
+    expect(persisted.at("api_option") == "Metal", "graphics API persists");
+#else
+    expect(persisted.at("api_option") == "Vulkan", "graphics API persists");
+#endif
+    expect(persisted.at("rr_manual_value") == 30, "manual refresh rate persists");
+    expect(persisted.at("no_lod_circuit").at(5) == true,
+           "per-circuit visibility persists");
+    expect(persisted.at("draw_distance") == 2.0, "draw distance persists");
+    expect(persisted.at("fog_scale") == 1.5, "fog density persists");
+
+    lambo::config::load_and_apply_graphics();
+#if defined(_WIN32)
+    expect(lambo::config::current_graphics().api_option == GraphicsApi::D3D12,
+#elif defined(__APPLE__)
+    expect(lambo::config::current_graphics().api_option == GraphicsApi::Metal,
+#else
+    expect(lambo::config::current_graphics().api_option == GraphicsApi::Vulkan,
+#endif
+           "settings survive reload through the config source of truth");
+
+    std::error_code error;
+    std::filesystem::remove_all(directory, error);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Implements #126 and #127 with an in-game configuration overlay and persistent per-controller control remapping.

- **Auto-Boot by Default**: The game boots straight into gameplay automatically; standalone launcher on boot is bypassed (available via \LAMBO_LAUNCHER=1\ override if desired).
- **In-Game Configuration Overlay**:
  - Accessible while in-game by pressing controller **Menu / Back / Start / Guide** buttons, keyboard <kbd>Esc</kbd> / <kbd>F1</kbd>, or from window menus (\Game -> Settings\ / \Controls\).
  - Presents a full-screen 2x2 dashboard for **Graphics and Display**, **Visual Enhancements**, **Controls Mapper**, and **Haptics & Rumble** (coming soon).
  - Includes **Resume Game** (<kbd>B</kbd> / <kbd>Esc</kbd> / Menu) and **Exit to Desktop** actions.
  - Full-screen edge-to-edge layout with 2D spatial navigation (\
av-up\, \
av-down\, \
av-left\, \
av-right\), autofocus restoration on input, and mouse/keyboard/gamepad support.
  - Removed outdated marketing subtitles for clean presentation.
- **Project64-Style N64 Controls Mapper**:
  - Reorganized into 4 clean columns: **Buttons & Triggers**, **C-Buttons**, **Digital Pad**, and **Analog Stick**.
  - Distinct N64 badge pills for every target (\[A]\, \[B]\, \[START]\, \[Z]\, \[L]\, \[R]\, \[C-U]\, etc.).
  - Direct single-slot click/press mapping with capture and conflict modals.
  - Live Raw Input & Evaluated N64 preview monitors.
  - Controller hotplug device selector and profile reset.
- **Controls Domain & Persistence**:
  - Dedicated \src/controls\ module with versioned JSON persistence (\%LOCALAPPDATA%/LamborghiniRecomp/controls.json\).
  - Capture state machine with release barriers preventing input leaks into gameplay.

## Validation

- Build compiles cleanly under Windows / MinGW64.
- All 11 CTest test suites pass 100%.
- Interactive testing and screenshot validation across all 5 configuration screens.