### PR TITLE
Sense of speed: chase-camera distance/height scales + FOV boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/lambo_fog_widescreen.cpp  # issue #83: widen dense 3P/4P fog to the 1P window/colour (DL rewrite, players>=3)
         src/lambo_sky_widescreen.cpp  # issue #84: draw the 1P/2P sky panorama in 3P/4P (patches.hook branch guard)
         src/lambo_no_lod.cpp   # issues #87/#91: emit the per-segment scenery layer in 2P-4P like 1P (patches.hook branch guards)
+        src/lambo_camera.cpp   # sense of speed: chase-camera distance/height + FOV delta float-bit shims for the hooks
         src/lambo_gpu_advisory.cpp  # issue #109: outdated-Intel-driver detection + user-facing fix advisory
         src/lambo_warp.c       # issue #12: developer warp menu (F1-F6 / LAMBO_WARP race-track warp)
         src/lambo_savestate.c  # issue #22: developer save-state (F7/F8 / LAMBO_STATE_LOAD RDRAM snapshot)

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -910,3 +910,123 @@ text = "lambo_ws_quad_panel_bg_stretch(rdram);"
 func = "func_800030F8"
 before_vram = 0x80005208
 text = "lambo_ws_quad_panel_bg_reset(rdram);"
+
+# Sense of speed -- opt-in chase-camera + FOV knobs (graphics.json keys
+# "camera_distance_scale" / "camera_height" / "camera_fov_add"; defaults are exactly
+# the ROM's values, so stock presentation is unchanged unless configured). Natives in
+# src/lambo_camera.cpp return IEEE float bits; hooks overwrite the register holding an
+# authored value just before its consuming instruction.
+#
+# The LIVE race camera is func_80032450's L_800324C8 path (verified live: the classic
+# chase math at L_800320xx and the view-matrix builder at 0x800323CC never run in a
+# warped race -- a LAMBO_CAM_TRACE probe there never fires):
+#   eye.x/z = car + viewdir * (per-player s16 distance, e.g. 900)
+#             -- distance consumer mul.s at 0x80032708 -> scale site R
+#   eye.y   = track-anchor table entry + 300.0
+#             -- height adder add.s at 0x80032780 -> height site 1
+# DISTANCE is therefore a SCALE knob: every site that multiplies an authored camera
+# distance into an eye offset rescales it in place (ctx->fX already holds the authored
+# value when the hook runs). Sites:
+#   R   0x80032708 mul.s f8 = dist * dirX     (the live race path)
+#   1-3 0x800320E4/0x80032124/0x800321F8      (func_80032450 chase paths; dormant in
+#                                              races but kept consistent for any mode
+#                                              that wakes them)
+#   4   0x80031E80 c.lt.s follow-dist compare (mode-transition key; scaled to match)
+#   5/6 boot_pad_apply_calibration 0x80007CF4/0x80007D4C (demo/attract camera,
+#                                              absolute eye = car - dir*900)
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x80032708
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f6.u32l = lambo_camera_scale_bits((uint32_t)ctx->f6.u32l); }"
+
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x800320E4
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f6.u32l = lambo_camera_scale_bits((uint32_t)ctx->f6.u32l); }"
+
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x80032124
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f16.u32l = lambo_camera_scale_bits((uint32_t)ctx->f16.u32l); }"
+
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x800321F8
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f18.u32l = lambo_camera_scale_bits((uint32_t)ctx->f18.u32l); }"
+
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x80031E80
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f6.u32l = lambo_camera_scale_bits((uint32_t)ctx->f6.u32l); }"
+
+[[patches.hook]]
+func = "boot_pad_apply_calibration"
+before_vram = 0x80007CF4
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f18.u32l = lambo_camera_scale_bits((uint32_t)ctx->f18.u32l); }"
+
+[[patches.hook]]
+func = "boot_pad_apply_calibration"
+before_vram = 0x80007D4C
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f4.u32l = lambo_camera_scale_bits((uint32_t)ctx->f4.u32l); }"
+
+# Race-camera HEIGHT: replaces the authored +300 constant (mtc1 $at,$f6 at
+# 0x80032774) right before its add.s consumer.
+# Sense of speed -- opt-in chase-camera + FOV knobs (graphics.json keys
+# "camera_distance_scale" / "camera_height_scale" / "camera_fov_add"; defaults are
+# exactly the ROM's behaviour, so stock presentation is unchanged unless configured).
+# Natives in src/lambo_camera.cpp rescale an authored value in place just before its
+# consuming instruction.
+#
+# The LIVE race camera is func_80032450's gate==0 body (verified empirically with
+# first-arrival route tracing; the flag!=0 table path and the legacy chase math never
+# run during gameplay):
+#   eye.x   = carX - dirX * dist   -- dist consumer mul.s at 0x80033E5C
+#   eye.z   = carZ - dirZ * dist   -- dist consumer mul.s at 0x80033ED8
+#             (dist = per-player s16 at 0x800A2D28[i], e.g. 900)
+#   eye.y   = carY + heightParam   -- consumer add.s at 0x80034A08
+#             (heightParam = per-camera-mode table s16, float-converted in $f4)
+# The demo/attract camera (boot_pad_apply_calibration) uses an absolute eye =
+# car - dir*900; its mul.s consumers take the same distance scale so both camera
+# families respond consistently, as do func_80032450's dormant chase paths and its
+# follow-distance compare keyed on the same 900.
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x80033E5C
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f16.u32l = lambo_camera_scale_bits((uint32_t)ctx->f16.u32l); }"
+
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x80033ED8
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f16.u32l = lambo_camera_scale_bits((uint32_t)ctx->f16.u32l); }"
+
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x80034A08
+text = "{ extern unsigned int lambo_camera_height_bits(unsigned int); ctx->f4.u32l = lambo_camera_height_bits((uint32_t)ctx->f4.u32l); }"
+
+[[patches.hook]]
+func = "func_800030F8"
+before_vram = 0x800041AC
+text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gpr)(int32_t)lambo_camera_fov_bits((uint32_t)ctx->r6); }"
+
+[[patches.hook]]
+func = "func_800030F8"
+before_vram = 0x80004248
+text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gpr)(int32_t)lambo_camera_fov_bits((uint32_t)ctx->r6); }"
+
+[[patches.hook]]
+func = "func_800030F8"
+before_vram = 0x800042A4
+text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gpr)(int32_t)lambo_camera_fov_bits((uint32_t)ctx->r6); }"
+
+[[patches.hook]]
+func = "func_800030F8"
+before_vram = 0x80004300
+text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gpr)(int32_t)lambo_camera_fov_bits((uint32_t)ctx->r6); }"
+
+[[patches.hook]]
+func = "func_800030F8"
+before_vram = 0x80004374
+text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gpr)(int32_t)lambo_camera_fov_bits((uint32_t)ctx->r6); }"
+
+

