### PR TITLE
Add true analog brake input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,10 @@ Same approach as [Snowboard Kids 2 Recompiled](https://github.com/cdlewis/snowbo
   explicitly when configuring, or `project()` fails with "C compiler is broken".
 - If a rebuild links stale recompiled code, delete stale archives under `build/` named
   `libRecompiledFuncs.a`.
+- **EOL trap:** `scripts/gen_syms_toml.py` has *mixed* line endings at HEAD and
+  `assets/ui/lambo.rcss` is LF-only — whole-file rewrites that normalise EOLs produce
+  thousands of diff-noise lines. Edit in place; never round-trip these files through a
+  text-mode script that rewrites every line.
 
 ## Game facts (verify from source / live-ares before building on them)
 
@@ -59,6 +63,11 @@ Same approach as [Snowboard Kids 2 Recompiled](https://github.com/cdlewis/snowbo
   un-swizzle; `get_frames_remaining` must report AI-rate (22050) frames, not device-rate (48000),
   or music plays ~2.2× slow. State 6 = music; state 8 = quiet music + SFX.
 - **Input map:** A = confirm, B = cancel; menu input buffer `D_8011C640` (mind byte order).
+- **Pedals:** throttle = s16 at vehicle+0xAA (±10/update toward a per-channel limit); brake demand
+  = float at vehicle+0xA0 (+1/update to 16 while B held, snapped to 0 on release), consumed by
+  the physics pass only while s16[vehicle+0xAC] > 0. The ROM's brake handlers rewrite both fields
+  every frame — analog-brake hooks must write AFTER them (vram 0x8001A9A0 merge), not at the
+  throttle sites. See docs/analog-throttle.md and docs/analog-brake.md.
 - **Rumble:** game uses custom start/stop wrappers (func_8006A7A0 / func_8006A82C) that call libultra's osMotorStart (func_8007AC78) and osMotorStop (func_8007AB10). The scan (func_80069710) runs osPfsInitPak first and skips osMotorInit when the Controller Pak succeeds. Keep the guest Rumble Pak flag (0x80110F08) truthful or the Championship save flow loops through the accessory-swap messages. Native overrides of the request function (func_8006A8B4) and the per-frame PWM engine (func_8006A910, gate-only deviation from the ROM body) plus the game-level wrappers preserve 0x80110F28/0x80110F18 state and drive SDL rumble without touching guest accessory detection; lower osMotorStart/osMotorStop overrides remain defensive.
 
 ## Test discipline

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,16 @@ if(BUILD_TESTING)
     )
     add_test(NAME lambo_analog_throttle_bridge COMMAND lambo_analog_throttle_tests)
 
+    add_executable(lambo_analog_brake_tests
+        tests/test_analog_brake.cpp
+        src/lambo_analog_brake.cpp
+    )
+    target_include_directories(lambo_analog_brake_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${N64MR}/N64Recomp/include
+    )
+    add_test(NAME lambo_analog_brake_bridge COMMAND lambo_analog_brake_tests)
+
     add_executable(lambo_ui_input_tests
         tests/test_ui_input.cpp
         src/ui/lambo_ui_input.cpp
@@ -318,6 +328,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/lambo_startup.cpp  # runtime-ready -> Play startup state machine (issue #126)
         src/lambo_input_gate.cpp # controller capture/neutral-release barrier (issue #126)
         src/lambo_analog_throttle.cpp # issue #128: atomic native-port throttle bridge + race hook
+        src/lambo_analog_brake.cpp    # issue #152: atomic native-port brake bridge + race hook
         src/controls/lambo_controls.cpp
         src/controls/lambo_controls_sdl.cpp
         src/ui/lambo_ui.cpp

--- a/assets/ui/lambo.rcss
+++ b/assets/ui/lambo.rcss
@@ -566,6 +566,12 @@ button:disabled {
   border: 1dp solid #ff922b;
 }
 
+.n64-badge-brake {
+  background-color: #c92a2a;
+  color: #ffffff;
+  border: 1dp solid #ff8787;
+}
+
 .n64-badge-mode {
   background-color: #1c2e4a;
   color: #ffd43b;

--- a/docs/analog-brake.md
+++ b/docs/analog-brake.md
@@ -1,0 +1,91 @@
+# Analog brake
+
+Issue [#152](https://github.com/alondero/automobililamborghini-recomp/issues/152).
+
+Follow-up to the analog throttle work
+([#128](https://github.com/alondero/automobililamborghini-recomp/issues/128),
+`docs/analog-throttle.md`). A controller axis can be mapped to the brake pedal
+in the controls mapper's DRIVING column; the native bridge drives the ROM's own
+brake field continuously while leaving digital play untouched.
+
+## Guest seam (measured, not assumed)
+
+The stock digital path inside `func_80019D20`:
+
+- Brake **demand** is the float at `vehicle + 0xA0`
+  (`0x800B69A8 + vehicle_index * 0x10C + 0xA0`). While B (`0x4000`) is held,
+  the stock code ramps it by **+1 per race update** up to a ceiling of
+  **16.0**, and the not-B release handler snaps it straight back to **0**.
+- The release handler (`func_8002A070`, vram tail `0x800295D8`) runs every
+  B-free frame: it masks the halfword at `vehicle + 0xAC` down to bit 15
+  (clearing the braking latch) and stores `0.0f` into the demand.
+- The **physics pass** (`func_8001EC1C`, consumers at vram `0x8001F618` and
+  `0x80022810`) applies deceleration of `demand * 10` per update — but only
+  while the **signed** halfword at `vehicle + 0xAC` is `> 0`. The pressed
+  branch latches bit 0 of that halfword while B is held.
+- The throttle field (`+0xAA`, see `docs/analog-throttle.md`) is fully
+  independent: holding both pedals works exactly as it does digitally.
+
+Verified live with a gdb write-watchpoint on the guest demand word plus
+per-frame field traces: partial demand holds its value and produces partial
+deceleration; full demand pins the car exactly like held digital B.
+
+## Hook placement matters
+
+The throttle pair brackets the A/Z block (`before_vram 0x80019FBC` /
+`0x8001A120`). The brake block lives **later** in the same updater
+(`0x8001A690`–`0x8001A990`), so a hook at the throttle merge would be undone by
+the release handler before physics ever reads the value. The brake bridge is a
+single apply-only hook at the brake block's own merge:
+
+```toml
+[[patches.hook]]
+func = "func_80019D20"
+before_vram = 0x8001A9A0
+text = "extern void lambo_analog_brake_apply(uint8_t*); lambo_analog_brake_apply(rdram);"
+```
+
+Both the pressed and released paths pass through `0x8001A9A0`, which then flows
+into the physics pass — so the values we write are the values physics consumes.
+
+## Host-side ramp
+
+Because the ROM's handlers rewrite both fields every frame, the continuous
+pedal ramp cannot live in guest memory. `src/lambo_analog_brake.cpp` keeps one
+float per native port (game-thread-only) and writes the absolute demand plus
+latch bit at the merge each frame. Rising demand follows the stock pressed
+ramp (+1 per update); falling demand snaps straight to the target, translating
+the stock release behaviour rather than inventing a decaying pedal. When the
+host publishes digital mode — or physical B is down, which hands control to the
+untouched stock path — the native ramp resets to neutral.
+
+## Native ownership / isolation
+
+Same split as the throttle bridge: SDL sampling and profile evaluation stay on
+the host input thread and publish one normalized snapshot per port through
+atomics; the game-thread hook reads only atomics and RDRAM. Digital mode makes
+the hook a no-op. Controller B and keyboard C remain full-brake fallbacks via
+the pad-word check, and the hook sits behind the race-only call chain, so menu
+B-cancel edges are unaffected.
+
+## Deterministic verification
+
+- `tests/test_analog_brake.cpp` — deterministic RDRAM-backed bridge tests
+  (ramp shape, ceiling, channel→port mapping, latch lifecycle, fallback).
+- `python tools/emu_instrumentation/probe_analog_brake.py` — warped-race probe:
+  asserts demand ramps to the normalized target, late-phase speed orders as
+  `0% > 50% > 100%`, full analog matches held digital B within tolerance, and
+  an A-confirm menu walk still reaches the race transition.
+
+Measured reference table (warped race, A held):
+
+| Brake input | Median demand | Median late-phase speed |
+| ----------- | ------------- | ----------------------- |
+| 0%          | 0.0           | 187                     |
+| 50%         | 8.0           | ~6                      |
+| 100%        | 16.0          | ~2                      |
+| Digital B   | 16.0          | 0                       |
+
+(50%/100% both pin the car near stationary under full throttle because the
+ROM's deceleration term `demand * 10` dwarfs engine acceleration at low speed;
+the ordering assertion is what the probe enforces.)

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -559,6 +559,34 @@ func = "func_800028D0"
 before_vram = 0x80001CD4
 text = "extern void lambo_savestate_tick(uint8_t*, recomp_context*); lambo_savestate_tick(rdram, ctx);"
 
+# Issue #128 — true analog throttle. Capture the pedal demand immediately before the
+# stock human-driver A/Z branch, then apply the selected native port's continuous target
+# at the common merge. The two hooks preserve the ROM's +/-10 pedal ramp, including exact
+# released/full-A behavior. Digital mode is a no-op. The natives read atomics and RDRAM only.
+[[patches.hook]]
+func = "func_80019D20"
+before_vram = 0x80019FBC
+text = "extern void lambo_analog_throttle_begin(uint8_t*); lambo_analog_throttle_begin(rdram);"
+
+[[patches.hook]]
+func = "func_80019D20"
+before_vram = 0x8001A120
+text = "extern void lambo_analog_throttle_apply(uint8_t*); lambo_analog_throttle_apply(rdram);"
+
+# Analog brake. The stock brake block sits LATER in the same updater (0x8001A690-
+# 0x8001A990): its not-B release handler (func_8002A070, vram tail 0x800295D8)
+# zeroes the float demand at vehicle offset 0xA0 and strips bit0 of the 0xAC
+# braking latch every frame, so a capture/apply pair around the throttle sites
+# would be undone before the physics pass (func_8001EC1C, decel = demand*10 while
+# s16[0xAC] > 0) ever reads them. One apply-only hook at the brake block's own
+# merge (0x8001A9A0, reached from both the pressed and released paths) writes the
+# host-ramped demand + latch after the stock handlers are done with them. Digital
+# mode is a no-op; digital B keeps the full-stock path. See docs/analog-brake.md.
+[[patches.hook]]
+func = "func_80019D20"
+before_vram = 0x8001A9A0
+text = "extern void lambo_analog_brake_apply(uint8_t*); lambo_analog_brake_apply(rdram);"
+
 # Issue #40 — widescreen lens flare. The sun flare emitter func_80036854 draws a chain of
 # 10 translucent "ghost" texrects. Under ar_option Expand RT64 squishes each small untagged
 # texrect into the central 4:3 band (invRatioScale = 1/aspectRatioScale) and collapses its
@@ -1028,18 +1056,3 @@ text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gp
 func = "func_800030F8"
 before_vram = 0x80004374
 text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gpr)(int32_t)lambo_camera_fov_bits((uint32_t)ctx->r6); }"
-
-
-# Issue #128 - true analog throttle. Capture the pedal demand immediately before the
-# stock human-driver A/Z branch, then apply the selected native port's continuous target
-# at the common merge. The two hooks preserve the ROM's +/-10 pedal ramp, including exact
-# released/full-A behavior. Digital mode is a no-op. The natives read atomics and RDRAM only.
-[[patches.hook]]
-func = "func_80019D20"
-before_vram = 0x80019FBC
-text = "extern void lambo_analog_throttle_begin(uint8_t*); lambo_analog_throttle_begin(rdram);"
-
-[[patches.hook]]
-func = "func_80019D20"
-before_vram = 0x8001A120
-text = "extern void lambo_analog_throttle_apply(uint8_t*); lambo_analog_throttle_apply(rdram);"

--- a/scripts/gen_syms_toml.py
+++ b/scripts/gen_syms_toml.py
@@ -938,6 +938,20 @@ func = "func_80019D20"
 before_vram = 0x8001A120
 text = "extern void lambo_analog_throttle_apply(uint8_t*); lambo_analog_throttle_apply(rdram);"
 
+# Analog brake. The stock brake block sits LATER in the same updater (0x8001A690-
+# 0x8001A990): its not-B release handler (func_8002A070, vram tail 0x800295D8)
+# zeroes the float demand at vehicle offset 0xA0 and strips bit0 of the 0xAC
+# braking latch every frame, so a capture/apply pair around the throttle sites
+# would be undone before the physics pass (func_8001EC1C, decel = demand*10 while
+# s16[0xAC] > 0) ever reads them. One apply-only hook at the brake block's own
+# merge (0x8001A9A0, reached from both the pressed and released paths) writes the
+# host-ramped demand + latch after the stock handlers are done with them. Digital
+# mode is a no-op; digital B keeps the full-stock path. See docs/analog-brake.md.
+[[patches.hook]]
+func = "func_80019D20"
+before_vram = 0x8001A9A0
+text = "extern void lambo_analog_brake_apply(uint8_t*); lambo_analog_brake_apply(rdram);"
+
 # Issue #40 — widescreen lens flare. The sun flare emitter func_80036854 draws a chain of
 # 10 translucent "ghost" texrects. Under ar_option Expand RT64 squishes each small untagged
 # texrect into the central 4:3 band (invRatioScale = 1/aspectRatioScale) and collapses its
@@ -1289,6 +1303,124 @@ text = "lambo_ws_quad_panel_bg_stretch(rdram);"
 func = "func_800030F8"
 before_vram = 0x80005208
 text = "lambo_ws_quad_panel_bg_reset(rdram);"
+
+# Sense of speed -- opt-in chase-camera + FOV knobs (graphics.json keys
+# "camera_distance_scale" / "camera_height" / "camera_fov_add"; defaults are exactly
+# the ROM's values, so stock presentation is unchanged unless configured). Natives in
+# src/lambo_camera.cpp return IEEE float bits; hooks overwrite the register holding an
+# authored value just before its consuming instruction.
+#
+# The LIVE race camera is func_80032450's L_800324C8 path (verified live: the classic
+# chase math at L_800320xx and the view-matrix builder at 0x800323CC never run in a
+# warped race -- a LAMBO_CAM_TRACE probe there never fires):
+#   eye.x/z = car + viewdir * (per-player s16 distance, e.g. 900)
+#             -- distance consumer mul.s at 0x80032708 -> scale site R
+#   eye.y   = track-anchor table entry + 300.0
+#             -- height adder add.s at 0x80032780 -> height site 1
+# DISTANCE is therefore a SCALE knob: every site that multiplies an authored camera
+# distance into an eye offset rescales it in place (ctx->fX already holds the authored
+# value when the hook runs). Sites:
+#   R   0x80032708 mul.s f8 = dist * dirX     (the live race path)
+#   1-3 0x800320E4/0x80032124/0x800321F8      (func_80032450 chase paths; dormant in
+#                                              races but kept consistent for any mode
+#                                              that wakes them)
+#   4   0x80031E80 c.lt.s follow-dist compare (mode-transition key; scaled to match)
+#   5/6 boot_pad_apply_calibration 0x80007CF4/0x80007D4C (demo/attract camera,
+#                                              absolute eye = car - dir*900)
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x80032708
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f6.u32l = lambo_camera_scale_bits((uint32_t)ctx->f6.u32l); }"
+
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x800320E4
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f6.u32l = lambo_camera_scale_bits((uint32_t)ctx->f6.u32l); }"
+
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x80032124
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f16.u32l = lambo_camera_scale_bits((uint32_t)ctx->f16.u32l); }"
+
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x800321F8
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f18.u32l = lambo_camera_scale_bits((uint32_t)ctx->f18.u32l); }"
+
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x80031E80
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f6.u32l = lambo_camera_scale_bits((uint32_t)ctx->f6.u32l); }"
+
+[[patches.hook]]
+func = "boot_pad_apply_calibration"
+before_vram = 0x80007CF4
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f18.u32l = lambo_camera_scale_bits((uint32_t)ctx->f18.u32l); }"
+
+[[patches.hook]]
+func = "boot_pad_apply_calibration"
+before_vram = 0x80007D4C
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f4.u32l = lambo_camera_scale_bits((uint32_t)ctx->f4.u32l); }"
+
+# Race-camera HEIGHT: replaces the authored +300 constant (mtc1 $at,$f6 at
+# 0x80032774) right before its add.s consumer.
+# Sense of speed -- opt-in chase-camera + FOV knobs (graphics.json keys
+# "camera_distance_scale" / "camera_height_scale" / "camera_fov_add"; defaults are
+# exactly the ROM's behaviour, so stock presentation is unchanged unless configured).
+# Natives in src/lambo_camera.cpp rescale an authored value in place just before its
+# consuming instruction.
+#
+# The LIVE race camera is func_80032450's gate==0 body (verified empirically with
+# first-arrival route tracing; the flag!=0 table path and the legacy chase math never
+# run during gameplay):
+#   eye.x   = carX - dirX * dist   -- dist consumer mul.s at 0x80033E5C
+#   eye.z   = carZ - dirZ * dist   -- dist consumer mul.s at 0x80033ED8
+#             (dist = per-player s16 at 0x800A2D28[i], e.g. 900)
+#   eye.y   = carY + heightParam   -- consumer add.s at 0x80034A08
+#             (heightParam = per-camera-mode table s16, float-converted in $f4)
+# The demo/attract camera (boot_pad_apply_calibration) uses an absolute eye =
+# car - dir*900; its mul.s consumers take the same distance scale so both camera
+# families respond consistently, as do func_80032450's dormant chase paths and its
+# follow-distance compare keyed on the same 900.
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x80033E5C
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f16.u32l = lambo_camera_scale_bits((uint32_t)ctx->f16.u32l); }"
+
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x80033ED8
+text = "{ extern unsigned int lambo_camera_scale_bits(unsigned int); ctx->f16.u32l = lambo_camera_scale_bits((uint32_t)ctx->f16.u32l); }"
+
+[[patches.hook]]
+func = "func_80032450"
+before_vram = 0x80034A08
+text = "{ extern unsigned int lambo_camera_height_bits(unsigned int); ctx->f4.u32l = lambo_camera_height_bits((uint32_t)ctx->f4.u32l); }"
+
+[[patches.hook]]
+func = "func_800030F8"
+before_vram = 0x800041AC
+text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gpr)(int32_t)lambo_camera_fov_bits((uint32_t)ctx->r6); }"
+
+[[patches.hook]]
+func = "func_800030F8"
+before_vram = 0x80004248
+text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gpr)(int32_t)lambo_camera_fov_bits((uint32_t)ctx->r6); }"
+
+[[patches.hook]]
+func = "func_800030F8"
+before_vram = 0x800042A4
+text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gpr)(int32_t)lambo_camera_fov_bits((uint32_t)ctx->r6); }"
+
+[[patches.hook]]
+func = "func_800030F8"
+before_vram = 0x80004300
+text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gpr)(int32_t)lambo_camera_fov_bits((uint32_t)ctx->r6); }"
+
+[[patches.hook]]
+func = "func_800030F8"
+before_vram = 0x80004374
+text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gpr)(int32_t)lambo_camera_fov_bits((uint32_t)ctx->r6); }"
 """
 
 UNSTUB = [

--- a/src/controls/lambo_controls.cpp
+++ b/src/controls/lambo_controls.cpp
@@ -32,15 +32,15 @@ std::deque<Command> command_queue;
 std::mutex snapshot_mutex;
 UiSnapshot published_snapshot;
 
-constexpr std::array<std::string_view, 17> target_names{
+constexpr std::array<std::string_view, 18> target_names{
     "a", "b", "z", "start", "l", "r", "dpad_up", "dpad_down",
     "dpad_left", "dpad_right", "c_up", "c_down", "c_left", "c_right",
-    "stick_x", "stick_y", "throttle",
+    "stick_x", "stick_y", "throttle", "brake",
 };
-constexpr std::array<std::string_view, 17> target_labels{
+constexpr std::array<std::string_view, 18> target_labels{
     "A", "B", "Z", "Start", "L", "R", "D-pad Up", "D-pad Down",
     "D-pad Left", "D-pad Right", "C Up", "C Down", "C Left", "C Right",
-    "N64 Stick X", "N64 Stick Y", "Throttle",
+    "N64 Stick X", "N64 Stick Y", "Throttle", "Brake",
 };
 constexpr std::array<std::string_view, 15> button_names{
     "a", "b", "x", "y", "back", "guide", "start", "left_stick", "right_stick",
@@ -192,6 +192,46 @@ std::optional<ThrottleConfig> parse_throttle(const json& value) {
     return result;
 }
 
+std::optional<BrakeConfig> parse_brake(const json& value) {
+    if (!value.is_object()) return std::nullopt;
+    const auto mode_field = value.find("mode");
+    const auto source_field = value.find("source");
+    const auto deadzone_field = value.find("deadzone");
+    const auto saturation_field = value.find("saturation");
+    if (mode_field == value.end() || !mode_field->is_string() ||
+        source_field == value.end() ||
+        deadzone_field == value.end() || !deadzone_field->is_number() ||
+        saturation_field == value.end() || !saturation_field->is_number()) return std::nullopt;
+
+    BrakeConfig result{};
+    const std::string mode = mode_field->get<std::string>();
+    if (mode == "digital") result.mode = BrakeMode::Digital;
+    else if (mode == "analog") result.mode = BrakeMode::Analog;
+    else return std::nullopt;
+    try {
+        result.deadzone = deadzone_field->get<float>();
+        result.saturation = saturation_field->get<float>();
+    } catch (const json::exception&) {
+        return std::nullopt;
+    }
+    if (!std::isfinite(result.deadzone) || !std::isfinite(result.saturation) ||
+        result.deadzone < 0.0f || result.deadzone > 0.5f ||
+        result.saturation < result.deadzone || result.saturation > 1.0f) return std::nullopt;
+
+    if (source_field->is_null()) return result;
+    if (!source_field->is_object()) return std::nullopt;
+    const auto axis_field = source_field->find("axis");
+    const auto direction_field = source_field->find("direction");
+    if (axis_field == source_field->end() || !axis_field->is_string() ||
+        direction_field == source_field->end() || !direction_field->is_string()) return std::nullopt;
+    const auto axis = axis_from_name(axis_field->get<std::string>());
+    const std::string direction = direction_field->get<std::string>();
+    if (!axis || (direction != "positive" && direction != "negative")) return std::nullopt;
+    result.source = BrakeSource{
+        *axis, direction == "positive" ? AxisDirection::Positive : AxisDirection::Negative};
+    return result;
+}
+
 void merge_profile(json& destination, const Profile& profile) {
     if (!destination.is_object()) destination = json::object();
     json& digital = destination["digital"];
@@ -248,6 +288,21 @@ void merge_profile(json& destination, const Profile& profile) {
     } else {
         throttle["source"] = nullptr;
     }
+    json& brake = destination["brake"];
+    if (!brake.is_object()) brake = json::object();
+    brake["mode"] = profile.brake.mode == BrakeMode::Analog ? "analog" : "digital";
+    brake["deadzone"] = profile.brake.deadzone;
+    brake["saturation"] = profile.brake.saturation;
+    if (profile.brake.source) {
+        json source = brake.contains("source") && brake["source"].is_object()
+            ? brake["source"] : json::object();
+        source["axis"] = axis_name(profile.brake.source->axis);
+        source["direction"] = profile.brake.source->direction == AxisDirection::Positive
+            ? "positive" : "negative";
+        brake["source"] = std::move(source);
+    } else {
+        brake["source"] = nullptr;
+    }
 }
 
 bool atomic_replace(const std::filesystem::path& temporary,
@@ -297,6 +352,7 @@ Profile default_profile() {
     profile.analog[0] = AnalogSource{LogicalAxis::LeftX, false, 8000};
     profile.analog[1] = AnalogSource{LogicalAxis::LeftY, true, 8000};
     profile.throttle = {ThrottleMode::Digital, std::nullopt, 0.05f, 1.0f};
+    profile.brake = {BrakeMode::Digital, std::nullopt, 0.05f, 1.0f};
     return profile;
 }
 
@@ -319,6 +375,23 @@ float evaluate_throttle_source(const ThrottleConfig& throttle, const RawState& s
     return span > 0.0f ? (magnitude - throttle.deadzone) / span : 1.0f;
 }
 
+float brake_source_magnitude(const BrakeConfig& brake, const RawState& state) {
+    if (!brake.source) return 0.0f;
+    const std::int16_t raw = state.axes[static_cast<std::size_t>(brake.source->axis)];
+    return brake.source->direction == AxisDirection::Positive
+        ? std::max(0.0f, static_cast<float>(raw) / 32767.0f)
+        : std::max(0.0f, -static_cast<float>(raw) / 32768.0f);
+}
+
+float evaluate_brake_source(const BrakeConfig& brake, const RawState& state) {
+    const float magnitude = brake_source_magnitude(brake, state);
+    if (magnitude <= 0.0f) return 0.0f;
+    if (magnitude >= brake.saturation) return 1.0f;
+    if (magnitude <= brake.deadzone) return 0.0f;
+    const float span = brake.saturation - brake.deadzone;
+    return span > 0.0f ? (magnitude - brake.deadzone) / span : 1.0f;
+}
+
 EvaluatedState evaluate(const Profile& profile, const RawState& state) {
     EvaluatedState result{};
     for (std::size_t target = 0; target < digital_target_count; ++target) {
@@ -335,6 +408,13 @@ EvaluatedState evaluate(const Profile& profile, const RawState& state) {
         if ((result.buttons & 0xA000u) != 0) result.throttle = 1.0f;
     } else {
         result.throttle = (result.buttons & 0xA000u) != 0 ? 1.0f : 0.0f;
+    }
+    result.brake_mode = profile.brake.mode;
+    if (profile.brake.mode == BrakeMode::Analog) {
+        result.brake = evaluate_brake_source(profile.brake, state);
+        if ((result.buttons & 0x4000u) != 0) result.brake = 1.0f;
+    } else {
+        result.brake = (result.buttons & 0x4000u) != 0 ? 1.0f : 0.0f;
     }
     return result;
 }
@@ -452,6 +532,10 @@ LoadResult load_config(const std::filesystem::path& path) {
             if (const auto parsed = parse_throttle(*throttle)) profile.throttle = *parsed;
             else result.warnings.emplace_back("invalid throttle configuration");
         }
+        if (const auto brake = value.find("brake"); brake != value.end()) {
+            if (const auto parsed = parse_brake(*brake)) profile.brake = *parsed;
+            else result.warnings.emplace_back("invalid brake configuration");
+        }
         for (std::size_t target = 0; target < digital_target_count; ++target) {
             for (const auto& source : profile.digital[target]) {
                 if (has_cross_target_duplicate(profile, static_cast<Target>(target), source)) {
@@ -469,6 +553,12 @@ LoadResult load_config(const std::filesystem::path& path) {
                 return analog && profile.throttle.source->axis == analog->axis;
             })) {
             result.warnings.emplace_back("throttle axis is also used by an N64 stick target");
+        }
+        if (profile.brake.source && std::any_of(profile.analog.begin(), profile.analog.end(),
+            [&](const std::optional<AnalogSource>& analog) {
+                return analog && profile.brake.source->axis == analog->axis;
+            })) {
+            result.warnings.emplace_back("brake axis is also used by an N64 stick target");
         }
         result.config.profiles[*guid] = std::move(profile);
     }
@@ -586,6 +676,9 @@ CaptureResult Capture::axis_event(std::int32_t controller_instance,
     } else if (*target_ == Target::Throttle) {
         candidate_ = ThrottleSource{
             axis, value > 0 ? AxisDirection::Positive : AxisDirection::Negative};
+    } else if (*target_ == Target::Brake) {
+        candidate_ = BrakeSource{
+            axis, value > 0 ? AxisDirection::Positive : AxisDirection::Negative};
     } else {
         candidate_ = AnalogSource{axis, *target_ == Target::StickY, 8000};
     }
@@ -637,11 +730,14 @@ CaptureResult Capture::finish_candidate(Profile& profile) {
             const bool throttle_conflict = profile.throttle.source &&
                 profile.throttle.source->axis == half->axis &&
                 profile.throttle.source->direction == half->direction;
+            const bool brake_conflict = profile.brake.source &&
+                profile.brake.source->axis == half->axis &&
+                profile.brake.source->direction == half->direction;
             const bool analog_conflict = std::any_of(profile.analog.begin(), profile.analog.end(),
                 [&](const std::optional<AnalogSource>& analog) {
                     return analog && analog->axis == half->axis;
                 });
-            if (throttle_conflict || analog_conflict) {
+            if (throttle_conflict || brake_conflict || analog_conflict) {
                 phase_ = CapturePhase::Conflict;
                 return CaptureResult::Conflict;
             }
@@ -656,6 +752,35 @@ CaptureResult Capture::finish_candidate(Profile& profile) {
             [&](const std::optional<AnalogSource>& analog) {
                 return analog && analog->axis == source.axis;
             });
+        conflict = conflict || (profile.brake.source &&
+            profile.brake.source->axis == source.axis &&
+            profile.brake.source->direction == source.direction);
+        for (std::size_t target = 0; target < digital_target_count && !conflict; ++target) {
+            for (const auto& binding : profile.digital[target]) {
+                if (const auto* half = std::get_if<AxisHalfSource>(&binding);
+                    half && half->axis == source.axis && half->direction == source.direction) {
+                    conflict = true;
+                    break;
+                }
+            }
+        }
+        if (conflict) {
+            phase_ = CapturePhase::Conflict;
+            return CaptureResult::Conflict;
+        }
+    } else if (*target_ == Target::Brake) {
+        const auto& source = std::get<BrakeSource>(*candidate_);
+        if (profile.brake.source == source) {
+            reset();
+            return CaptureResult::Noop;
+        }
+        bool conflict = std::any_of(profile.analog.begin(), profile.analog.end(),
+            [&](const std::optional<AnalogSource>& analog) {
+                return analog && analog->axis == source.axis;
+            });
+        conflict = conflict || (profile.throttle.source &&
+            profile.throttle.source->axis == source.axis &&
+            profile.throttle.source->direction == source.direction);
         for (std::size_t target = 0; target < digital_target_count && !conflict; ++target) {
             for (const auto& binding : profile.digital[target]) {
                 if (const auto* half = std::get_if<AxisHalfSource>(&binding);
@@ -685,6 +810,8 @@ CaptureResult Capture::finish_candidate(Profile& profile) {
         }
         const bool throttle_conflict = profile.throttle.source &&
             profile.throttle.source->axis == source.axis;
+        const bool brake_conflict = profile.brake.source &&
+            profile.brake.source->axis == source.axis;
         bool digital_conflict = false;
         for (const auto& bindings : profile.digital) {
             digital_conflict = digital_conflict || std::any_of(bindings.begin(), bindings.end(),
@@ -693,7 +820,7 @@ CaptureResult Capture::finish_candidate(Profile& profile) {
                     return half && half->axis == source.axis;
                 });
         }
-        if (throttle_conflict || digital_conflict) {
+        if (throttle_conflict || brake_conflict || digital_conflict) {
             phase_ = CapturePhase::Conflict;
             return CaptureResult::Conflict;
         }
@@ -707,6 +834,8 @@ CaptureResult Capture::commit(Profile& profile) {
         profile.digital[index].push_back(std::get<DigitalSource>(*candidate_));
     } else if (*target_ == Target::Throttle) {
         profile.throttle.source = std::get<ThrottleSource>(*candidate_);
+    } else if (*target_ == Target::Brake) {
+        profile.brake.source = std::get<BrakeSource>(*candidate_);
     } else {
         profile.analog[index - digital_target_count] = std::get<AnalogSource>(*candidate_);
     }
@@ -734,6 +863,25 @@ CaptureResult Capture::move_conflict(Profile& profile) {
         for (auto& analog : profile.analog) {
             if (analog && analog->axis == source.axis) analog.reset();
         }
+        if (profile.brake.source && profile.brake.source->axis == source.axis &&
+            profile.brake.source->direction == source.direction) {
+            profile.brake.source.reset();
+        }
+    } else if (*target_ == Target::Brake) {
+        const auto& source = std::get<BrakeSource>(*candidate_);
+        for (auto& bindings : profile.digital) {
+            std::erase_if(bindings, [&](const DigitalSource& binding) {
+                const auto* half = std::get_if<AxisHalfSource>(&binding);
+                return half && half->axis == source.axis && half->direction == source.direction;
+            });
+        }
+        for (auto& analog : profile.analog) {
+            if (analog && analog->axis == source.axis) analog.reset();
+        }
+        if (profile.throttle.source && profile.throttle.source->axis == source.axis &&
+            profile.throttle.source->direction == source.direction) {
+            profile.throttle.source.reset();
+        }
     } else if (target_index < digital_target_count) {
         const auto& source = std::get<DigitalSource>(*candidate_);
         for (std::size_t index = 0; index < digital_target_count; ++index) {
@@ -746,6 +894,10 @@ CaptureResult Capture::move_conflict(Profile& profile) {
             if (profile.throttle.source && profile.throttle.source->axis == half->axis &&
                 profile.throttle.source->direction == half->direction) {
                 profile.throttle.source.reset();
+            }
+            if (profile.brake.source && profile.brake.source->axis == half->axis &&
+                profile.brake.source->direction == half->direction) {
+                profile.brake.source.reset();
             }
             for (auto& analog : profile.analog) {
                 if (analog && analog->axis == half->axis) analog.reset();
@@ -767,6 +919,9 @@ CaptureResult Capture::move_conflict(Profile& profile) {
         }
         if (profile.throttle.source && profile.throttle.source->axis == source.axis) {
             profile.throttle.source.reset();
+        }
+        if (profile.brake.source && profile.brake.source->axis == source.axis) {
+            profile.brake.source.reset();
         }
     }
     return commit(profile);

--- a/src/controls/lambo_controls.h
+++ b/src/controls/lambo_controls.h
@@ -21,6 +21,7 @@ enum class Target {
     CUp, CDown, CLeft, CRight,
     StickX, StickY,
     Throttle,
+    Brake,
     Count,
 };
 
@@ -36,6 +37,7 @@ enum class LogicalAxis {
 
 enum class AxisDirection { Negative, Positive };
 enum class ThrottleMode { Digital, Analog };
+enum class BrakeMode { Digital, Analog };
 
 struct ButtonSource {
     LogicalButton button{};
@@ -70,6 +72,20 @@ struct ThrottleConfig {
     bool operator==(const ThrottleConfig&) const = default;
 };
 
+struct BrakeSource {
+    LogicalAxis axis{};
+    AxisDirection direction{AxisDirection::Positive};
+    bool operator==(const BrakeSource&) const = default;
+};
+
+struct BrakeConfig {
+    BrakeMode mode{BrakeMode::Digital};
+    std::optional<BrakeSource> source;
+    float deadzone{0.05f};
+    float saturation{1.0f};
+    bool operator==(const BrakeConfig&) const = default;
+};
+
 using DigitalSource = std::variant<ButtonSource, AxisHalfSource>;
 using DigitalBindings = std::vector<DigitalSource>;
 
@@ -80,6 +96,7 @@ struct Profile {
     std::array<DigitalBindings, digital_target_count> digital;
     std::array<std::optional<AnalogSource>, analog_target_count> analog;
     ThrottleConfig throttle;
+    BrakeConfig brake;
     bool operator==(const Profile&) const = default;
 };
 
@@ -94,6 +111,8 @@ struct EvaluatedState {
     std::int8_t stick_y{};
     ThrottleMode throttle_mode{ThrottleMode::Digital};
     float throttle{};
+    BrakeMode brake_mode{BrakeMode::Digital};
+    float brake{};
     bool operator==(const EvaluatedState&) const = default;
 };
 
@@ -101,6 +120,8 @@ Profile default_profile();
 EvaluatedState evaluate(const Profile& profile, const RawState& state);
 float throttle_source_magnitude(const ThrottleConfig& throttle, const RawState& state);
 float evaluate_throttle_source(const ThrottleConfig& throttle, const RawState& state);
+float brake_source_magnitude(const BrakeConfig& brake, const RawState& state);
+float evaluate_brake_source(const BrakeConfig& brake, const RawState& state);
 std::uint32_t pack(const EvaluatedState& state);
 
 std::string_view target_name(Target target);
@@ -172,7 +193,7 @@ public:
     bool active() const { return phase_ != CapturePhase::Idle; }
     CapturePhase phase() const { return phase_; }
     std::optional<Target> target() const { return target_; }
-    const std::optional<std::variant<DigitalSource, AnalogSource, ThrottleSource>>& candidate() const {
+    const std::optional<std::variant<DigitalSource, AnalogSource, ThrottleSource, BrakeSource>>& candidate() const {
         return candidate_;
     }
 
@@ -186,7 +207,7 @@ private:
     std::optional<Target> target_;
     std::int32_t controller_instance_{};
     int neutral_samples_{};
-    std::optional<std::variant<DigitalSource, AnalogSource, ThrottleSource>> candidate_;
+    std::optional<std::variant<DigitalSource, AnalogSource, ThrottleSource, BrakeSource>> candidate_;
 };
 
 enum class ControllerLayout { Xbox, PlayStation, Nintendo, Generic };
@@ -202,6 +223,7 @@ struct ControllerInfo {
 enum class CommandKind {
     Select, Add, Remove, Threshold, Deadzone, Invert, ResetTarget,
     Saturation, ThrottleMode, ClearThrottleSource,
+    BrakeMode, ClearBrakeSource,
     ResetProfile, ConflictAccept, ConflictMove, CaptureCancel,
 };
 

--- a/src/controls/lambo_controls_sdl.cpp
+++ b/src/controls/lambo_controls_sdl.cpp
@@ -93,6 +93,7 @@ struct SdlAdapter::Impl {
     std::string status;
     bool rumble_on{};
     ThrottleMode disconnected_throttle_mode{ThrottleMode::Digital};
+    BrakeMode disconnected_brake_mode{BrakeMode::Digital};
     Profile fallback_profile{default_profile()};
 
     Device* selected_device() {
@@ -178,6 +179,12 @@ struct SdlAdapter::Impl {
                     return analog && snapshot.profile.throttle.source->axis == analog->axis;
                 });
         }
+        if (snapshot.profile.brake.source) {
+            duplicate = duplicate || std::any_of(snapshot.profile.analog.begin(),
+                snapshot.profile.analog.end(), [&](const std::optional<AnalogSource>& analog) {
+                    return analog && snapshot.profile.brake.source->axis == analog->axis;
+                });
+        }
         if (duplicate) snapshot.warnings.emplace_back(
             "One or more controller sources are intentionally assigned to multiple N64 targets.");
         for (const auto& device : devices) {
@@ -243,6 +250,7 @@ void SdlAdapter::device_removed(std::int32_t instance) {
     const bool was_selected = impl_->selected && *impl_->selected == instance;
     if (was_selected) {
         impl_->disconnected_throttle_mode = impl_->selected_profile().throttle.mode;
+        impl_->disconnected_brake_mode = impl_->selected_profile().brake.mode;
         impl_->stop_rumble();
         impl_->capture.cancel();
         impl_->selected.reset();
@@ -325,6 +333,11 @@ void SdlAdapter::process_commands() {
                     profile.throttle.saturation = std::max(
                         profile.throttle.saturation, profile.throttle.deadzone);
                     changed = true;
+                } else if (command.target == Target::Brake) {
+                    profile.brake.deadzone = std::clamp(command.value / 1000.0f, 0.0f, 0.5f);
+                    profile.brake.saturation = std::max(
+                        profile.brake.saturation, profile.brake.deadzone);
+                    changed = true;
                 } else if (target >= digital_target_count && target < digital_target_count + analog_target_count) {
                     if (!profile.analog[target - digital_target_count]) break;
                     profile.analog[target - digital_target_count]->deadzone =
@@ -336,6 +349,11 @@ void SdlAdapter::process_commands() {
                         profile.throttle.source->direction == AxisDirection::Positive
                             ? AxisDirection::Negative : AxisDirection::Positive;
                     changed = true;
+                } else if (command.target == Target::Brake && profile.brake.source) {
+                    profile.brake.source->direction =
+                        profile.brake.source->direction == AxisDirection::Positive
+                            ? AxisDirection::Negative : AxisDirection::Positive;
+                    changed = true;
                 } else if (target >= digital_target_count && target < digital_target_count + analog_target_count) {
                     auto& source = profile.analog[target - digital_target_count];
                     if (source) { source->invert = !source->invert; changed = true; }
@@ -344,6 +362,10 @@ void SdlAdapter::process_commands() {
                 if (command.target == Target::Throttle) {
                     profile.throttle.saturation = std::clamp(
                         command.value / 1000.0f, profile.throttle.deadzone, 1.0f);
+                    changed = true;
+                } else if (command.target == Target::Brake) {
+                    profile.brake.saturation = std::clamp(
+                        command.value / 1000.0f, profile.brake.deadzone, 1.0f);
                     changed = true;
                 } break;
             case CommandKind::ThrottleMode:
@@ -357,10 +379,22 @@ void SdlAdapter::process_commands() {
                     profile.throttle.source.reset();
                     changed = true;
                 } break;
+            case CommandKind::BrakeMode:
+                if (command.target == Target::Brake) {
+                    profile.brake.mode = command.value != 0
+                        ? BrakeMode::Analog : BrakeMode::Digital;
+                    changed = true;
+                } break;
+            case CommandKind::ClearBrakeSource:
+                if (command.target == Target::Brake && profile.brake.source) {
+                    profile.brake.source.reset();
+                    changed = true;
+                } break;
             case CommandKind::ResetTarget: {
                 const Profile defaults = default_profile();
                 if (target < digital_target_count) profile.digital[target] = defaults.digital[target];
                 else if (command.target == Target::Throttle) profile.throttle = defaults.throttle;
+                else if (command.target == Target::Brake) profile.brake = defaults.brake;
                 else if (target < digital_target_count + analog_target_count)
                     profile.analog[target - digital_target_count] = defaults.analog[target - digital_target_count];
                 changed = true; break;
@@ -401,14 +435,17 @@ EvaluatedState SdlAdapter::sample() {
         else if (impl_->capture.phase() != before) ++impl_->config_revision;
         impl_->evaluated = evaluate(impl_->selected_profile(), impl_->raw);
         impl_->disconnected_throttle_mode = impl_->evaluated.throttle_mode;
+        impl_->disconnected_brake_mode = impl_->evaluated.brake_mode;
     } else {
         impl_->evaluated = {};
         if (device) {
             impl_->disconnected_throttle_mode = impl_->selected_profile().throttle.mode;
+            impl_->disconnected_brake_mode = impl_->selected_profile().brake.mode;
         }
         // Preserve the selected profile's mode while publishing a neutral sample.
         // Analog disconnect must write 0 now, rather than re-enable the ROM's ramp-down.
         impl_->evaluated.throttle_mode = impl_->disconnected_throttle_mode;
+        impl_->evaluated.brake_mode = impl_->disconnected_brake_mode;
     }
     ++impl_->sample_revision;
     if (impl_->capture.phase() != CapturePhase::Idle ||

--- a/src/lambo_analog_brake.cpp
+++ b/src/lambo_analog_brake.cpp
@@ -1,0 +1,160 @@
+#include "lambo_analog_brake.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <cstdio>
+#include <cstdint>
+
+#include "recomp.h"
+
+// Guest seam (measured live, see docs/analog-brake.md):
+// - Brake demand is the float at vehicle offset 0xA0. Stock digital play ramps
+//   it +1/update to 16 while B is held (func_80029DCC) and the release handler
+//   (func_8002A070) snaps it to 0 on the first B-free frame.
+// - The physics pass (func_8001EC1C, vram 0x8001F618/0x80022810) applies
+//   deceleration of demand * 10 only while the SIGNED halfword at offset 0xAC
+//   is > 0 (bit 0 = braking latch, set by the stock pressed branch).
+// The ROM's own handlers rewrite both fields every frame, so instead of
+// fighting them the ramp state lives host-side and is written absolutely at
+// the merge hook, which runs before the physics pass consumes the values.
+
+namespace {
+
+constexpr uint32_t kAnalogEnabled = 0x80000000u;
+constexpr uint32_t kValueMask = 0x0000FFFFu;
+constexpr gpr kCurrentVehicleAddr = (gpr)(int32_t)0x80098398u;
+constexpr gpr kCurrentChannelAddr = (gpr)(int32_t)0x800CE6AAu;
+constexpr gpr kSelectedPadPtrAddr = (gpr)(int32_t)0x800A39DCu;
+constexpr uint32_t kVehicleBase = 0x800B69A8u;
+constexpr uint32_t kVehicleStride = 0x10Cu;
+constexpr uint32_t kSpeedOffset = 0x90u;
+constexpr uint32_t kBrakeOffset = 0xA0u;
+constexpr uint32_t kBrakeLatchOffset = 0xACu;
+constexpr uint16_t kBrakeLatchBit = 0x0001u;
+constexpr float kBrakeMax = 16.0f;
+constexpr float kBrakeStep = 1.0f;
+
+std::array<std::atomic<uint32_t>, lambo::analog_brake::kPortCount> g_ports{};
+std::atomic<bool> g_probe_enabled{false};
+// Game-thread-only pedal state: the continuous demand currently applied per port.
+std::array<float, lambo::analog_brake::kPortCount> g_ramp{};
+std::array<std::atomic<unsigned>, lambo::analog_brake::kPortCount> g_probe_frames{};
+
+uint16_t quantize(float value) {
+    if (!std::isfinite(value) || value <= 0.0f) return 0;
+    if (value >= 1.0f) return UINT16_MAX;
+    return static_cast<uint16_t>(std::lround(value * static_cast<float>(UINT16_MAX)));
+}
+
+float bits_to_float(uint32_t bits) {
+    static_assert(sizeof(float) == sizeof(uint32_t));
+    float out;
+    __builtin_memcpy(&out, &bits, sizeof(out));
+    return out;
+}
+
+uint32_t float_to_bits(float value) {
+    uint32_t out;
+    __builtin_memcpy(&out, &value, sizeof(out));
+    return out;
+}
+
+} // namespace
+
+namespace lambo::analog_brake {
+
+void publish(unsigned port, bool analog_mode, float effective_value) {
+    if (port >= kPortCount) return;
+    const uint32_t packed = analog_mode
+        ? kAnalogEnabled | static_cast<uint32_t>(quantize(effective_value))
+        : 0u;
+    g_ports[port].store(packed, std::memory_order_release);
+}
+
+void set_probe(bool enabled) {
+    for (auto& frame : g_probe_frames) frame.store(0, std::memory_order_relaxed);
+    g_probe_enabled.store(enabled, std::memory_order_release);
+}
+
+bool sample(unsigned port, float& effective_value) {
+    effective_value = 0.0f;
+    if (port >= kPortCount) return false;
+    const uint32_t packed = g_ports[port].load(std::memory_order_acquire);
+    if ((packed & kAnalogEnabled) == 0) return false;
+    effective_value = static_cast<float>(packed & kValueMask) /
+                      static_cast<float>(UINT16_MAX);
+    return true;
+}
+
+float scale_to_guest(uint16_t normalized) {
+    return static_cast<float>(normalized) / static_cast<float>(UINT16_MAX) * kBrakeMax;
+}
+
+} // namespace lambo::analog_brake
+
+extern "C" void lambo_analog_brake_apply(uint8_t* rdram) {
+    const int channel = static_cast<int16_t>(MEM_H(0, kCurrentChannelAddr));
+    if (channel < 1 || channel > static_cast<int>(lambo::analog_brake::kPortCount)) return;
+
+    const unsigned port = static_cast<unsigned>(channel - 1);
+    const uint32_t packed = g_ports[port].load(std::memory_order_acquire);
+    const bool analog_mode = (packed & kAnalogEnabled) != 0;
+    const bool probing = g_probe_enabled.load(std::memory_order_acquire);
+    if (!analog_mode && !probing) return;
+
+    const int vehicle = static_cast<int16_t>(MEM_H(0, kCurrentVehicleAddr));
+    // -1 is the ROM's inactive-vehicle sentinel (same meaning as the throttle hook).
+    if (vehicle < 0) return;
+
+    uint16_t normalized = analog_mode ? static_cast<uint16_t>(packed & kValueMask) : 0;
+    const uint32_t selected_pad = static_cast<uint32_t>(MEM_W(0, kSelectedPadPtrAddr));
+    const uint32_t expected_pad = 0x800A39E0u + port * 6u;
+    bool digital_pressed = false;
+    if (selected_pad == expected_pad) {
+        const uint16_t buttons = static_cast<uint16_t>(MEM_HU(0, (gpr)(int32_t)selected_pad));
+        digital_pressed = (buttons & 0x4000u) != 0;
+        if (digital_pressed) normalized = UINT16_MAX; // stock B fallback keeps the ROM path
+    }
+    if (analog_mode && !digital_pressed) {
+        // Translate the stock one-directional pedal: rising demand follows the
+        // ROM's +1-per-update pressed ramp; falling demand snaps straight to
+        // the target exactly as the stock release handler does (there is no
+        // stock falling ramp to preserve). Write the absolute demand + braking
+        // latch after the ROM's own handlers so the physics pass consumes them
+        // later in this same frame.
+        const float target = lambo::analog_brake::scale_to_guest(normalized);
+        float& ramp = g_ramp[port];
+        if (ramp < target) ramp = std::min(ramp + kBrakeStep, target);
+        else ramp = target;
+        MEM_W(0, (gpr)(int32_t)(kVehicleBase +
+            static_cast<uint32_t>(vehicle) * kVehicleStride + kBrakeOffset)) =
+            float_to_bits(ramp);
+        const gpr latch_addr = (gpr)(int32_t)(kVehicleBase +
+            static_cast<uint32_t>(vehicle) * kVehicleStride + kBrakeLatchOffset);
+        const uint16_t flags = static_cast<uint16_t>(MEM_HU(0, latch_addr));
+        const uint16_t updated = ramp > 0.0f
+            ? static_cast<uint16_t>(flags | kBrakeLatchBit)
+            : static_cast<uint16_t>(flags & ~kBrakeLatchBit);
+        MEM_H(0, latch_addr) = static_cast<int16_t>(updated);
+    } else {
+        // Digital mode or held stock B owns the guest field completely; the
+        // native pedal restarts its ramp from neutral when analog resumes.
+        g_ramp[port] = 0.0f;
+    }
+    if (probing) {
+        const unsigned frame = g_probe_frames[port].fetch_add(1, std::memory_order_relaxed) + 1;
+        const gpr demand_addr = (gpr)(int32_t)(kVehicleBase +
+            static_cast<uint32_t>(vehicle) * kVehicleStride + kBrakeOffset);
+        const float demand = bits_to_float(MEM_W(0, demand_addr));
+        const int32_t speed = static_cast<int32_t>(MEM_W(0,
+            (gpr)(int32_t)(kVehicleBase +
+                static_cast<uint32_t>(vehicle) * kVehicleStride + kSpeedOffset)));
+        std::fprintf(stderr,
+            "[probe] analog brake field: mode=%s port=%u channel=%d vehicle=%d frame=%u "
+            "normalized=%u demand=%.1f speed=%d\n",
+            analog_mode ? "analog" : "digital", port, channel, vehicle, frame,
+            static_cast<unsigned>(normalized), static_cast<double>(demand), speed);
+    }
+}

--- a/src/lambo_analog_brake.h
+++ b/src/lambo_analog_brake.h
@@ -1,0 +1,27 @@
+#ifndef LAMBO_ANALOG_BRAKE_H
+#define LAMBO_ANALOG_BRAKE_H
+
+#include <cstdint>
+
+namespace lambo::analog_brake {
+
+constexpr unsigned kPortCount = 4;
+
+// Called by the host input thread after profile evaluation. In analog mode,
+// effective_value already includes the digital B/keyboard fallback.
+void publish(unsigned port, bool analog_mode, float effective_value);
+void set_probe(bool enabled);
+
+// Exposed for deterministic tests and instrumentation.
+bool sample(unsigned port, float& effective_value);
+float scale_to_guest(uint16_t normalized);
+
+} // namespace lambo::analog_brake
+
+// Race-thread hook, invoked at the stock brake block's merge point
+// (vram 0x8001A9A0 in func_80019D20), after the ROM's own brake handlers have
+// run and before the physics pass consumes the demand. Reads only the atomics
+// above and guest RDRAM.
+extern "C" void lambo_analog_brake_apply(uint8_t* rdram);
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,7 @@
 #include "lambo_menu.h"
 #include "lambo_input_gate.h"
 #include "lambo_analog_throttle.h"
+#include "lambo_analog_brake.h"
 #include "lambo_startup.h"
 #include "controls/lambo_controls_sdl.h"
 #include "ui/lambo_ui.h"
@@ -532,6 +533,7 @@ static constexpr int   N64_STICK_MAX   = 80;
 static uint16_t g_held_buttons = 0;                 // LAMBO_MODERN_INPUT env override, OR'd in
 static int8_t   g_held_sx = 0, g_held_sy = 0;       // LAMBO_MODERN_INPUT stick override (harness)
 static float    g_held_throttle = -1.0f;             // LAMBO_ANALOG_THROTTLE=[0,1] override
+static float    g_held_brake = -1.0f;                // LAMBO_ANALOG_BRAKE=[0,1] override
 // LAMBO_INPUT_PULSE=BTNHEX:PERIOD:DUTY[:STARTVI] -- periodic button pulse for headless menu
 // navigation (a held LAMBO_MODERN_INPUT mask is one EDGE forever, so it can advance at most one
 // menu; a pulse presses/releases every PERIOD VIs for DUTY VIs, walking a whole menu chain).
@@ -628,6 +630,10 @@ static void input_sample() {
     const bool analog_mode = forced_analog ||
         controller.throttle_mode == lambo::controls::ThrottleMode::Analog;
     const float physical_throttle = forced_analog ? g_held_throttle : controller.throttle;
+    const bool forced_brake = g_held_brake >= 0.0f;
+    const bool brake_analog_mode = forced_brake ||
+        controller.brake_mode == lambo::controls::BrakeMode::Analog;
+    const float physical_brake = forced_brake ? g_held_brake : controller.brake;
     uint32_t snap = (uint16_t)b
                   | ((uint32_t)(uint8_t)(int8_t)sx << 16)
                   | ((uint32_t)(uint8_t)(int8_t)sy << 24);
@@ -640,6 +646,9 @@ static void input_sample() {
     const float throttle = lambo::input_gate::guest_input_suppressed()
         ? 0.0f : physical_throttle;
     lambo::analog_throttle::publish(0, analog_mode, throttle);
+    const float brake = lambo::input_gate::guest_input_suppressed()
+        ? 0.0f : physical_brake;
+    lambo::analog_brake::publish(0, brake_analog_mode, brake);
 }
 
 static void input_poll_stub() {}
@@ -820,6 +829,18 @@ int main(int argc, char** argv) {
         }
     }
     lambo::analog_throttle::set_probe(std::getenv("LAMBO_ANALOG_THROTTLE_PROBE") != nullptr);
+    if (const char* analog = std::getenv("LAMBO_ANALOG_BRAKE")) {
+        char* end = nullptr;
+        const float parsed = std::strtof(analog, &end);
+        if (end != analog && end != nullptr && *end == '\0' && std::isfinite(parsed)) {
+            g_held_brake = std::clamp(parsed, 0.0f, 1.0f);
+            // Headless mode has no SDL event pump, so publish the deterministic
+            // harness value here as well as from input_sample's normal main-thread path.
+            lambo::analog_brake::publish(0, true, g_held_brake);
+            LAMBO_LOG("probe", "analog brake override: %.3f\n", g_held_brake);
+        }
+    }
+    lambo::analog_brake::set_probe(std::getenv("LAMBO_ANALOG_BRAKE_PROBE") != nullptr);
     if (const char* pu = std::getenv("LAMBO_INPUT_PULSE")) {
         // BTNHEX:PERIOD:DUTY[:STARTVI[:COUNT]], VI units. e.g. 1000:150:4:300 taps START for 4 VIs
         // every 150 VIs starting at VI 300 -- enough edges to walk the whole menu chain headless.

--- a/src/ui/lambo_ui_controls.cpp
+++ b/src/ui/lambo_ui_controls.cpp
@@ -106,8 +106,9 @@ constexpr std::array<TargetMeta, 2> stick_targets{{
     {Target::StickY, "n64-badge-stick", "Y", "N64 Stick Y"},
 }};
 
-// Target::Throttle is rendered by the dedicated DRIVING column below, not a mapper row.
-static_assert(buttons_targets.size() + cbuttons_targets.size() + dpad_targets.size() + stick_targets.size() + 1 ==
+// Target::Throttle and Target::Brake are rendered by the dedicated DRIVING column
+// below, not mapper rows.
+static_assert(buttons_targets.size() + cbuttons_targets.size() + dpad_targets.size() + stick_targets.size() + 2 ==
               static_cast<std::size_t>(Target::Count));
 
 void render_mapper_row(std::ostringstream& out, const TargetMeta& meta,
@@ -174,14 +175,21 @@ std::optional<Command> control_action_from_name(std::string_view action) {
     else if (fields[0] == "reset-target" && fields.size() == 2) command.kind = CommandKind::ResetTarget;
     else if (fields[0] == "invert" && fields.size() == 2 &&
              (*target == Target::StickX || *target == Target::StickY ||
-              *target == Target::Throttle)) command.kind = CommandKind::Invert;
+              *target == Target::Throttle || *target == Target::Brake)) command.kind = CommandKind::Invert;
     else if (fields[0] == "mode" && fields.size() == 3 && *target == Target::Throttle) {
         const auto value = number<int>(fields[2]);
         if (!value || (*value != 0 && *value != 1)) return std::nullopt;
         command.kind = CommandKind::ThrottleMode; command.value = *value;
+    } else if (fields[0] == "mode" && fields.size() == 3 && *target == Target::Brake) {
+        const auto value = number<int>(fields[2]);
+        if (!value || (*value != 0 && *value != 1)) return std::nullopt;
+        command.kind = CommandKind::BrakeMode; command.value = *value;
     } else if (fields[0] == "clear-source" && fields.size() == 2 &&
                *target == Target::Throttle) {
         command.kind = CommandKind::ClearThrottleSource;
+    } else if (fields[0] == "clear-source" && fields.size() == 2 &&
+               *target == Target::Brake) {
+        command.kind = CommandKind::ClearBrakeSource;
     } else if (fields[0] == "remove" && fields.size() == 3) {
         if (static_cast<std::size_t>(*target) >= digital_target_count) return std::nullopt;
         const auto index = number<std::size_t>(fields[2]); if (!index) return std::nullopt;
@@ -193,13 +201,13 @@ std::optional<Command> control_action_from_name(std::string_view action) {
         command.kind = CommandKind::Threshold; command.binding_index = *index; command.value = *value;
     } else if (fields[0] == "deadzone" && fields.size() == 3 &&
                (*target == Target::StickX || *target == Target::StickY ||
-                *target == Target::Throttle)) {
+                *target == Target::Throttle || *target == Target::Brake)) {
         const auto value = number<int>(fields[2]);
-        const int maximum = *target == Target::Throttle ? 500 : 32767;
+        const int maximum = (*target == Target::Throttle || *target == Target::Brake) ? 500 : 32767;
         if (!value || *value < 0 || *value > maximum) return std::nullopt;
         command.kind = CommandKind::Deadzone; command.value = *value;
     } else if (fields[0] == "saturation" && fields.size() == 3 &&
-               *target == Target::Throttle) {
+               (*target == Target::Throttle || *target == Target::Brake)) {
         const auto value = number<int>(fields[2]);
         if (!value || *value < 0 || *value > 1000) return std::nullopt;
         command.kind = CommandKind::Saturation; command.value = *value;
@@ -273,119 +281,156 @@ ControlsView controls_view(const UiSnapshot& snapshot) {
     }
     bindings << "</div>";
 
-    // Column 5: DRIVING (issue #128 analog throttle)
-    const auto& throttle = snapshot.profile.throttle;
-    const int deadzone = std::clamp(static_cast<int>(std::lround(throttle.deadzone * 1000.0f)), 0, 500);
-    const int saturation = std::clamp(static_cast<int>(std::lround(throttle.saturation * 1000.0f)), deadzone, 1000);
+    // Column 5: DRIVING (issue #128 analog throttle; analog brake follows the same seam)
     bindings << "<div class=\"column mapper-section driving-section\">"
              << "<span class=\"mapper-section-title\">DRIVING</span>";
 
-    // Row 1: Mode (Digital vs Analog)
-    bindings << "<div class=\"mapper-row\">"
-             << "<div class=\"mapper-label-col\">"
-             << "<span class=\"n64-badge n64-badge-mode\">MODE</span>"
-             << "<span class=\"mapper-target-name\">Throttle</span>"
-             << "</div>"
-             << "<div class=\"segmented-control\">"
-             << "<button" << disabled << " class=\"segment-btn"
-             << (throttle.mode == ThrottleMode::Digital ? " active" : "")
-             << "\" onclick=\"control:mode:throttle:0\">Digital</button>"
-             << "<button" << disabled << " class=\"segment-btn"
-             << (throttle.mode == ThrottleMode::Analog ? " active" : "")
-             << "\" onclick=\"control:mode:throttle:1\">Analog</button>"
-             << "</div>"
-             << "</div>";
-
-    // Row 2: Throttle Axis Slot
-    bindings << "<div class=\"mapper-row\">"
-             << "<div class=\"mapper-label-col\">"
-             << "<span class=\"n64-badge n64-badge-throttle\">GAS</span>"
-             << "<span class=\"mapper-target-name\">Pedal Axis</span>"
-             << "</div>"
-             << "<button" << disabled << " class=\"mapper-slot-btn\" onclick=\"control:add:throttle\">";
-    if (throttle.source) {
-        bindings << "<span class=\"mapper-slot-val\">Axis " << axis_name(throttle.source->axis)
-                 << (throttle.source->direction == AxisDirection::Positive ? " +" : " -")
-                 << "</span>";
-    } else {
-        bindings << "<span class=\"mapper-slot-val slot-empty\">None (Click)</span>";
-    }
-    bindings << "</button></div>";
-
-    // Row 3: Direction & Clear (when assigned)
-    if (throttle.source) {
+    const auto render_pedal = [&](const char* axis_label,
+                                  const char* badge_class, const char* badge_text,
+                                  const char* tname, bool analog_mode,
+                                  bool has_source, std::string_view axis, bool positive,
+                                  int deadzone, int saturation) {
+        // Row 1: Mode (Digital vs Analog)
         bindings << "<div class=\"mapper-row\">"
                  << "<div class=\"mapper-label-col\">"
-                 << "<span class=\"mapper-sub-label\">Direction</span>"
+                 << "<span class=\"n64-badge n64-badge-mode\">MODE</span>"
+                 << "<span class=\"mapper-target-name\">" << axis_label << "</span>"
                  << "</div>"
-                 << "<div class=\"driving-inline-actions\">"
-                 << "<button" << disabled << " class=\"mapper-slot-btn\" onclick=\"control:invert:throttle\">"
-                 << "<span class=\"mapper-slot-val\">"
-                 << (throttle.source->direction == AxisDirection::Positive ? "Normal (+)" : "Inverted (-)")
-                 << "</span></button>"
-                 << "<button" << disabled << " class=\"btn-unassign\" onclick=\"control:clear-source:throttle\">Clear</button>"
+                 << "<div class=\"segmented-control\">"
+                 << "<button" << disabled << " class=\"segment-btn"
+                 << (!analog_mode ? " active" : "")
+                 << "\" onclick=\"control:mode:" << tname << ":0\">Digital</button>"
+                 << "<button" << disabled << " class=\"segment-btn"
+                 << (analog_mode ? " active" : "")
+                 << "\" onclick=\"control:mode:" << tname << ":1\">Analog</button>"
                  << "</div>"
                  << "</div>";
-    }
 
-    // Row 4: Deadzone Stepper
-    char dz_str[16];
-    std::snprintf(dz_str, sizeof(dz_str), "%.1f%%", deadzone / 10.0f);
-    bindings << "<div class=\"mapper-row\">"
-             << "<div class=\"mapper-label-col\">"
-             << "<span class=\"mapper-sub-label\">Deadzone</span>"
-             << "</div>"
-             << "<div class=\"stepper-control\">"
-             << "<button" << disabled << " class=\"stepper-btn\" onclick=\"control:deadzone:throttle:"
-             << std::max(0, deadzone - 10) << "\">-</button>"
-             << "<span class=\"stepper-value\">" << dz_str << "</span>"
-             << "<button" << disabled << " class=\"stepper-btn\" onclick=\"control:deadzone:throttle:"
-             << std::min(500, deadzone + 10) << "\">+</button>"
-             << "</div>"
-             << "</div>";
+        // Row 2: Axis Slot
+        bindings << "<div class=\"mapper-row\">"
+                 << "<div class=\"mapper-label-col\">"
+                 << "<span class=\"n64-badge " << badge_class << "\">" << badge_text << "</span>"
+                 << "<span class=\"mapper-target-name\">Pedal Axis</span>"
+                 << "</div>"
+                 << "<button" << disabled << " class=\"mapper-slot-btn\" onclick=\"control:add:"
+                 << tname << "\">";
+        if (has_source) {
+            bindings << "<span class=\"mapper-slot-val\">Axis " << axis
+                     << (positive ? " +" : " -")
+                     << "</span>";
+        } else {
+            bindings << "<span class=\"mapper-slot-val slot-empty\">None (Click)</span>";
+        }
+        bindings << "</button></div>";
 
-    // Row 5: Saturation Stepper
-    char sat_str[16];
-    std::snprintf(sat_str, sizeof(sat_str), "%.1f%%", saturation / 10.0f);
-    bindings << "<div class=\"mapper-row\">"
-             << "<div class=\"mapper-label-col\">"
-             << "<span class=\"mapper-sub-label\">Saturation</span>"
-             << "</div>"
-             << "<div class=\"stepper-control\">"
-             << "<button" << disabled << " class=\"stepper-btn\" onclick=\"control:saturation:throttle:"
-             << std::max(deadzone, saturation - 10) << "\">-</button>"
-             << "<span class=\"stepper-value\">" << sat_str << "</span>"
-             << "<button" << disabled << " class=\"stepper-btn\" onclick=\"control:saturation:throttle:"
-             << std::min(1000, saturation + 10) << "\">+</button>"
-             << "</div>"
-             << "</div>";
+        // Row 3: Direction & Clear (when assigned)
+        if (has_source) {
+            bindings << "<div class=\"mapper-row\">"
+                     << "<div class=\"mapper-label-col\">"
+                     << "<span class=\"mapper-sub-label\">Direction</span>"
+                     << "</div>"
+                     << "<div class=\"driving-inline-actions\">"
+                     << "<button" << disabled << " class=\"mapper-slot-btn\" onclick=\"control:invert:"
+                     << tname << "\">"
+                     << "<span class=\"mapper-slot-val\">"
+                     << (positive ? "Normal (+)" : "Inverted (-)")
+                     << "</span></button>"
+                     << "<button" << disabled << " class=\"btn-unassign\" onclick=\"control:clear-source:"
+                     << tname << "\">Clear</button>"
+                     << "</div>"
+                     << "</div>";
+        }
 
-    const int raw_throttle = std::clamp(static_cast<int>(std::lround(
-        throttle_source_magnitude(snapshot.profile.throttle, snapshot.raw) * 100.0f)), 0, 100);
-    const int effective_throttle = std::clamp(static_cast<int>(std::lround(
-        snapshot.evaluated.throttle * 100.0f)), 0, 100);
+        // Row 4: Deadzone Stepper
+        char value_str[16];
+        std::snprintf(value_str, sizeof(value_str), "%.1f%%", deadzone / 10.0f);
+        bindings << "<div class=\"mapper-row\">"
+                 << "<div class=\"mapper-label-col\">"
+                 << "<span class=\"mapper-sub-label\">Deadzone</span>"
+                 << "</div>"
+                 << "<div class=\"stepper-control\">"
+                 << "<button" << disabled << " class=\"stepper-btn\" onclick=\"control:deadzone:"
+                 << tname << ":" << std::max(0, deadzone - 10) << "\">-</button>"
+                 << "<span class=\"stepper-value\">" << value_str << "</span>"
+                 << "<button" << disabled << " class=\"stepper-btn\" onclick=\"control:deadzone:"
+                 << tname << ":" << std::min(500, deadzone + 10) << "\">+</button>"
+                 << "</div>"
+                 << "</div>";
+
+        // Row 5: Saturation Stepper
+        std::snprintf(value_str, sizeof(value_str), "%.1f%%", saturation / 10.0f);
+        bindings << "<div class=\"mapper-row\">"
+                 << "<div class=\"mapper-label-col\">"
+                 << "<span class=\"mapper-sub-label\">Saturation</span>"
+                 << "</div>"
+                 << "<div class=\"stepper-control\">"
+                 << "<button" << disabled << " class=\"stepper-btn\" onclick=\"control:saturation:"
+                 << tname << ":" << std::max(deadzone, saturation - 10) << "\">-</button>"
+                 << "<span class=\"stepper-value\">" << value_str << "</span>"
+                 << "<button" << disabled << " class=\"stepper-btn\" onclick=\"control:saturation:"
+                 << tname << ":" << std::min(1000, saturation + 10) << "\">+</button>"
+                 << "</div>"
+                 << "</div>";
+
+        // Row 6: Reset
+        bindings << "<button" << disabled
+                 << " class=\"btn-reset-throttle secondary\" onclick=\"control:reset-target:"
+                 << tname << "\">Reset " << axis_label << "</button>";
+    };
+
+    const auto& throttle = snapshot.profile.throttle;
+    render_pedal("Throttle", "n64-badge-throttle", "GAS", "throttle",
+                 throttle.mode == ThrottleMode::Analog,
+                 throttle.source.has_value(),
+                 throttle.source ? axis_name(throttle.source->axis) : "",
+                 !throttle.source || throttle.source->direction == AxisDirection::Positive,
+                 std::clamp(static_cast<int>(std::lround(throttle.deadzone * 1000.0f)), 0, 500),
+                 std::clamp(static_cast<int>(std::lround(throttle.saturation * 1000.0f)), 0, 1000));
+
+    const auto& brake = snapshot.profile.brake;
+    render_pedal("Brake", "n64-badge-brake", "BRK", "brake",
+                 brake.mode == BrakeMode::Analog,
+                 brake.source.has_value(),
+                 brake.source ? axis_name(brake.source->axis) : "",
+                 !brake.source || brake.source->direction == AxisDirection::Positive,
+                 std::clamp(static_cast<int>(std::lround(brake.deadzone * 1000.0f)), 0, 500),
+                 std::clamp(static_cast<int>(std::lround(brake.saturation * 1000.0f)), 0, 1000));
+
+    const auto percent = [](float value) {
+        return std::clamp(static_cast<int>(std::lround(value * 100.0f)), 0, 100);
+    };
+    const int raw_throttle = percent(throttle_source_magnitude(snapshot.profile.throttle, snapshot.raw));
+    const int effective_throttle = percent(snapshot.evaluated.throttle);
+    const int raw_brake = percent(brake_source_magnitude(snapshot.profile.brake, snapshot.raw));
+    const int effective_brake = percent(snapshot.evaluated.brake);
     view.throttle_preview =
         "<div class=\"driving-meter-box\">"
-        "<div class=\"meter-row\"><span class=\"meter-label\">Raw</span>"
+        "<div class=\"meter-row\"><span class=\"meter-label\">Gas</span>"
         "<div class=\"throttle-meter\"><div class=\"throttle-meter-fill raw-fill\" style=\"width: " +
         std::to_string(raw_throttle) + "%;\"></div></div>"
         "<span class=\"meter-value\">" + std::to_string(raw_throttle) + "%</span></div>"
-        "<div class=\"meter-row\"><span class=\"meter-label\">Effective</span>"
+        "<div class=\"meter-row\"><span class=\"meter-label\">Eff</span>"
         "<div class=\"throttle-meter\"><div class=\"throttle-meter-fill effective-fill\" style=\"width: " +
         std::to_string(effective_throttle) + "%;\"></div></div>"
         "<span class=\"meter-value\">" + std::to_string(effective_throttle) + "%</span></div>"
+        "<div class=\"meter-row\"><span class=\"meter-label\">Brk</span>"
+        "<div class=\"throttle-meter\"><div class=\"throttle-meter-fill raw-fill\" style=\"width: " +
+        std::to_string(raw_brake) + "%;\"></div></div>"
+        "<span class=\"meter-value\">" + std::to_string(raw_brake) + "%</span></div>"
+        "<div class=\"meter-row\"><span class=\"meter-label\">Eff</span>"
+        "<div class=\"throttle-meter\"><div class=\"throttle-meter-fill effective-fill\" style=\"width: " +
+        std::to_string(effective_brake) + "%;\"></div></div>"
+        "<span class=\"meter-value\">" + std::to_string(effective_brake) + "%</span></div>"
         "</div>";
 
-    // Row 6: Live Meter Container (updated dynamically on sample)
+    // Row 7: Live Meter Container (updated dynamically on sample)
     bindings << "<div id=\"controls-throttle-preview\" class=\"throttle-preview\">"
              << view.throttle_preview
              << "</div>";
 
-    // Row 7: Reset Throttle
-    bindings << "<button" << disabled << " class=\"btn-reset-throttle secondary\" onclick=\"control:reset-target:throttle\">Reset Throttle</button>";
-
     // Row 8: Fallback Guidance Hint
-    bindings << "<p class=\"driving-hint\">A and keyboard X always provide full throttle fallback.</p>";
+    bindings << "<p class=\"driving-hint\">A/keyboard X always provide full throttle and "
+             "B/keyboard C full brake fallback.</p>";
 
     bindings << "</div>"; // mapper-section
 

--- a/tests/test_analog_brake.cpp
+++ b/tests/test_analog_brake.cpp
@@ -1,0 +1,166 @@
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+#include "lambo_analog_brake.h"
+
+namespace {
+
+constexpr uint32_t kCurrentVehicleAddr = 0x80098398u;
+constexpr uint32_t kCurrentChannelAddr = 0x800CE6AAu;
+constexpr uint32_t kSelectedPadPtrAddr = 0x800A39DCu;
+constexpr uint32_t kPadBase = 0x800A39E0u;
+constexpr uint32_t kVehicleBase = 0x800B69A8u;
+constexpr uint32_t kVehicleStride = 0x10Cu;
+constexpr uint32_t kBrakeOffset = 0xA0u;
+constexpr uint32_t kLatchOffset = 0xACu;
+
+int failures = 0;
+
+void expect(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+int16_t& halfword(std::vector<uint8_t>& rdram, uint32_t address) {
+    return *reinterpret_cast<int16_t*>(&rdram[(address ^ 2u) & 0x7FFFFFu]);
+}
+
+int32_t& word(std::vector<uint8_t>& rdram, uint32_t address) {
+    return *reinterpret_cast<int32_t*>(&rdram[address & 0x7FFFFFu]);
+}
+
+uint32_t latch_address(int vehicle) {
+    return kVehicleBase + static_cast<uint32_t>(vehicle) * kVehicleStride + kLatchOffset;
+}
+
+float read_brake(const std::vector<uint8_t>& rdram, int vehicle) {
+    const uint32_t address =
+        kVehicleBase + static_cast<uint32_t>(vehicle) * kVehicleStride + kBrakeOffset;
+    uint32_t bits = static_cast<uint32_t>(
+        word(const_cast<std::vector<uint8_t>&>(rdram), address));
+    float out;
+    std::memcpy(&out, &bits, sizeof(out));
+    return out;
+}
+
+void write_brake(std::vector<uint8_t>& rdram, int vehicle, float value) {
+    const uint32_t address =
+        kVehicleBase + static_cast<uint32_t>(vehicle) * kVehicleStride + kBrakeOffset;
+    uint32_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    word(rdram, address) = static_cast<int32_t>(bits);
+}
+
+void set_context(std::vector<uint8_t>& rdram, int vehicle, int channel) {
+    halfword(rdram, kCurrentVehicleAddr) = static_cast<int16_t>(vehicle);
+    halfword(rdram, kCurrentChannelAddr) = static_cast<int16_t>(channel);
+    word(rdram, kSelectedPadPtrAddr) = static_cast<int32_t>(kPadBase +
+        static_cast<uint32_t>(channel - 1) * 6u);
+    halfword(rdram, kPadBase + static_cast<uint32_t>(channel - 1) * 6u) = 0;
+}
+
+// Mirrors the stock ROM behaviour around the apply hook: while B is held the
+// demand ramps +1 toward 16 and the latch bit sets; on release the demand snaps
+// to 0 and the latch clears on the next pass.
+void race_step(std::vector<uint8_t>& rdram, int vehicle, bool digital_pressed) {
+    float demand = read_brake(rdram, vehicle);
+    if (digital_pressed) {
+        demand = std::min(demand + 1.0f, 16.0f);
+        halfword(rdram, latch_address(vehicle)) |= 0x0001;
+    } else {
+        demand = 0.0f;
+        halfword(rdram, latch_address(vehicle)) &= static_cast<int16_t>(~0x0001);
+    }
+    write_brake(rdram, vehicle, demand);
+    lambo_analog_brake_apply(rdram.data());
+}
+
+} // namespace
+
+int main() {
+    using namespace lambo::analog_brake;
+
+    expect(scale_to_guest(0) == 0.0f, "zero scales to zero");
+    expect(std::abs(scale_to_guest(UINT16_MAX / 4) - 4.0f) < 0.01f,
+           "quarter input scales to a quarter of 16");
+    expect(std::abs(scale_to_guest(UINT16_MAX / 2) - 8.0f) < 0.01f,
+           "half input scales to half of 16");
+    expect(scale_to_guest(UINT16_MAX) == 16.0f, "full input reaches the stock ceiling");
+
+    std::vector<uint8_t> rdram(8 * 1024 * 1024);
+    set_context(rdram, 1, 1);
+    write_brake(rdram, 1, 5.0f);
+
+    publish(0, false, 1.0f);
+    race_step(rdram, 1, false);
+    expect(read_brake(rdram, 1) == 0.0f,
+           "digital mode leaves the ROM's released snap-to-zero untouched");
+
+    publish(0, true, 0.5f);
+    write_brake(rdram, 1, 0.0f);
+    race_step(rdram, 1, false);
+    expect(read_brake(rdram, 1) == 1.0f,
+           "analog mode preserves the ROM's one-unit rising ramp");
+    for (int frame = 0; frame < 7; ++frame) race_step(rdram, 1, false);
+    expect(std::abs(read_brake(rdram, 1) - 8.0f) < 0.01f,
+           "analog mode settles at the normalized demand without overshooting");
+    expect((halfword(rdram, latch_address(1)) & 0x0001) != 0,
+           "analog braking latches the physics gate like held digital B");
+
+    halfword(rdram, kCurrentVehicleAddr) = -1;
+    write_brake(rdram, 1, 3.0f);
+    lambo_analog_brake_apply(rdram.data());
+    expect(read_brake(rdram, 1) == 3.0f,
+           "inactive ROM vehicle sentinel leaves guest memory untouched");
+    halfword(rdram, kCurrentVehicleAddr) = 1;
+
+    halfword(rdram, kPadBase) = static_cast<int16_t>(0x4000u);
+    for (int frame = 0; frame < 20; ++frame) race_step(rdram, 1, true);
+    expect(read_brake(rdram, 1) == 16.0f,
+           "stock B remains a full-brake fallback in analog mode");
+    halfword(rdram, kPadBase) = 0;
+
+    set_context(rdram, 2, 2);
+    write_brake(rdram, 2, 12.0f);
+    publish(0, true, 0.25f);
+    publish(1, true, 1.0f);
+    for (int frame = 0; frame < 6; ++frame) race_step(rdram, 2, false);
+    // Channel 2 -> port 1 (target full brake). The native pedal starts its own
+    // ramp from neutral regardless of the stale guest value, and port 0's
+    // quarter sample must not be consulted.
+    expect(read_brake(rdram, 2) == 6.0f,
+           "one-based guest channel selects the matching zero-based native port");
+    expect((halfword(rdram, latch_address(2)) & 0x0001) != 0,
+           "the physics gate latches while the analog demand is active");
+
+    // Release: the stock released path snaps to zero, so a falling target snaps
+    // immediately instead of inventing a ramp the ROM does not have.
+    publish(1, true, 0.0f);
+    race_step(rdram, 2, false);
+    expect(read_brake(rdram, 2) == 0.0f &&
+           (halfword(rdram, latch_address(2)) & 0x0001) == 0,
+           "analog release snaps to neutral like the stock release handler");
+    // A partial reduction also lands on target within one update.
+    publish(1, true, 0.5f);
+    write_brake(rdram, 2, 0.0f);
+    for (int frame = 0; frame < 8; ++frame) race_step(rdram, 2, false);
+    publish(1, true, 0.25f);
+    race_step(rdram, 2, false);
+    expect(std::abs(read_brake(rdram, 2) - 4.0f) < 0.01f,
+           "easing off mid-brake snaps to the lower normalized target");
+
+    float sampled = -1.0f;
+    publish(3, true, std::numeric_limits<float>::quiet_NaN());
+    expect(sample(3, sampled) && sampled == 0.0f, "non-finite host samples clamp to neutral");
+    publish(3, false, 1.0f);
+    expect(!sample(3, sampled), "digital snapshots are reported as inactive");
+
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_controls.cpp
+++ b/tests/test_controls.cpp
@@ -83,6 +83,8 @@ int main() {
     Profile analog_throttle = profile;
     analog_throttle.throttle = {ThrottleMode::Analog,
         ThrottleSource{LogicalAxis::TriggerRight, AxisDirection::Positive}, 0.1f, 0.9f};
+    expect(profile.brake.mode == BrakeMode::Digital && !profile.brake.source,
+           "default brake is digital with an unassigned analog source");
     raw = {};
     raw.axes[static_cast<std::size_t>(LogicalAxis::TriggerRight)] = 3277;
     expect(evaluate_throttle_source(analog_throttle.throttle, raw) < 0.001f,
@@ -121,6 +123,50 @@ int main() {
     raw.axes[static_cast<std::size_t>(LogicalAxis::TriggerRight)] = 8192;
     expect(evaluate(analog_throttle, raw).throttle == 1.0f,
            "equal positive deadzone and saturation form a deterministic step");
+
+    Profile analog_brake = profile;
+    analog_brake.brake = {BrakeMode::Analog,
+        BrakeSource{LogicalAxis::TriggerLeft, AxisDirection::Positive}, 0.1f, 0.9f};
+    raw = {};
+    raw.axes[static_cast<std::size_t>(LogicalAxis::TriggerLeft)] = 3277;
+    expect(evaluate_brake_source(analog_brake.brake, raw) < 0.001f,
+           "brake is neutral at the deadzone boundary");
+    raw.axes[static_cast<std::size_t>(LogicalAxis::TriggerLeft)] = 16384;
+    expect(std::abs(brake_source_magnitude(analog_brake.brake, raw) - 0.5f) < 0.001f,
+           "raw brake magnitude is available before shaping");
+    expect(std::abs(evaluate(analog_brake, raw).brake - 0.5f) < 0.001f,
+           "brake rescales linearly between deadzone and saturation");
+    raw.axes[static_cast<std::size_t>(LogicalAxis::TriggerLeft)] = 29491;
+    expect(evaluate(analog_brake, raw).brake == 1.0f,
+           "brake reaches full output at saturation");
+    raw = {};
+    raw.buttons[static_cast<std::size_t>(LogicalButton::B)] = true;
+    expect(evaluate(analog_brake, raw).brake == 1.0f,
+           "digital B is a full fallback in analog brake mode");
+    raw = {};
+    expect(evaluate(profile, raw).brake_mode == BrakeMode::Digital &&
+           evaluate(profile, raw).brake == 0.0f,
+           "digital brake mode mirrors the B button state");
+    raw.buttons[static_cast<std::size_t>(LogicalButton::B)] = true;
+    expect(evaluate(profile, raw).brake == 1.0f, "digital brake mode reports held B");
+    // Split-axis pedals: throttle and brake may share one physical axis if their
+    // directions differ; capturing a brake on the throttle's exact half is a conflict.
+    {
+        Profile split = profile;
+        split.throttle = {ThrottleMode::Analog,
+            ThrottleSource{LogicalAxis::RightY, AxisDirection::Negative}, 0.05f, 1.0f};
+        Capture capture;
+        capture.begin(Target::Brake, 0);
+        RawState neutral{};
+        for (int i = 0; i < 8 && capture.phase() != CapturePhase::Listening; ++i)
+            capture.sample(neutral, split);
+        expect(capture.axis_event(0, LogicalAxis::RightY, -20000) == CaptureResult::None &&
+               capture.phase() == CapturePhase::WaitingForRelease,
+               "brake capture accepts an axis event");
+        for (int i = 0; i < 8; ++i) capture.sample(neutral, split);
+        expect(capture.phase() == CapturePhase::Conflict,
+               "brake cannot take the exact half-axis the throttle already owns");
+    }
 
     raw = {};
     raw.axes[static_cast<std::size_t>(LogicalAxis::LeftX)] = 7999;
@@ -172,6 +218,12 @@ int main() {
            "explicit empty binding remains unbound");
     expect(profile_for_guid(loaded.config, config.preferred_controller_guid).throttle ==
            saved_profile.throttle, "analog throttle settings persist per controller GUID");
+    saved_profile.brake = {BrakeMode::Analog,
+        BrakeSource{LogicalAxis::TriggerLeft, AxisDirection::Positive}, 0.2f, 0.95f};
+    expect(save_config(config, path).saved, "controls config saves atomically (brake)");
+    loaded = load_config(path);
+    expect(profile_for_guid(loaded.config, config.preferred_controller_guid).brake ==
+           saved_profile.brake, "analog brake settings persist per controller GUID");
     std::ifstream saved_file(path);
     nlohmann::json saved; saved_file >> saved;
     expect(saved["unknown_root"]["keep"] == true, "unknown root fields survive rewrite");

--- a/tools/emu_instrumentation/probe_analog_brake.py
+++ b/tools/emu_instrumentation/probe_analog_brake.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Verify live guest brake demand, deceleration, digital parity, and menu isolation.
+
+The probe boots the port headlessly into a warped race with A held (via
+LAMBO_MODERN_INPUT), publishes one fixed analog brake value through the
+production atomic bridge, and parses the game-thread hook's opt-in field trace.
+It asserts the demand ramps to the normalized target and that speed decreases
+monotonically with brake input, that full analog braking matches held digital B,
+and runs an A-confirm menu smoke outside the race hook.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_EXE = REPO / "build" / "lamborghini_modern.exe"
+TRACE = re.compile(
+    r"analog brake field: mode=(analog|digital) port=(\d+) channel=(\d+) "
+    r"vehicle=(\d+) frame=(\d+) normalized=(\d+) demand=(-?[\d.]+) speed=(-?\d+)"
+)
+MENU_TRACE = re.compile(r"\[menu\] vi=(\d+)\s+screen=(-?\d+) sub=(-?\d+)")
+STATE_TRACE = re.compile(r"\[state\] vi=(\d+)\s+state=(-?\d+)")
+SAMPLE_FRAME = 180
+MEDIAN_WINDOW = 300  # race updates after the countdown before sampling speed
+
+
+def median(values: list[float]) -> float:
+    ordered = sorted(values)
+    return ordered[len(ordered) // 2]
+
+
+def run_sample(executable: Path, value: float | None) -> tuple[float, float]:
+    """Run a warped race holding A with an optional analog brake override.
+
+    Returns (median demand, median late-phase speed) across the trace.
+    """
+    environment = os.environ.copy()
+    environment.update({
+        "LAMBO_HEADLESS": "1",
+        "LAMBO_WARP": "1",
+        "LAMBO_ANALOG_BRAKE_PROBE": "1",
+        "LAMBO_MODERN_INPUT": "8000",  # hold A so the car is always under power
+        "LAMBO_MODERN_MAX_VIS": "2400",
+    })
+    if value is None:
+        # Digital mode: no analog override at all; brake comes from pulsing B below.
+        environment.pop("LAMBO_ANALOG_BRAKE", None)
+        environment["LAMBO_MODERN_INPUT"] = "C000"  # hold A + digital B
+    else:
+        environment["LAMBO_ANALOG_BRAKE"] = f"{value:.6f}"
+    completed = subprocess.run(
+        [str(executable), "--lambo-debug"],
+        cwd=REPO,
+        env=environment,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=120,
+        check=False,
+    )
+    matches = list(TRACE.finditer(completed.stdout))
+    if completed.returncode != 0 or not matches:
+        print(completed.stdout, file=sys.stderr)
+        raise RuntimeError(
+            f"probe run failed for value {value}: exit={completed.returncode}, "
+            f"field traces={len(matches)}"
+        )
+    samples = []
+    for match in matches:
+        mode = match.group(1)
+        port, channel, _vehicle, frame = map(int, match.groups()[1:5])
+        demand = float(match.group(7))
+        speed = int(match.group(8))
+        samples.append((mode, port, channel, frame, demand, speed))
+    if not samples:
+        raise RuntimeError("no brake field samples")
+    mode, port, channel = samples[0][0], samples[0][1], samples[0][2]
+    expected_mode = "digital" if value is None else "analog"
+    if mode != expected_mode:
+        raise RuntimeError(f"unexpected bridge mode {mode} (wanted {expected_mode})")
+    if port != 0 or channel != 1:
+        raise RuntimeError(f"unexpected player mapping: port={port}, channel={channel}")
+    demands = [sample[4] for sample in samples]
+    speeds = [sample[5] for sample in samples[MEDIAN_WINDOW:]]
+    if len(speeds) < 50:
+        raise RuntimeError(f"probe did not collect a late-phase window ({len(speeds)} samples)")
+    return median(demands), median(speeds)
+
+
+def run_menu_smoke(executable: Path) -> tuple[tuple[int, int], tuple[int, int]]:
+    environment = os.environ.copy()
+    environment.update({
+        "LAMBO_HEADLESS": "1",
+        "LAMBO_ANALOG_BRAKE": "0.5",
+        "LAMBO_INPUT_PULSE": "8000:120:4:900",
+        "LAMBO_MODERN_MAX_VIS": "2400",
+    })
+    environment.pop("LAMBO_WARP", None)
+    environment.pop("LAMBO_MODERN_INPUT", None)
+    completed = subprocess.run(
+        [str(executable), "--lambo-debug"], cwd=REPO, env=environment,
+        text=True, encoding="utf-8", errors="replace", stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT, timeout=90, check=False,
+    )
+    screens = [(int(match.group(2)), int(match.group(3)))
+               for match in MENU_TRACE.finditer(completed.stdout)]
+    states = [int(match.group(2)) for match in STATE_TRACE.finditer(completed.stdout)]
+    distinct = list(dict.fromkeys(screens))
+    if completed.returncode != 0 or len(distinct) < 2 or 8 not in states:
+        print(completed.stdout, file=sys.stderr)
+        raise RuntimeError(
+            f"menu A-confirm smoke did not reach the race transition: screens={distinct}, states={states}"
+        )
+    return distinct[0], distinct[-1]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exe", type=Path, default=DEFAULT_EXE)
+    args = parser.parse_args()
+    executable = args.exe.resolve()
+    if not executable.is_file():
+        parser.error(f"executable not found: {executable}")
+
+    failures = 0
+    print(" input | median demand | median late speed")
+    print("-------+---------------+------------------")
+    speeds: dict[str, float] = {}
+    for label, value in (("0%", 0.0), ("50%", 0.5), ("100%", 1.0)):
+        demand, speed = run_sample(executable, value)
+        print(f" {label:>5} | {demand:>13.1f} | {speed:>16.0f}")
+        speeds[label] = speed
+    failures += abs(speeds["100%"] - speeds["0%"]) < 20
+    failures += not (speeds["0%"] > speeds["50%"] > speeds["100%"])
+
+    digital_demand, digital_speed = run_sample(executable, None)
+    print(f" dig-B | {digital_demand:>13.1f} | {digital_speed:>16.0f}")
+    tolerance = max(5.0, abs(speeds["100%"]) * 0.25)
+    failures += abs(speeds["100%"] - digital_speed) > tolerance
+
+    first_menu, last_menu = run_menu_smoke(executable)
+    print(f"menu A-confirm smoke: {first_menu} -> {last_menu}")
+    if failures:
+        print(f"FAIL: {failures} brake probe mismatch(es)", file=sys.stderr)
+        return 1
+    print("PASS: brake demand ramp, partial braking order, digital parity, and menu A-confirm")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #152

Follow-up to #128 (true analog throttle). Adds a configurable analog brake axis alongside the existing analog throttle, in the same shape.

## What

- **Guest bridge** (\src/lambo_analog_brake.{h,cpp}\): atomic host->game-thread pedal bridge. One apply-only hook at the stock brake block's merge (vram \