### PR TITLE
Fix skybox coverage for wide camera FOV

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -58,6 +58,9 @@ git -C lib/rt64 apply "$(pwd)/patches/0009-rt64-widescreen-split-subviewport.pat
 # RT64 renderer — all platforms (explicit-D3D12 adapter escape hatch for Intel GPUs):
 git -C lib/rt64 apply "$(pwd)/patches/0010-rt64-intel-explicit-d3d12-escape-hatch.patch"
 
+# RT64 renderer — all platforms (finite backdrops independent of camera FOV):
+git -C lib/rt64 apply "$(pwd)/patches/0011-rt64-fov-independent-backdrop.patch"
+
 # RT64 renderer — Windows / MinGW only (absolute paths avoid depth confusion):
 git -C lib/rt64 apply "$(pwd)/patches/0005-rt64-mingw-gcc-compat.patch"
 git -C lib/rt64/src/contrib/plume apply "$(pwd)/patches/0004-plume-d3d12-mingw-com-abi-struct-return.patch"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,14 @@ if(BUILD_TESTING)
     )
     add_test(NAME lambo_config_live_updates COMMAND lambo_config_tests)
 
+    add_executable(lambo_camera_projection_tests
+        tests/test_camera_projection.cpp
+    )
+    target_include_directories(lambo_camera_projection_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    add_test(NAME lambo_camera_projection_policy COMMAND lambo_camera_projection_tests)
+
     add_executable(lambo_controller_pak_tests
         tests/test_controller_pak.c
         src/libultra_stubs.c

--- a/build.ps1
+++ b/build.ps1
@@ -15,7 +15,7 @@
       3. ROM check (skippable via -RomPath; CI forwards its $env:ROM_FILENAME).
       4. Defensive submodule reset before patching (a half-applied patch from a
          prior run would otherwise break the next apply).
-      5. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0008, 0009, 0010, 0005, 0004) with
+      5. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0008, 0009, 0010, 0011, 0005, 0004) with
          --ignore-whitespace (CRLF mismatches on Windows git). 0007 adds the
          save-state thread-context registry; without it, src/lambo_savestate.c
          fails to link with "undefined reference to ultramodern_relink_thread_contexts".