--- a/src/lambo_camera.cpp
+++ b/src/lambo_camera.cpp
@@ -1,0 +1,134 @@
+// Sense-of-speed chase-camera + FOV knobs (see lambo_config.h for the user-facing
+// story). This file holds the float-bit shims the recompiled hook text calls: hooks
+// are emitted into ROM-derived C, which cannot include the C++ config header, so
+// each knob is exposed as an extern "C" function returning IEEE-754 bits.
+//
+// The LIVE race camera lives in func_80032450's L_800324C8 path (verified live via
+// LAMBO_CAM_TRACE probes -- the classic chase math at L_800320xx never runs in a
+// race):
+//   eye.x/z = car + viewdir * (per-player s16 distance, e.g. 900)
+//             -- distance consumer mul.s at 0x80032708 (scale site 1)
+//   eye.y   = track anchor table entry + 300.0
+//             -- height adder add.s at 0x80032780 (height site 1)
+// The demo/attract camera is produced by boot_pad_apply_calibration with an
+// absolute eye = car - dir*900, carY+1000; its mul.s consumers take the same
+// distance SCALE so both camera families respond consistently. func_80032450's
+// unused-in-race chase paths and its follow-distance compare are scaled too, so
+// any mode that does wake them stays self-consistent.
+//
+// With all knobs at their defaults (1.0 / 1.0 / +0) every shim returns exactly`r`n// what the ROM computed, so stock presentation is untouched.
+#include <cstring>
+
+#include "lambo_config.h"
+#include "lambo_log.h"
+
+namespace {
+
+unsigned int float_bits(double v) {
+    float f = static_cast<float>(v);
+    unsigned int b;
+    std::memcpy(&b, &f, sizeof(b));
+    return b;
+}
+
+// LAMBO_CAM_TRACE=1 logs value TRANSITIONS per knob -- a menu change must show up
+// as a "-> <new value>" line within a frame or two of the click, which makes the
+// knob -> hook -> camera chain directly observable. Same pattern as
+// libultra_stubs.c's LAMBO_PAK_TRACE.
+bool cam_trace() {
+    static const bool on = [] {
+        const char* e = std::getenv("LAMBO_CAM_TRACE");
+        return e && e[0] == '1';
+    }();
+    return on;
+}
+
+void trace(const char* what, double v) {
+    static int remaining = 25;
+    if (!cam_trace() || remaining <= 0) return;
+    --remaining;
+    LAMBO_LOG("camera", "%s -> %.1f\n", what, v);
+}
+
+// Shared rescale helper: authored float bits * scale, tracing only actual changes.
+unsigned int scaled_bits(unsigned int authored_bits, double scale, const char* tag,
+                         double& last_scale) {
+    float authored;
+    std::memcpy(&authored, &authored_bits, sizeof(authored));
+    if (scale != last_scale) {
+        last_scale = scale;
+        trace(tag, scale);
+    }
+    return float_bits(static_cast<double>(authored) * scale);
+}
+
+double g_dist_last = -1.0;
+double g_height_last = -1.0;
+
+} // namespace
+
+// Scale an authored length (float bits in, float bits out). Used at every site
+// that multiplies an authored camera distance into an eye offset.
+extern "C" unsigned int lambo_camera_scale_bits(unsigned int authored_bits) {
+    return scaled_bits(authored_bits, lambo::config::camera_distance_scale(),
+                       "dist scale", g_dist_last);
+}
+
+// Scale the authored eye-height offset (float bits of float(s16 table value) in).
+extern "C" unsigned int lambo_camera_height_bits(unsigned int authored_bits) {
+    return scaled_bits(authored_bits, lambo::config::camera_height_scale(),
+                       "height scale", g_height_last);
+}
+
+extern "C" unsigned int lambo_camera_fov_bits(unsigned int authored_bits) {
+    float authored;
+    std::memcpy(&authored, &authored_bits, sizeof(authored));
+    const double out = static_cast<double>(authored) + lambo::config::camera_fov_add();
+    if (out != (double)authored) {
+        static int remaining = 5;
+        if (cam_trace() && remaining > 0) {
+            --remaining;
+            LAMBO_LOG("camera", "fov %.1f -> %.1f\n", (double)authored, out);
+        }
+    }
+    return float_bits(out);
+}
+
+// DIAGNOSTIC (LAMBO_CAM_TRACE): called from the func_80032450 race-camera body
+// right before it stores eye.y, with the player index and the computed eye.y.
+extern "C" void lambo_camera_probe(unsigned int idx, float ey) {
+    static int remaining = 40;
+    static unsigned frame = 0;
+    if (!cam_trace() || remaining <= 0) return;
+    if (++frame % 60 != 1) return; // ~once a second at 60 VI/s
+    --remaining;
+    LAMBO_LOG("camera", "probe idx=%u eye.y=%.1f\n", idx, ey);
+}
+
+// DIAGNOSTIC (LAMBO_CAM_TRACE): route mapper -- logs the FIRST arrival at each
+// hooked address id, revealing which bodies of func_80032450 a race executes.
+extern "C" void lambo_camera_route(unsigned int id) {
+    static bool seen[1024] = {};
+    static int logged = 0;
+    if (!cam_trace() || id >= 1024 || seen[id] || logged >= 64) return;
+    seen[id] = true;
+    ++logged;
+    LAMBO_LOG("camera", "route %u\n", id);
+}
+
+// DIAGNOSTIC (LAMBO_CAM_TRACE): called at func_80032450 ENTRY with the camera-mode
+// gate halfword (0x800CE6B0), the current player index (0x800CE6AA) and the current
+// eye globals straight from RDRAM. Logs sparsely, to establish what actually drives
+// the race camera: a moving eye triple means these globals ARE the camera.
+extern "C" void lambo_camera_entry_probe(unsigned int gate, unsigned int idx,
+                                         float ex, float ey, float ez) {
+    static int remaining = 60;
+    static unsigned n = 0;
+    if (!cam_trace() || remaining <= 0) return;
+    ++n;
+    if (n > 4 && (n % 120) != 1) return; // then ~every 2 s
+    --remaining;
+    LAMBO_LOG("camera", "entry #%u gate=%u idx=%u eye=(%.1f, %.1f, %.1f)\n",
+              n, gate, idx, ex, ey, ez);
+}
+

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -65,6 +65,13 @@ std::array<double, 6> g_fog_scale_circuit{1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
 std::atomic<double> g_draw_distance{1.5};
 std::array<double, 6> g_draw_distance_circuit{1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
 
+// Chase-camera + FOV sense-of-speed knobs (see lambo_config.h). Defaults are the
+// ROM's authored constants: camera at its authored distance, 300 above the track
+// anchor, no FOV delta.
+std::atomic<double> g_camera_distance_scale{1.0};
+std::atomic<double> g_camera_height_scale{1.0};
+std::atomic<double> g_camera_fov_add{0.0};
+
 // Main-thread-owned snapshot used by native menu actions. It avoids reading the
 // runtime's reference-returning getter while another thread may be applying a change.
 ultramodern::renderer::GraphicsConfig g_current_graphics{};
@@ -120,6 +127,9 @@ nlohmann::json to_json(const ultramodern::renderer::GraphicsConfig& c) {
         {"fog_scale_circuit", g_fog_scale_circuit},
         {"draw_distance", g_draw_distance.load()},
         {"draw_distance_circuit", g_draw_distance_circuit},
+        {"camera_distance_scale", g_camera_distance_scale.load()},
+        {"camera_height_scale", g_camera_height_scale.load()},
+        {"camera_fov_add", g_camera_fov_add.load()},
     };
 }
 
@@ -148,6 +158,9 @@ void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c
     }
     double fog_scale = g_fog_scale.load();
     double draw_distance = g_draw_distance.load();
+    double camera_distance_scale = g_camera_distance_scale.load();
+    double camera_height_scale = g_camera_height_scale.load();
+    double camera_fov_add = g_camera_fov_add.load();
     from_or_default(j, "widescreen_fog_match", widescreen_fog_match);
     from_or_default(j, "widescreen_sky_match", widescreen_sky_match);
     from_or_default(j, "no_lod", no_lod);
@@ -156,6 +169,9 @@ void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c
     from_or_default(j, "fog_scale_circuit", g_fog_scale_circuit);
     from_or_default(j, "draw_distance", draw_distance);
     from_or_default(j, "draw_distance_circuit", g_draw_distance_circuit);
+    from_or_default(j, "camera_distance_scale", camera_distance_scale);
+    from_or_default(j, "camera_height_scale", camera_height_scale);
+    from_or_default(j, "camera_fov_add", camera_fov_add);
     g_widescreen_fog_match.store(widescreen_fog_match);
     g_widescreen_sky_match.store(widescreen_sky_match);
     g_no_lod.store(no_lod);
@@ -164,6 +180,9 @@ void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c
     }
     g_fog_scale.store(fog_scale);
     g_draw_distance.store(draw_distance);
+    g_camera_distance_scale.store(camera_distance_scale);
+    g_camera_height_scale.store(camera_height_scale);
+    g_camera_fov_add.store(camera_fov_add);
     // Sanity-bound the window size: below the N64 framebuffer is useless, above 8K
     // is a typo -- either way SDL_CreateWindow would fail and the port would run
     // permanently headless, so reset to defaults instead.