@@ -177,7 +177,7 @@ try {
     git -C lib/rt64 checkout -- . | Out-Null
     git -C lib/rt64/src/contrib/plume checkout -- . | Out-Null
 
-    # --- 6. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0008, 0009, 0010, 0005, 0004) -
+    # --- 6. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0008, 0009, 0010, 0011, 0005, 0004) -
     # Mirrors CI's Windows job exactly (workflow lines 210-214). 0001 then 0007
     # both patch N64ModernRuntime with disjoint hunks (verified to apply
     # sequentially on the pinned commit). 0007 adds the save-state thread-
@@ -196,6 +196,7 @@ try {
         @{ Sub = 'lib/rt64';                   Patch = 'patches/0005-rt64-mingw-gcc-compat.patch' },
         @{ Sub = 'lib/rt64';                   Patch = 'patches/0009-rt64-widescreen-split-subviewport.patch' },
         @{ Sub = 'lib/rt64';                   Patch = 'patches/0010-rt64-intel-explicit-d3d12-escape-hatch.patch' },
+        @{ Sub = 'lib/rt64';                   Patch = 'patches/0011-rt64-fov-independent-backdrop.patch' },
         @{ Sub = 'lib/rt64/src/contrib/plume'; Patch = 'patches/0004-plume-d3d12-mingw-com-abi-struct-return.patch' }
     )
     foreach ($p in $patches) {

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@
 #   3. Submodule init (recursive; core.longpaths isn't needed on Linux).
 #   4. Defensive submodule reset before patching (half-applied patches from a
 #      prior run would otherwise break the next apply with "patch failed: ...").
-#   5. Apply Lamborghini patches (Linux: 0001, 0007, 0006, 0008, 0009, 0010 — no MinGW/D3D12
+#   5. Apply Lamborghini patches (Linux: 0001, 0007, 0006, 0008, 0009, 0010, 0011 — no MinGW/D3D12
 #      fixes needed; no plume patch). 0007 adds the save-state thread-context
 #      registry; without it, src/lambo_savestate.c fails to link with
 #      "undefined reference to ultramodern_relink_thread_contexts".
@@ -96,7 +96,7 @@ git -C lib/N64ModernRuntime checkout -- .
 git -C lib/rt64 checkout -- .
 git -C lib/rt64/src/contrib/plume checkout -- . 2>/dev/null || true
 
-# --- 6. Apply Lamborghini patches (Linux: 0001, 0007, 0006, 0008, 0009, 0010) ----------------
+# --- 6. Apply Lamborghini patches (Linux: 0001, 0007, 0006, 0008, 0009, 0010, 0011) ----------------
 # Mirrors CI's Linux job exactly (workflow lines 93-95). 0001 then 0007 both
 # patch N64ModernRuntime with disjoint hunks (verified to apply sequentially
 # on the pinned commit). 0007 adds the save-state thread-context registry +
@@ -111,6 +111,7 @@ PATCHES=(
     "lib/rt64:0008-rt64-skybox-stretch-parallaxless-backdrop.patch"
     "lib/rt64:0009-rt64-widescreen-split-subviewport.patch"
     "lib/rt64:0010-rt64-intel-explicit-d3d12-escape-hatch.patch"
+    "lib/rt64:0011-rt64-fov-independent-backdrop.patch"
 )
 for entry in "${PATCHES[@]}"; do
     sub="${entry%%:*}"

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -615,6 +615,37 @@ func = "func_800030F8"
 before_vram = 0x80004E94
 text = "{ extern uint32_t lambo_sky_match_1p_guard(uint8_t*, uint32_t); ctx->r1 = lambo_sky_match_1p_guard(rdram, (uint32_t)ctx->r1); }"
 
+# Both calls assemble the finite sky panorama with a rotation-only view and the
+# current race projection. Tag the projection load as well as the emitted draw
+# so RT64 allocates a backdrop-only transform; tagging after the load would also
+# modify later world/HUD draws that reuse its transform index. The first load has
+# two mutually-exclusive branches. The first end hook sits on the sky guard's
+# merge label, so the native ignores an unmatched end.
+[[patches.hook]]
+func = "func_800030F8"
+before_vram = 0x80004DEC
+text = "{ extern void lambo_sky_backdrop_begin(uint8_t*); lambo_sky_backdrop_begin(rdram); }"
+
+[[patches.hook]]
+func = "func_800030F8"
+before_vram = 0x80004E34
+text = "{ extern void lambo_sky_backdrop_begin(uint8_t*); lambo_sky_backdrop_begin(rdram); }"
+
+[[patches.hook]]
+func = "func_800030F8"
+before_vram = 0x80004EA4
+text = "{ extern void lambo_sky_backdrop_end(uint8_t*); lambo_sky_backdrop_end(rdram); }"
+
+[[patches.hook]]
+func = "func_800030F8"
+before_vram = 0x800052C0
+text = "{ extern void lambo_sky_backdrop_begin(uint8_t*); lambo_sky_backdrop_begin(rdram); }"
+
+[[patches.hook]]
+func = "func_800030F8"
+before_vram = 0x80005308
+text = "{ extern void lambo_sky_backdrop_end(uint8_t*); lambo_sky_backdrop_end(rdram); }"
+
 # Issues #87/#91 -- no_lod: emit the per-segment scenery layer in 2P-4P like 1P. The scene
 # builder func_8000A6C0 draws each track segment as up to three sub-DLs from the 64-byte
 # segment record (+0x4 road, +0x8 walls, +0xC far scenery) but gates the scenery emit on

--- a/patches/0011-rt64-fov-independent-backdrop.patch
+++ b/patches/0011-rt64-fov-independent-backdrop.patch
@@ -1,0 +1,312 @@
+diff --git a/include/rt64_extended_gbi.h b/include/rt64_extended_gbi.h
+index a370cbe..8762d65 100644
+--- a/include/rt64_extended_gbi.h
++++ b/include/rt64_extended_gbi.h
+@@ -120,6 +120,7 @@
+ #define G_EX_ASPECT_AUTO            0x0
+ #define G_EX_ASPECT_STRETCH         0x1
+ #define G_EX_ASPECT_ADJUST          0x2
++#define G_EX_ASPECT_BACKDROP        0x3
+ 
+ #define G_EX_VERTEX_POSITION        0x0
+ #define G_EX_VERTEX_VELOCITY        0x1
+@@ -329,6 +330,14 @@ typedef union {
+         0 \
+     )
+ 
++// The second command's word 1 was reserved by matrix-group V1. Backdrop groups
++// use it to carry the IEEE-754 projection multiplier computed alongside the
++// exact game FOV, keeping live configuration changes frame-consistent.
++#define gEXSetMatrixGroupProjectionFovScale(cmd, scale_bits) \
++    DOWHILE( \
++        (((GfxCommand *)(cmd)) + 1)->values.word1 = (unsigned)(scale_bits); \
++    )
++
+ #define gEXMatrixGroupSimple(cmd, id, push, proj, pos, rot, persp, vert, tile, order, edit, tc, lookat) \
+     gEXMatrixGroup(cmd, id, G_EX_INTERPOLATE_SIMPLE, push, proj, pos, rot, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_SKIP, persp, vert, tile, order, edit, G_EX_ASPECT_AUTO, tc, lookat)
+ 
+diff --git a/src/gbi/rt64_gbi_extended.cpp b/src/gbi/rt64_gbi_extended.cpp
+index 20c0d4d..13fc6ea 100644
+--- a/src/gbi/rt64_gbi_extended.cpp
++++ b/src/gbi/rt64_gbi_extended.cpp
+@@ -4,6 +4,9 @@
+ 
+ #include "rt64_gbi_extended.h"
+ 
++#include <cmath>
++#include <cstring>
++
+ #include "../include/rt64_extended_gbi.h"
+ 
+ namespace RT64 {
+@@ -147,7 +150,16 @@ namespace RT64 {
+             const uint8_t editable = (*dl)->p0(19, 1);
+             const uint8_t aspect = (*dl)->p0(20, 2);
+             const uint8_t lookat = (*dl)->p0(24, 2);
+-            state->rsp->matrixId(id, push, proj, mode, pos, rot, scale, skew, persp, vpos, vtc, tile, lookat, order, aspect, editable, idIsAddress, editGroup);
++            float projectionFovScale = 1.0f;
++            const uint32_t projectionFovScaleBits = (*dl)->w1;
++            if (projectionFovScaleBits != 0) {
++                std::memcpy(&projectionFovScale, &projectionFovScaleBits,
++                            sizeof(projectionFovScale));
++                if (!std::isfinite(projectionFovScale) || (projectionFovScale <= 0.0f)) {
++                    projectionFovScale = 1.0f;
++                }
++            }
++            state->rsp->matrixId(id, push, proj, mode, pos, rot, scale, skew, persp, vpos, vtc, tile, lookat, order, aspect, editable, projectionFovScale, idIsAddress, editGroup);
+         }
+ 
+         void matrixGroupV1(State *state, DisplayList **dl) {
+@@ -156,7 +168,10 @@ namespace RT64 {
+ 
+         void popMatrixGroupV1(State *state, DisplayList **dl) {
+             const uint8_t popCount = (*dl)->p1(0, 8);
+-            const uint8_t proj = (*dl)->p0(8, 1);
++            // gEXPopMatrixGroup encodes both fields in word 1. Reading the
++            // projection selector from word 0 silently pops the model stack and
++            // leaks scoped projection metadata into every later draw.
++            const uint8_t proj = (*dl)->p1(8, 1);
+             state->rsp->popMatrixId(popCount, proj);
+         }
+ 
+diff --git a/src/hle/rt64_rsp.cpp b/src/hle/rt64_rsp.cpp
+index ee2030b..8a62045 100644
+--- a/src/hle/rt64_rsp.cpp
++++ b/src/hle/rt64_rsp.cpp
+@@ -1190,7 +1190,7 @@ namespace RT64 {
+         state->updateDrawStatusAttribute(DrawAttribute::ExtendedType);
+     }
+ 
+-    void RSP::matrixId(uint32_t id, bool push, bool proj, bool decompose, uint8_t pos, uint8_t rot, uint8_t scale, uint8_t skew, uint8_t persp, uint8_t vpos, uint8_t vtc, uint8_t tile, uint8_t lookat, uint8_t order, uint8_t aspect, uint8_t editable, bool idIsAddress, bool editGroup) {
++    void RSP::matrixId(uint32_t id, bool push, bool proj, bool decompose, uint8_t pos, uint8_t rot, uint8_t scale, uint8_t skew, uint8_t persp, uint8_t vpos, uint8_t vtc, uint8_t tile, uint8_t lookat, uint8_t order, uint8_t aspect, uint8_t editable, float projectionFovScale, bool idIsAddress, bool editGroup) {
+         assert((idIsAddress == editGroup) && "This case is not supported yet.");
+ 
+         auto setGroupProperties = [=](TransformGroup* dstGroup, bool newGroup) {
+@@ -1208,6 +1208,7 @@ namespace RT64 {
+                 dstGroup->ordering = order;
+                 dstGroup->aspectMode = aspect;
+                 dstGroup->editable = editable;
++                dstGroup->projectionFovScale = projectionFovScale;
+             }
+         };
+ 
+@@ -1247,6 +1248,13 @@ namespace RT64 {
+             dstGroup->matrixId = id;
+             setGroupProperties(dstGroup, true);
+             stackChanged = true;
++            // Projection metadata (not only matrix contents) affects processing
++            // and viewport mapping. Split subsequent draws into a new projection
++            // so a scoped aspect mode cannot leak into later calls that reuse the
++            // same N64 projection matrix.
++            if (proj) {
++                projectionMatrixChanged = true;
++            }
+         }
+     }
+ 
+@@ -1258,6 +1266,9 @@ namespace RT64 {
+             count--;
+             stackSize--;
+             stackChanged = true;
++            if (proj) {
++                projectionMatrixChanged = true;
++            }
+         }
+     }
+ 
+diff --git a/src/hle/rt64_rsp.h b/src/hle/rt64_rsp.h
+index 61bb3b1..0a6f761 100644
+--- a/src/hle/rt64_rsp.h
++++ b/src/hle/rt64_rsp.h
+@@ -296,7 +296,7 @@ namespace RT64 {
+         void setViewportAlign(uint16_t ori, int16_t offx, int16_t offy);
+         void vertexTestZ(uint8_t vtxIndex);
+         void endVertexTestZ();
+-        void matrixId(uint32_t id, bool push, bool proj, bool decompose, uint8_t pos, uint8_t rot, uint8_t scale, uint8_t skew, uint8_t persp, uint8_t vpos, uint8_t vtc, uint8_t tile, uint8_t lookat, uint8_t order, uint8_t aspect, uint8_t editable, bool idIsAddress, bool editGroup);
++        void matrixId(uint32_t id, bool push, bool proj, bool decompose, uint8_t pos, uint8_t rot, uint8_t scale, uint8_t skew, uint8_t persp, uint8_t vpos, uint8_t vtc, uint8_t tile, uint8_t lookat, uint8_t order, uint8_t aspect, uint8_t editable, float projectionFovScale, bool idIsAddress, bool editGroup);
+         void popMatrixId(uint8_t count, bool proj);
+         void forceBranch(bool force);
+         void extendRDRAM(bool isExtended);
+@@ -304,4 +304,4 @@ namespace RT64 {
+         void setGBI(GBI *gbi);
+         void setNoN(bool NoN);
+     };
+-};
+\ No newline at end of file
++};
+diff --git a/src/hle/rt64_transform_group.h b/src/hle/rt64_transform_group.h
+index 399e665..ddf1e11 100644
+--- a/src/hle/rt64_transform_group.h
++++ b/src/hle/rt64_transform_group.h
+@@ -24,5 +24,6 @@ namespace RT64 {
+         uint8_t ordering = G_EX_ORDER_AUTO;
+         uint8_t aspectMode = G_EX_ASPECT_AUTO;
+         uint8_t editable = G_EX_EDIT_NONE;
++        float projectionFovScale = 1.0f;
+     };
+-};
+\ No newline at end of file
++};
+diff --git a/src/render/rt64_framebuffer_renderer.cpp b/src/render/rt64_framebuffer_renderer.cpp
+index 6b2b974..2765b55 100644
+--- a/src/render/rt64_framebuffer_renderer.cpp
++++ b/src/render/rt64_framebuffer_renderer.cpp
+@@ -14,6 +14,7 @@
+ #include "shared/rt64_raster_params.h"
+ 
+ #include "rt64_descriptor_sets.h"
++#include "rt64_projection_processor.h"
+ #include "rt64_render_worker.h"
+ 
+ // TODO: Move to shared.
+@@ -1495,7 +1496,18 @@ namespace RT64 {
+                 // so taking the wide branch (screenScale.x stays 1.0) lets it fill that half
+                 // instead of being squeezed to the 4:3 centre. computeOrigin() treats WIDE (>= NONE)
+                 // as centre, so convertViewportRect still produces the correct half-width scissor.
+-                bool useWideViewport = ((viewportOrigin == G_EX_ORIGIN_NONE) && coversWholeWidth && horizontalRatio) || (viewportOrigin == G_EX_ORIGIN_WIDE);
++                const uint32_t projGroupIndex = drawData.viewProjTransformGroups[proj.transformsIndex];
++                const TransformGroup &projGroup = drawData.transformGroups[projGroupIndex];
++                const auto &viewTransform = drawData.viewTransforms[proj.transformsIndex];
++                const bool fovIndependentBackdrop = isFovIndependentBackdrop(
++                    proj.type, projGroup.aspectMode, viewTransform);
++                // A finite backdrop is rendered as a complete source-aspect image. Once
++                // its authored FOV has been restored by ProjectionProcessor, map that
++                // image over the entire destination viewport instead of centering it in
++                // the original-width band. This is what makes coverage independent of
++                // the destination aspect ratio rather than merely "wide enough" at 16:9.
++                bool useWideViewport = ((viewportOrigin == G_EX_ORIGIN_NONE) && coversWholeWidth && horizontalRatio) ||
++                                       (viewportOrigin == G_EX_ORIGIN_WIDE) || fovIndependentBackdrop;
+                 if (useWideViewport) {
+                     projInvRatioScale = 1.0f;
+                 }
+@@ -1922,4 +1934,4 @@ namespace RT64 {
+         unsigned int im3dVertexCount;
+     };
+ };
+-*/
+\ No newline at end of file
++*/
+diff --git a/src/render/rt64_projection_processor.cpp b/src/render/rt64_projection_processor.cpp
+index c5dd321..fd17720 100644
+--- a/src/render/rt64_projection_processor.cpp
++++ b/src/render/rt64_projection_processor.cpp
+@@ -16,6 +16,13 @@ namespace RT64 {
+         matrix[2][0] *= aspectRatioScale;
+         matrix[3][0] *= aspectRatioScale;
+     }
++
++    inline void adjustProjectionFov(interop::float4x4 &matrix, const float fovScale) {
++        for (int row = 0; row < 4; row++) {
++            matrix[row][0] *= fovScale;
++            matrix[row][1] *= fovScale;
++        }
++    }
+     
+     // ProjectionProcessor
+ 
+@@ -90,7 +97,14 @@ namespace RT64 {
+             // is exactly right -- without it the quadrant, stretched to fill its output quarter,
+             // would be horizontally distorted.
+             const bool wideSubViewport = (viewportOrigin == G_EX_ORIGIN_WIDE);
++            const interop::float4x4 &viewTransform = drawData.viewTransforms[proj.transformsIndex];
++            const bool parallaxlessView = isParallaxlessView(viewTransform);
++            const bool fovIndependentBackdrop = isFovIndependentBackdrop(
++                proj.type, curProjGroup.aspectMode, viewTransform);
+             bool adjustAspectRatio = (curProjGroup.aspectMode == G_EX_ASPECT_ADJUST) || wideSubViewport;
++            if (fovIndependentBackdrop) {
++                adjustAspectRatio = false;
++            }
+             if ((curProjGroup.aspectMode == G_EX_ASPECT_AUTO) && !wideSubViewport) {
+                 FixedRect intersectionRect = proj.scissorRect;
+                 if (proj.usesViewport()) {
+@@ -119,12 +133,8 @@ namespace RT64 {
+             // float noise, kept well below any real scene's camera offset. This runs in the
+             // render thread every presented frame, so it also covers the paused state where the
+             // game's own per-frame frustum builder (func_8004384C) is frozen.
+-            if (adjustAspectRatio && (proj.type == Projection::Type::Perspective)) {
+-                const interop::float4x4 &vT = drawData.viewTransforms[proj.transformsIndex];
+-                const float translationEpsilon = 0.5f;
+-                if ((fabsf((float)vT[3][0]) < translationEpsilon) &&
+-                    (fabsf((float)vT[3][1]) < translationEpsilon) &&
+-                    (fabsf((float)vT[3][2]) < translationEpsilon)) {
++            if (!fovIndependentBackdrop && adjustAspectRatio && (proj.type == Projection::Type::Perspective)) {
++                if (parallaxlessView) {
+                     adjustAspectRatio = false;
+                 }
+             }
+@@ -143,7 +153,14 @@ namespace RT64 {
+                 projMatrix = workload.debuggerCamera.projMatrix;
+             }
+ 
++            float backdropFovScale = 1.0f;
++            if (fovIndependentBackdrop) {
++                backdropFovScale = curProjGroup.projectionFovScale;
++            }
++            const float restoredVerticalScale =
++                std::abs((float)projMatrix[1][1]) * backdropFovScale;
+             adjustProjectionMatrix(projMatrix, projRatioScale);
++            adjustProjectionFov(projMatrix, backdropFovScale);
+ 
+             interop::float4x4 &prevViewTransform = drawData.prevViewTransforms[proj.transformsIndex];
+             interop::float4x4 &prevProjTransform = drawData.prevProjTransforms[proj.transformsIndex];
+@@ -152,6 +169,12 @@ namespace RT64 {
+                 const interop::float4x4 curProjTransform = projMatrix;
+                 interop::float4x4 adjustedPrevProj = *prevProjMatrix;
+                 adjustProjectionMatrix(adjustedPrevProj, projRatioScale);
++                if (fovIndependentBackdrop) {
++                    const float prevVerticalScale = std::abs((float)adjustedPrevProj[1][1]);
++                    const float prevBackdropFovScale = (prevVerticalScale > 1.0e-8f)
++                        ? (restoredVerticalScale / prevVerticalScale) : 1.0f;
++                    adjustProjectionFov(adjustedPrevProj, prevBackdropFovScale);
++                }
+                 viewMatrix = rigidBody->lerp(p.curFrameWeight, *prevViewMatrix, curViewTransform, true);
+                 prevViewTransform = rigidBody->lerp(p.prevFrameWeight, *prevViewMatrix, curViewTransform, true);
+ 
+@@ -191,4 +214,4 @@ namespace RT64 {
+ 
+         bufferUploader->submit(p.worker, uploads);
+     }
+-};
+\ No newline at end of file
++};
+diff --git a/src/render/rt64_projection_processor.h b/src/render/rt64_projection_processor.h
+index 5bc3a2a..1a6c9af 100644
+--- a/src/render/rt64_projection_processor.h
++++ b/src/render/rt64_projection_processor.h
+@@ -4,11 +4,29 @@
+ 
+ #pragma once
+ 
++#include <cmath>
++
++#include "../include/rt64_extended_gbi.h"
++
+ #include "hle/rt64_game_frame.h"
+ 
+ #include "rt64_buffer_uploader.h"
+ 
+ namespace RT64 {
++    inline bool isParallaxlessView(const interop::float4x4 &viewTransform) {
++        constexpr float translationEpsilon = 0.5f;
++        return (std::abs((float)viewTransform[3][0]) < translationEpsilon) &&
++            (std::abs((float)viewTransform[3][1]) < translationEpsilon) &&
++            (std::abs((float)viewTransform[3][2]) < translationEpsilon);
++    }
++
++    inline bool isFovIndependentBackdrop(Projection::Type type, uint8_t aspectMode,
++                                         const interop::float4x4 &viewTransform) {
++        return (type == Projection::Type::Perspective) &&
++            (aspectMode == G_EX_ASPECT_BACKDROP) &&
++            isParallaxlessView(viewTransform);
++    }
++
+     struct ProjectionProcessor {
+         std::unique_ptr<BufferUploader> bufferUploader;
+         std::vector<BufferUploader::Upload> uploads;
+@@ -30,4 +48,4 @@ namespace RT64 {
+         void processScene(const ProcessParams &p, const GameScene &scene, size_t sceneIndex);
+         void upload(const ProcessParams &p);
+     };
+-};
+\ No newline at end of file
++};

--- a/src/lambo_camera.cpp
+++ b/src/lambo_camera.cpp
@@ -17,8 +17,10 @@
 // any mode that does wake them stays self-consistent.
 //
 // With all knobs at their defaults (1.0 / 1.0 / +0) every shim returns exactly`r`n// what the ROM computed, so stock presentation is untouched.
+#include <atomic>
 #include <cstring>
 
+#include "lambo_camera_projection.h"
 #include "lambo_config.h"
 #include "lambo_log.h"
 
@@ -64,6 +66,7 @@ unsigned int scaled_bits(unsigned int authored_bits, double scale, const char* t
 
 double g_dist_last = -1.0;
 double g_height_last = -1.0;
+std::atomic<unsigned int> g_backdrop_projection_scale_bits{0x3F800000u};
 
 } // namespace
 
@@ -83,7 +86,12 @@ extern "C" unsigned int lambo_camera_height_bits(unsigned int authored_bits) {
 extern "C" unsigned int lambo_camera_fov_bits(unsigned int authored_bits) {
     float authored;
     std::memcpy(&authored, &authored_bits, sizeof(authored));
-    const double out = static_cast<double>(authored) + lambo::config::camera_fov_add();
+    const double out = lambo_clamp_vertical_fov(
+        static_cast<double>(authored) + lambo::config::camera_fov_add());
+    const float backdrop_scale = static_cast<float>(
+        lambo_backdrop_fov_restore_scale(static_cast<double>(authored), out));
+    g_backdrop_projection_scale_bits.store(float_bits(backdrop_scale),
+                                            std::memory_order_release);
     if (out != (double)authored) {
         static int remaining = 5;
         if (cam_trace() && remaining > 0) {
@@ -92,6 +100,21 @@ extern "C" unsigned int lambo_camera_fov_bits(unsigned int authored_bits) {
         }
     }
     return float_bits(out);
+}
+
+// The display-list tag embeds the correction computed alongside the exact FOV
+// passed to guPerspective. RT64 therefore never re-reads live configuration for
+// an older workload when a menu change lands between game and render threads.
+extern "C" unsigned int lambo_camera_backdrop_projection_scale_bits() {
+    const unsigned int bits = g_backdrop_projection_scale_bits.load(std::memory_order_acquire);
+    static int remaining = 5;
+    if (cam_trace() && remaining > 0) {
+        --remaining;
+        float scale;
+        std::memcpy(&scale, &bits, sizeof(scale));
+        LAMBO_LOG("camera", "backdrop projection restore %.4f\n", (double)scale);
+    }
+    return bits;
 }
 
 // DIAGNOSTIC (LAMBO_CAM_TRACE): called from the func_80032450 race-camera body

--- a/src/lambo_camera_projection.h
+++ b/src/lambo_camera_projection.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+
+// Keep every camera layout away from guPerspective's singular endpoints. The
+// current UI range only reaches the lower endpoint in 2P (20 + -20), but this
+// also makes future config-range changes safe.
+inline double lambo_clamp_vertical_fov(double degrees) {
+    if (!std::isfinite(degrees)) {
+        return 40.0;
+    }
+    return std::clamp(degrees, 1.0, 170.0);
+}
+
+// A finite panorama must retain its authored FOV even while the world camera is
+// widened. Return the projection multiplier which maps cot(adjusted / 2) back
+// to cot(authored / 2). Narrower cameras already overfill the panorama.
+inline double lambo_backdrop_fov_restore_scale(double authored_degrees,
+                                                double adjusted_degrees) {
+    if (!std::isfinite(authored_degrees) || !std::isfinite(adjusted_degrees) ||
+        !(adjusted_degrees > authored_degrees)) {
+        return 1.0;
+    }
+
+    constexpr double pi = 3.14159265358979323846;
+    const double authored_radians = authored_degrees * pi / 180.0;
+    const double adjusted_radians = adjusted_degrees * pi / 180.0;
+    if (!(authored_radians > 0.0) || authored_radians >= pi ||
+        !(adjusted_radians > 0.0) || adjusted_radians >= pi) {
+        return 1.0;
+    }
+
+    const double restore = std::tan(adjusted_radians * 0.5) /
+                           std::tan(authored_radians * 0.5);
+    return (std::isfinite(restore) && restore > 0.0) ? restore : 1.0;
+}
+
+extern "C" unsigned int lambo_camera_backdrop_projection_scale_bits();

--- a/src/lambo_sky_widescreen.cpp
+++ b/src/lambo_sky_widescreen.cpp
@@ -7,9 +7,70 @@
 
 #include <cstdint>
 
+#include "lambo_camera_projection.h"
 #include "lambo_config.h"
+#include "recomp.h"
+#include "rt64_extended_gbi.h"
+
+#define LAMBO_DL_CURSOR 0x800A39CCu
+
+namespace {
+
+bool s_backdrop_group_open;
+
+void emit_cmd(uint8_t* rdram, uint32_t w0, uint32_t w1) {
+    const gpr cursor_address = (gpr)(int32_t)LAMBO_DL_CURSOR;
+    const gpr cursor = MEM_W(0, cursor_address);
+    MEM_W(0, cursor) = (int32_t)w0;
+    MEM_W(4, cursor) = (int32_t)w1;
+    MEM_W(0, cursor_address) = (int32_t)(cursor + 8);
+}
+
+void emit_group_commands(uint8_t* rdram, const GfxCommand* commands, int count) {
+    for (int i = 0; i < count; ++i) {
+        emit_cmd(rdram, commands[i].values.word0, commands[i].values.word1);
+    }
+}
+
+} // namespace
 
 extern "C" uint32_t lambo_sky_match_1p_guard(uint8_t* rdram, uint32_t at) {
     (void)rdram;
     return lambo::config::widescreen_sky_match() ? 1u : at;
+}
+
+// Bracket the game's own finite panorama with a semantic RT64 transform-group
+// marker. This is deliberately explicit: the old renderer heuristic inferred a
+// backdrop from a zero-translation view matrix, which could not distinguish the
+// sky from every other rotation-only camera and had no knowledge of camera FOV.
+extern "C" void lambo_sky_backdrop_begin(uint8_t* rdram) {
+    if (s_backdrop_group_open) {
+        return;
+    }
+
+    GfxCommand enable{};
+    gEXEnable(&enable);
+    emit_group_commands(rdram, &enable, 1);
+
+    GfxCommand group[2]{};
+    gEXMatrixGroup(group, G_EX_ID_AUTO, G_EX_INTERPOLATE_DECOMPOSE, G_EX_PUSH, 1,
+                   G_EX_COMPONENT_AUTO, G_EX_COMPONENT_AUTO, G_EX_COMPONENT_AUTO,
+                   G_EX_COMPONENT_AUTO, G_EX_COMPONENT_AUTO, G_EX_COMPONENT_SKIP,
+                   G_EX_COMPONENT_AUTO, G_EX_ORDER_AUTO, G_EX_EDIT_NONE,
+                   G_EX_ASPECT_BACKDROP, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_AUTO);
+    gEXSetMatrixGroupProjectionFovScale(
+        group, lambo_camera_backdrop_projection_scale_bits());
+    emit_group_commands(rdram, group, 2);
+    s_backdrop_group_open = true;
+}
+
+extern "C" void lambo_sky_backdrop_end(uint8_t* rdram) {
+    if (!s_backdrop_group_open) {
+        return; // first call's post-jal hook is also a branch merge label
+    }
+
+    GfxCommand pop{};
+    gEXPopMatrixGroup(&pop, 1);
+    emit_group_commands(rdram, &pop, 1);
+    s_backdrop_group_open = false;
 }

--- a/src/rt64_renderer.cpp
+++ b/src/rt64_renderer.cpp
@@ -55,8 +55,8 @@ void dummy_check_interrupts() {}
 // Live swapchain handle for the widescreen HUD rect-aspect helper (issue #67): the
 // game-space 2D HUD geometry shifts key off the effective rect-pin aspect, which depends
 // on the live output size and hr_option -- see lambo_ws_get_hud_rect_aspect_bits() below.
-// (The issue #3 skybox no longer uses this: it is handled entirely in the renderer by
-// stretching parallax-free perspective backdrops -- patches/0008-rt64-skybox-stretch-parallaxless-backdrop.patch.)
+// (The issue #3 skybox no longer uses this: renderer patches 0008 and 0011 identify,
+// restore, and stretch the explicitly tagged finite backdrop independently of camera FOV.)
 //
 // Written on the gfx thread (RT64Context ctor/dtor), read every frame on the CPU/
 // game-logic thread inside lambo_ws_get_hud_rect_aspect_bits() below -- unlike

--- a/tests/test_camera_projection.cpp
+++ b/tests/test_camera_projection.cpp
@@ -1,0 +1,54 @@
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+
+#include "lambo_camera_projection.h"
+
+namespace {
+
+void expect(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+double cot_half_fov(double degrees) {
+    constexpr double pi = 3.14159265358979323846;
+    return 1.0 / std::tan(degrees * pi / 360.0);
+}
+
+bool nearly_equal(double a, double b) {
+    return std::abs(a - b) < 1.0e-5;
+}
+
+} // namespace
+
+int main() {
+    constexpr double authored_fovs[] = {20.0, 32.0, 40.0, 52.0};
+    constexpr double positive_deltas[] = {5.0, 20.0, 60.0};
+
+    for (double authored : authored_fovs) {
+        for (double delta : positive_deltas) {
+            const double adjusted_scale = cot_half_fov(authored + delta);
+            const double restore = lambo_backdrop_fov_restore_scale(authored, authored + delta);
+            expect(nearly_equal(adjusted_scale * restore, cot_half_fov(authored)),
+                   "backdrop projection must recover the authored vertical FOV");
+        }
+    }
+
+    expect(lambo_backdrop_fov_restore_scale(40.0, 40.0) == 1.0,
+           "stock FOV must remain bit-for-bit unscaled");
+    expect(lambo_backdrop_fov_restore_scale(40.0, 30.0) == 1.0,
+           "a narrower camera already overfills the finite backdrop");
+    expect(lambo_backdrop_fov_restore_scale(0.0, 20.0) == 1.0,
+           "invalid projection scales must fail safe");
+
+    expect(lambo_clamp_vertical_fov(0.0) == 1.0,
+           "the lowest configured FOV must not create a singular projection");
+    expect(lambo_clamp_vertical_fov(200.0) == 170.0,
+           "unexpected future config values must remain projection-safe");
+
+    std::cout << "camera projection policy tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Tag the finite sky panorama explicitly so RT64 can distinguish it from ordinary rotation-only views.
- Restore the authored sky FOV and stretch the panorama over the full destination viewport at any aspect ratio.
- Carry the exact correction in the display-list projection metadata, avoiding live-setting timing mismatches.
- Fix scoped RT64 projection-group popping/state leakage and clamp unsafe FOV endpoints.

## Validation

- Clean patch-based Windows build: `./build.ps1`
- Automated tests: 13/13 passing via `ctest.exe --test-dir build -R "^lambo_" --output-on-failure`.
- Runtime stress-tested at +60 degrees FOV and 32:9 in 1-player and 4-player layouts; sky coverage and HUD projection remain correct.