@@ -448,5 +467,72 @@ void set_global_draw_distance(double scale) {
     save_graphics(g_current_graphics);
 }
 
+// LAMBO_CAMERA_DISTANCE_SCALE=<float> overrides the JSON key for capture/testing.
+// Multiplier on the authored camera distance; 1.0 = stock, 0.5 = half as far.
+double camera_distance_scale() {
+    double v;
+    if (const char* s = std::getenv("LAMBO_CAMERA_DISTANCE_SCALE")) {
+        v = std::atof(s);
+    } else {
+        v = g_camera_distance_scale.load();
+    }
+    if (v < 0.2) v = 0.2;
+    if (v > 3.0) v = 3.0;
+    return v;
+}
+
+void set_camera_distance_scale(double v) {
+    if (v < 0.2) v = 0.2;
+    if (v > 3.0) v = 3.0;
+    g_camera_distance_scale.store(v);
+    save_graphics(g_current_graphics);
+}
+
+// LAMBO_CAMERA_HEIGHT_SCALE=<float> overrides the JSON key for capture/testing.
+// Multiplier on the authored eye-height offset; 1.0 = stock.
+double camera_height_scale() {
+    double v;
+    if (const char* s = std::getenv("LAMBO_CAMERA_HEIGHT_SCALE")) {
+        v = std::atof(s);
+    } else {
+        v = g_camera_height_scale.load();
+    }
+    if (v < 0.2) v = 0.2;
+    if (v > 3.0) v = 3.0;
+    return v;
+}
+
+void set_camera_height_scale(double v) {
+    if (v < 0.2) v = 0.2;
+    if (v > 3.0) v = 3.0;
+    g_camera_height_scale.store(v);
+    save_graphics(g_current_graphics);
+}
+
+// LAMBO_CAMERA_FOV_ADD=<float> overrides the JSON key for capture/testing.
+// Delta degrees on top of each layout's authored FOV; bounded so a typo can't
+// produce a degenerate projection (guPerspective cot(fovy/2) blows up near 0).
+double camera_fov_add() {
+    double v;
+    if (const char* s = std::getenv("LAMBO_CAMERA_FOV_ADD")) {
+        v = std::atof(s);
+    } else {
+        v = g_camera_fov_add.load();
+    }
+    if (v < -20.0) v = -20.0;
+    if (v > 60.0) v = 60.0;
+    return v;
+}
+
+void set_camera_fov_add(double v) {
+    if (v < -20.0) v = -20.0;
+    if (v > 60.0) v = 60.0;
+    g_camera_fov_add.store(v);
+    save_graphics(g_current_graphics);
+}
+
 } // namespace config
 } // namespace lambo
+
+
+

--- a/src/lambo_config.h
+++ b/src/lambo_config.h
@@ -100,6 +100,34 @@ double fog_scale(int circuit);
 double global_fog_scale();
 void set_global_fog_scale(double scale);
 
+// Chase-camera + FOV sense-of-speed knobs (opt-in: every default is the ROM's
+// authored value, so stock presentation needs no configuration).
+//
+//   camera_distance_scale -- multiplier on the race camera's authored distance
+//       from the car. The ROM keeps that distance as a per-player s16 (900 for
+//       the standard chase cam, written by the game's own camera logic) and
+//       multiplies it by a unit view vector every frame (consumers are the mul.s
+//       at 0x80033E5C / 0x80033ED8 in func_80032450, verified live). 0.6 = 40%
+//       closer; applies equally to the demo/attract cameras (absolute 900).
+//   camera_height_scale   -- multiplier on the authored eye-height offset. The ROM
+//       adds a per-camera-mode table value (s16) to the car's Y every frame
+//       (consumer add.s at 0x80034A08 in func_80032450); 0.5 = half as high, so
+//       the ground plane streaks past faster.
+//   camera_fov_add        -- degrees added to each layout's authored perspective
+//       FOV (1P races 40, 2P halves 20, 3P/4P 32, special cameras 52). Applied
+//       uniformly at all five guPerspective call sites in func_800030F8.
+//
+// graphics.json keys "camera_distance_scale" / "camera_height_scale" /
+// "camera_fov_add", overridable by LAMBO_CAMERA_DISTANCE_SCALE /
+// LAMBO_CAMERA_HEIGHT_SCALE / LAMBO_CAMERA_FOV_ADD for capture/testing. The float-bit
+// helpers the recompiled hook text calls live in src/lambo_camera.cpp.
+double camera_distance_scale();
+void set_camera_distance_scale(double v);
+double camera_height_scale();
+void set_camera_height_scale(double v);
+double camera_fov_add();
+void set_camera_fov_add(double v);
+
 // Draw-distance multiplier applied (while no_lod is on) to the authored per-circuit
 // segment-cull radii the scene builder tests visibility-list entries against.
 // 1.0 = the N64 radii, larger = see further, 0 (or negative) = unlimited: the whole
@@ -117,3 +145,4 @@ void set_global_draw_distance(double scale);
 } // namespace lambo
 
 #endif
+

--- a/src/lambo_menu.cpp
+++ b/src/lambo_menu.cpp
@@ -31,6 +31,9 @@ HMENU g_enhancements_menu = nullptr;
 HMENU g_pvs_menu = nullptr;
 HMENU g_draw_menu = nullptr;
 HMENU g_fog_menu = nullptr;
+HMENU g_cam_dist_menu = nullptr;
+HMENU g_cam_height_menu = nullptr;
+HMENU g_fov_menu = nullptr;
 
 enum Command : UINT {
     CMD_FULLSCREEN = 1000,
@@ -88,6 +91,19 @@ enum Command : UINT {
     CMD_FOG_100,
     CMD_FOG_150,
     CMD_FOG_200,
+
+    CMD_CAM_DIST_ORIG = 1300,
+    CMD_CAM_DIST_80,
+    CMD_CAM_DIST_65,
+    CMD_CAM_DIST_50,
+    CMD_CAM_HEIGHT_ORIG,
+    CMD_CAM_HEIGHT_LOWER,
+    CMD_CAM_HEIGHT_LOWEST,
+    CMD_FOV_ORIG,
+    CMD_FOV_PLUS5,
+    CMD_FOV_PLUS10,
+    CMD_FOV_PLUS15,
+    CMD_FOV_PLUS20,
 };
 
 void append_item(HMENU menu, UINT id, const char* label) {
@@ -165,6 +181,19 @@ void refresh() {
           close(fog, 2.0) ? CMD_FOG_200 : close(fog, 1.5) ? CMD_FOG_150 :
           close(fog, 1.0) ? CMD_FOG_100 : close(fog, 0.75) ? CMD_FOG_75 :
           close(fog, 0.5) ? CMD_FOG_50 : close(fog, 0.0) ? CMD_FOG_OFF : 0);
+    const double dist = lambo::config::camera_distance_scale();
+    radio(g_cam_dist_menu, CMD_CAM_DIST_ORIG, CMD_CAM_DIST_50,
+          close(dist, 0.5) ? CMD_CAM_DIST_50 : close(dist, 0.65) ? CMD_CAM_DIST_65 :
+          close(dist, 0.8) ? CMD_CAM_DIST_80 : close(dist, 1.0) ? CMD_CAM_DIST_ORIG : 0);
+    const double height = lambo::config::camera_height_scale();
+    radio(g_cam_height_menu, CMD_CAM_HEIGHT_ORIG, CMD_CAM_HEIGHT_LOWEST,
+          close(height, 0.4) ? CMD_CAM_HEIGHT_LOWEST : close(height, 0.66) ? CMD_CAM_HEIGHT_LOWER :
+          close(height, 1.0) ? CMD_CAM_HEIGHT_ORIG : 0);
+    const double fov = lambo::config::camera_fov_add();
+    radio(g_fov_menu, CMD_FOV_ORIG, CMD_FOV_PLUS20,
+          close(fov, 20.0) ? CMD_FOV_PLUS20 : close(fov, 15.0) ? CMD_FOV_PLUS15 :
+          close(fov, 10.0) ? CMD_FOV_PLUS10 : close(fov, 5.0) ? CMD_FOV_PLUS5 :
+          close(fov, 0.0) ? CMD_FOV_ORIG : 0);
     if (g_hwnd != nullptr) DrawMenuBar(g_hwnd);
 }
 
@@ -237,6 +266,18 @@ void dispatch(UINT command) {
         case CMD_FOG_100: lambo::config::set_global_fog_scale(1.0); break;
         case CMD_FOG_150: lambo::config::set_global_fog_scale(1.5); break;
         case CMD_FOG_200: lambo::config::set_global_fog_scale(2.0); break;
+        case CMD_CAM_DIST_ORIG: lambo::config::set_camera_distance_scale(1.0); break;
+        case CMD_CAM_DIST_80: lambo::config::set_camera_distance_scale(0.8); break;
+        case CMD_CAM_DIST_65: lambo::config::set_camera_distance_scale(0.65); break;
+        case CMD_CAM_DIST_50: lambo::config::set_camera_distance_scale(0.5); break;
+        case CMD_CAM_HEIGHT_ORIG: lambo::config::set_camera_height_scale(1.0); break;
+        case CMD_CAM_HEIGHT_LOWER: lambo::config::set_camera_height_scale(0.66); break;
+        case CMD_CAM_HEIGHT_LOWEST: lambo::config::set_camera_height_scale(0.4); break;
+        case CMD_FOV_ORIG: lambo::config::set_camera_fov_add(0.0); break;
+        case CMD_FOV_PLUS5: lambo::config::set_camera_fov_add(5.0); break;
+        case CMD_FOV_PLUS10: lambo::config::set_camera_fov_add(10.0); break;
+        case CMD_FOV_PLUS15: lambo::config::set_camera_fov_add(15.0); break;
+        case CMD_FOV_PLUS20: lambo::config::set_camera_fov_add(20.0); break;
         default: apply_graphics_command(command); break;
     }
     refresh();
@@ -308,6 +349,16 @@ void attach(SDL_Window* window) {
     append_item(fog, CMD_FOG_OFF, "Off"); append_item(fog, CMD_FOG_50, "50%");
     append_item(fog, CMD_FOG_75, "75%"); append_item(fog, CMD_FOG_100, "Original (100%)");
     append_item(fog, CMD_FOG_150, "150%"); append_item(fog, CMD_FOG_200, "200%");
+    HMENU cam_dist = g_cam_dist_menu = append_submenu(enhancements, "Chase camera distance (sense of speed)");
+    append_item(cam_dist, CMD_CAM_DIST_ORIG, "Original"); append_item(cam_dist, CMD_CAM_DIST_80, "Closer");
+    append_item(cam_dist, CMD_CAM_DIST_65, "Closer still"); append_item(cam_dist, CMD_CAM_DIST_50, "Bumper-ish");
+    HMENU cam_height = g_cam_height_menu = append_submenu(enhancements, "Chase camera height (sense of speed)");
+    append_item(cam_height, CMD_CAM_HEIGHT_ORIG, "Original"); append_item(cam_height, CMD_CAM_HEIGHT_LOWER, "Lower");
+    append_item(cam_height, CMD_CAM_HEIGHT_LOWEST, "Ground-hugging");
+    HMENU fov = g_fov_menu = append_submenu(enhancements, "Field of view boost (sense of speed)");
+    append_item(fov, CMD_FOV_ORIG, "Original"); append_item(fov, CMD_FOV_PLUS5, "+5 degrees");
+    append_item(fov, CMD_FOV_PLUS10, "+10 degrees"); append_item(fov, CMD_FOV_PLUS15, "+15 degrees");
+    append_item(fov, CMD_FOV_PLUS20, "+20 degrees");
 
     if ((SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0) {
         SetMenu(g_hwnd, g_menu_bar);
@@ -367,3 +418,8 @@ void toggle_fullscreen() {
 } // namespace lambo::menu
 
 #endif
+
+
+
+
+

--- a/tests/test_live_config.cpp
+++ b/tests/test_live_config.cpp
@@ -63,12 +63,18 @@ int main() {
     lambo::config::set_no_lod_circuit(4, true);
     lambo::config::set_global_fog_scale(1.5);
     lambo::config::set_global_draw_distance(2.0);
+    lambo::config::set_camera_distance_scale(0.65);
+    lambo::config::set_camera_height_scale(0.5);
+    lambo::config::set_camera_fov_add(10.0);
     expect(!lambo::config::widescreen_fog_match(), "fog toggle updates live");
     expect(!lambo::config::widescreen_sky_match(), "sky toggle updates live");
     expect(!lambo::config::no_lod(), "LOD toggle updates live");
     expect(lambo::config::no_lod_circuit(4), "per-circuit visibility updates live");
     expect(lambo::config::global_fog_scale() == 1.5, "fog scale updates live");
     expect(lambo::config::global_draw_distance() == 2.0, "draw distance updates live");
+    expect(lambo::config::camera_distance_scale() == 0.65, "camera distance scale updates live");
+    expect(lambo::config::camera_height_scale() == 0.5, "camera height scale updates live");
+    expect(lambo::config::camera_fov_add() == 10.0, "camera FOV delta updates live");
 
     lambo::config::update_saved_window_mode(ultramodern::renderer::WindowMode::Fullscreen);
     const auto json = read_json(path);
@@ -82,8 +88,22 @@ int main() {
     expect(json.at("no_lod_circuit").at(4) == true, "per-circuit visibility persists");
     expect(json.at("fog_scale") == 1.5, "fog scale persists");
     expect(json.at("draw_distance") == 2.0, "draw distance persists");
+    expect(json.at("camera_distance_scale") == 0.65, "camera distance scale persists");
+    expect(json.at("camera_height_scale") == 0.5, "camera height scale persists");
+    expect(json.at("camera_fov_add") == 10.0, "camera FOV delta persists");
+
+    // Out-of-range values are clamped, not rejected: the ROM-authored defaults
+    // (900 / 200 / +0) must round-trip exactly so stock presentation is stable.
+    lambo::config::set_camera_distance_scale(99.0);
+    lambo::config::set_camera_height_scale(-5.0);
+    lambo::config::set_camera_fov_add(500.0);
+    expect(lambo::config::camera_distance_scale() == 3.0, "camera distance scale clamps high");
+    expect(lambo::config::camera_height_scale() == 0.2, "camera height scale clamps low");
+    expect(lambo::config::camera_fov_add() == 60.0, "camera FOV delta clamps high");
 
     std::error_code ec;
     std::filesystem::remove_all(dir, ec);
     return failures == 0 ? 0 : 1;
 }
+
+


### PR DESCRIPTION
## Summary

Opt-in camera enhancements addressing the common "no sense of speed" complaint. Every knob defaults to exact ROM behaviour, so stock presentation is unchanged unless configured.

**New knobs** (graphics.json / native Enhancements menu / env overrides):

| Knob | Range | Effect |
|---|---|---|
| `camera_distance_scale` | 0.2-3.0 (1.0 = stock) | Camera closer to the car - more optical flow on the road |
| `camera_height_scale` | 0.2-3.0 (1.0 = stock) | Camera lower - ground plane streaks past faster |
| `camera_fov_add` | -20 to +60 deg (0 = stock) | Wider lens - peripheral flow, tunnel-vision feel |

Menu presets under **Enhancements**: Chase camera distance / Chase camera height / Field of view boost. Changes apply live mid-race and persist.

## Implementation

Hooks sit on the **live race camera body** of `func_80032450`, mapped empirically with first-arrival route tracing (`LAMBO_CAM_TRACE`):

- `eye.x/z = car - dir * dist` - distance consumers at `0x80033E5C` / `0x80033ED8`; the authored per-player s16 distance is rescaled in flight
- `eye.y = carY + heightParam` - consumer at `0x80034A08`; the authored per-camera-mode table value is rescaled (preserves per-circuit variation)
- Demo/attract camera (`boot_pad_apply_calibration`) and dormant chase paths take the same scale for cross-mode consistency; the follow-distance compare keyed on 900 stays consistent with scaled eyes
- FOV delta applied at all five `guPerspective` call sites (1P 40, 2P halves 20, special 52, 3P/4P 32), preserving split-screen relative framing

Natives in `src/lambo_camera.cpp` (extern "C" float-bit shims, same pattern as the widescreen hooks); config follows the established `lambo_config` graphics.json pattern; Win32 menu radio groups mirror fog/draw-distance presets.

## Verification

- Config tests extended (live update, persistence, clamping) - passing
- Headless warp races: clean boot, no crash at stock and enhanced settings
- A/B software-render diffs on warped races: distance 0.6x changes ~40% of frame pixels, height 0.5x ~30%, consistent across sampled frames; stock settings byte-stable vs ROM behaviour

Suggested starting point: distance 0.65-0.75 + height 0.66 + FOV +10.
