### PR TITLE
Fix FOV-boost peripheral pop-in: widen scene builder's view-cone cull to track camera_fov_add

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,11 @@ Same approach as [Snowboard Kids 2 Recompiled](https://github.com/cdlewis/snowbo
   un-swizzle; `get_frames_remaining` must report AI-rate (22050) frames, not device-rate (48000),
   or music plays ~2.2× slow. State 6 = music; state 8 = quiet music + SFX.
 - **Input map:** A = confirm, B = cancel; menu input buffer `D_8011C640` (mind byte order).
+- **View-cone cull is FOV-coupled:** the scene builder (func_8000A6C0) ANDs both segment
+  cull paths with an authored forward-cone cosine double `0.886` at 0x8008D8C0/C8 — the
+  only readers. It was authored for the N64 frustum, so any FOV change must rewrite it
+  per frame or geometry pops in at the screen edges regardless of draw distance
+  (`lambo_view_cone_cos` + the world-draw hook; docs/no_lod_audit.md §11).
 - **Rumble:** game uses custom start/stop wrappers (func_8006A7A0 / func_8006A82C) that call libultra's osMotorStart (func_8007AC78) and osMotorStop (func_8007AB10). The scan (func_80069710) runs osPfsInitPak first and skips osMotorInit when the Controller Pak succeeds. Keep the guest Rumble Pak flag (0x80110F08) truthful or the Championship save flow loops through the accessory-swap messages. Native overrides of the request function (func_8006A8B4) and the per-frame PWM engine (func_8006A910, gate-only deviation from the ROM body) plus the game-level wrappers preserve 0x80110F28/0x80110F18 state and drive SDL rumble without touching guest accessory detection; lower osMotorStart/osMotorStop overrides remain defensive.
 
 ## Test discipline

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ N64Recomp ports (Zelda 64: Recompiled et al.):
 | `fog_scale_circuit` | array of 6 numbers | `[1,1,1,1,1,1]` | Per-circuit fog multipliers (multiplied with `fog_scale`), e.g. clear a single hazy track by lowering its entry. |
 | `draw_distance` | `0` or `0.1`–`100` | `1.5` | Multiplier on the authored per-circuit draw-distance radii (needs `no_lod`). `1.0` = the N64 distances, higher = see further, `0` = unlimited — note that unlimited draws distant track pieces the artists never meant to be visible (they float with nothing in between). |
 | `draw_distance_circuit` | array of 6 numbers | `[1,1,1,1,1,1]` | Per-circuit draw-distance multipliers (multiplied with `draw_distance`), e.g. extend just one short-sighted city track. |
+| `camera_fov_add` | `-20`–`60` degrees | `0` | Degrees added to each camera layout's authored field of view (sense-of-speed effect). The scene builder's view-cone cull widens to match, so higher values do not cause peripheral pop-in. Also settable live from the Enhancements menu. |
 | `show_launcher` | `true`, `false` | `false` | When `false`, the game auto-boots directly into gameplay with the in-game configuration overlay available during play. When `true`, presents the standalone launcher shell at boot. Overridable via `LAMBO_LAUNCHER=1/0`. |
 
 ## In-Game Configuration & Controls

--- a/docs/no_lod_audit.md
+++ b/docs/no_lod_audit.md
@@ -325,6 +325,31 @@ at ~51k units vs its 35000 radius) needs ≥1.46x, so 1.5 fixes every measured p
 while staying close to authored reach. With the multiplier the per-mode budget
 *ratios* (multiplayer columns 20000–27500) are preserved rather than flattened.
 
+## 11. Addendum (2026-08-24): the forward-cone cull is FOV-coupled (camera_fov_add pop-in)
+
+A user report of peripheral pop-in with `camera_fov_add > 0` — persisting with
+unlimited draw distance and the full-track walk on — surfaced the one cull gate this
+audit had classified as "frame-coherent view culling, not pop-in" and left untouched:
+
+- **Both §8/§9 cull paths are AND-ed with an authored forward-view cone**, stored as
+  a double `0.886` (~27.6° half-angle) at `0x8008D8C0` (coarse entry-level test, read
+  at `0x8000D38C`) and `0x8008D8C8` (per-sub-point fine test, read at `0x8000D588`).
+  A whole-RecompiledFuncs scan confirms these loads are the constants' only readers.
+  The width matches the authored N64 frustum (1P vFOV 40° → ~26° horizontal half-angle
+  at 4:3), so it was invisible until the projection widened.
+- **Why unlimited radii don't help:** with radius = 1e9 every distance test passes and
+  the *cone* becomes the effective gate. Geometry outside ~27.6° off the view axis is
+  culled while already rendered once `camera_fov_add` pushes the frustum past it, and
+  pops in as it crosses the authored boundary — exactly "appears from nowhere at the
+  periphery".
+- **Fix (independent of `no_lod`, shipped with the camera knobs):** each guPerspective
+  call's authored/adjusted FOV pair computes a widened cosine (`lambo_view_cone_cos`,
+  src/lambo_camera_projection.h — tan-space scaling that keeps the cull boundary in
+  lockstep with the screen edge) and the existing world-draw hook rewrites both doubles
+  per frame (same savestate rationale as §8). At `camera_fov_add == 0` the stored bits
+  are bit-identical to the ROM double (C literal `0.886` == ROM bytes,
+  `0x3FEC5A1CAC083127`), pinned by test.
+
 ---
 *Method note: MIPS classification used `tools/scan_lod_patterns.py` output cross-read
 against the recompiled C (per-instruction VRAM comments) rather than raw disassembly;

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -674,7 +674,11 @@ text = "{ extern uint32_t lambo_no_lod_scenery_guard(uint8_t*, uint32_t); ctx->r
 # sits on the world-draw path (0x8000CD3C, after the 0x200 state gate, before the first
 # table read) and rewrites the radii when no_lod() to authored * draw_distance config
 # (0 = unlimited 1e9): per frame, not once at load, because a savestate restore brings
-# the ROM values back. Cone/half-plane tests are untouched, so nothing is synthesised --
+# the ROM values back. The same hook also rewrites the forward-cone cosine doubles at
+# 0x8008D8C0/C8 (authored 0.886, the constants' only readers are this builder's cull
+# tests) so the view cone tracks camera_fov_add -- without that, a widened projection
+# renders past the authored cone and peripheral segments pop in as they cross it.
+# Half-plane tests stay untouched, so nothing is synthesised --
 # the game just stops hiding segments it already streamed. Native in src/lambo_no_lod.cpp.
 [[patches.hook]]
 func = "func_8000A6C0"

--- a/src/lambo_camera.cpp
+++ b/src/lambo_camera.cpp
@@ -67,6 +67,16 @@ unsigned int scaled_bits(unsigned int authored_bits, double scale, const char* t
 double g_dist_last = -1.0;
 double g_height_last = -1.0;
 std::atomic<unsigned int> g_backdrop_projection_scale_bits{0x3F800000u};
+// Bits of the scene-builder forward-view-cone cosine (a full double, NOT a
+// float round-trip: stock must restore the ROM double bit-for-bit), recomputed
+// alongside each guPerspective FOV so the cull cone tracks the rendered frustum
+// (see lambo_view_cone_cos in lambo_camera_projection.h).
+//
+// Last-writer-wins across the five guPerspective call sites, same accepted
+// assumption as g_backdrop_projection_scale_bits: within a frame the camera
+// layout's projection is computed immediately before its scene build, so the
+// bits read by the per-frame RDRAM rewrite belong to that viewport.
+std::atomic<unsigned long long> g_view_cone_cos_bits{0x3FEC5A1CAC083127ull};
 
 } // namespace
 
@@ -92,6 +102,15 @@ extern "C" unsigned int lambo_camera_fov_bits(unsigned int authored_bits) {
         lambo_backdrop_fov_restore_scale(static_cast<double>(authored), out));
     g_backdrop_projection_scale_bits.store(float_bits(backdrop_scale),
                                             std::memory_order_release);
+    // Keep the scene builder's view-cone cosine in step with the rendered FOV
+    // (see lambo_no_lod.cpp for where the bits land in RDRAM). Stored as full
+    // double bits: at stock the identity path returns kAuthoredViewConeCos and
+    // the ROM constant lands back in RDRAM bit-for-bit.
+    const double cone_cos = lambo_view_cone_cos(
+        kAuthoredViewConeCos, static_cast<double>(authored), out);
+    unsigned long long dbits;
+    std::memcpy(&dbits, &cone_cos, sizeof(dbits));
+    g_view_cone_cos_bits.store(dbits, std::memory_order_release);
     if (out != (double)authored) {
         static int remaining = 5;
         if (cam_trace() && remaining > 0) {
@@ -113,6 +132,20 @@ extern "C" unsigned int lambo_camera_backdrop_projection_scale_bits() {
         float scale;
         std::memcpy(&scale, &bits, sizeof(scale));
         LAMBO_LOG("camera", "backdrop projection restore %.4f\n", (double)scale);
+    }
+    return bits;
+}
+
+// Double bits of the widened forward-view-cone cosine for the scene builder's
+// segment cull (consumed by the per-frame RDRAM rewrite in lambo_no_lod.cpp).
+extern "C" unsigned long long lambo_camera_view_cone_cos_bits() {
+    const unsigned long long bits = g_view_cone_cos_bits.load(std::memory_order_acquire);
+    static int remaining = 5;
+    if (cam_trace() && remaining > 0) {
+        --remaining;
+        double v;
+        std::memcpy(&v, &bits, sizeof(v));
+        LAMBO_LOG("camera", "view cone cos %.6f\n", v);
     }
     return bits;
 }

--- a/src/lambo_camera_projection.h
+++ b/src/lambo_camera_projection.h
@@ -3,6 +3,11 @@
 #include <algorithm>
 #include <cmath>
 
+// The scene builder's authored forward view-cone cosine (ROM doubles at
+// 0x8008D8C0/C8). A C double literal 0.886 is bit-identical to the ROM value,
+// so restoring it verbatim keeps stock behaviour byte-stable.
+inline constexpr double kAuthoredViewConeCos = 0.886;
+
 // Keep every camera layout away from guPerspective's singular endpoints. The
 // current UI range only reaches the lower endpoint in 2P (20 + -20), but this
 // also makes future config-range changes safe.
@@ -34,6 +39,45 @@ inline double lambo_backdrop_fov_restore_scale(double authored_degrees,
     const double restore = std::tan(adjusted_radians * 0.5) /
                            std::tan(authored_radians * 0.5);
     return (std::isfinite(restore) && restore > 0.0) ? restore : 1.0;
+}
+
+// The scene builder (func_8000A6C0) culls visibility-list entries against an
+// authored forward view cone stored as a cosine threshold (kAuthoredViewConeCos,
+// ~27.6 degree half-angle). The constant was authored for the N64 frustum:
+// widening the projection without widening the cone leaves geometry outside it
+// culled while already on screen -- periphery pop-in. Map the authored cone
+// half-angle through the same tan-space scaling the horizontal frustum edge
+// undergoes at fixed aspect (tan scales linearly with tan(vfov/2)), keeping the
+// cull boundary in tan-space lockstep with the screen edge. This matches the
+// authored margin exactly along the vertical axis and approximately on the
+// diagonals. Narrowing the FOV symmetrically tightens the cone. Any invalid
+// input passes the authored constant through untouched.
+inline double lambo_view_cone_cos(double authored_cone_cos,
+                                  double authored_fov_degrees,
+                                  double adjusted_fov_degrees) {
+    if (!std::isfinite(authored_cone_cos) || authored_cone_cos < -1.0 ||
+        authored_cone_cos > 1.0 || !std::isfinite(authored_fov_degrees) ||
+        !std::isfinite(adjusted_fov_degrees)) {
+        return authored_cone_cos;
+    }
+
+    constexpr double pi = 3.14159265358979323846;
+    const double authored_half = authored_fov_degrees * pi / 360.0;
+    const double adjusted_half = adjusted_fov_degrees * pi / 360.0;
+    if (!(authored_half > 0.0) || authored_half >= pi / 2.0 ||
+        !(adjusted_half > 0.0) || adjusted_half >= pi / 2.0) {
+        return authored_cone_cos;
+    }
+    if (adjusted_fov_degrees == authored_fov_degrees) {
+        return authored_cone_cos;
+    }
+
+    const double cone_half = std::acos(authored_cone_cos);
+    const double scale = std::tan(adjusted_half) / std::tan(authored_half);
+    const double widened = std::cos(std::atan(std::tan(cone_half) * scale));
+    // A near-180-degree projection must not push the threshold negative past
+    // the game's own front-half-plane fallbacks; clamp to a hair above zero.
+    return std::clamp(widened, 1.0e-4, 1.0);
 }
 
 extern "C" unsigned int lambo_camera_backdrop_projection_scale_bits();

--- a/src/lambo_config.h
+++ b/src/lambo_config.h
@@ -121,7 +121,10 @@ void set_global_fog_scale(double scale);
 //       the ground plane streaks past faster.
 //   camera_fov_add        -- degrees added to each layout's authored perspective
 //       FOV (1P races 40, 2P halves 20, 3P/4P 32, special cameras 52). Applied
-//       uniformly at all five guPerspective call sites in func_800030F8.
+//       uniformly at all five guPerspective call sites in func_800030F8. The
+//       scene builder's forward view-cone cull constant (ROM double 0.886,
+//       0x8008D8C0/C8) is widened to match, so peripheral geometry does not
+//       pop in when the rendered frustum outgrows the authored cone.
 //
 // graphics.json keys "camera_distance_scale" / "camera_height_scale" /
 // "camera_fov_add", overridable by LAMBO_CAMERA_DISTANCE_SCALE /

--- a/src/lambo_no_lod.cpp
+++ b/src/lambo_no_lod.cpp
@@ -18,6 +18,8 @@
 
 #include "lambo_config.h"
 
+extern "C" unsigned long long lambo_camera_view_cone_cos_bits();
+
 extern "C" uint32_t lambo_no_lod_scenery_guard(uint8_t* rdram, uint32_t at) {
     (void)rdram;
     return lambo::config::no_lod() ? 1u : at;
@@ -33,8 +35,9 @@ extern "C" uint32_t lambo_no_lod_scenery_guard(uint8_t* rdram, uint32_t at) {
 // values back. The radii are scaled by the draw_distance config (0 = unlimited) from
 // a compiled-in copy of the authored table: the live table can't be trusted as the
 // baseline because this hook rewrites it every frame and a savestate captured while
-// it ran would restore the rewritten values. The forward-cone/half-plane tests and
-// the per-frame visibility walk still decide what is drawn.
+// it ran would restore the rewritten values. The half-plane tests and the
+// per-frame visibility walk still decide what is drawn; the forward-cone constant
+// is rewritten in this hook so it tracks camera_fov_add (see the cone block below).
 extern "C" void lambo_no_lod_draw_distance(uint8_t* rdram) {
     // ROM copy of the float[6][5] at 0x80088FD0 ([circuit][player-count column]),
     // extracted from the .z64 at 0x89BD0 (= vram - 0x80000000 + 0xC00).
@@ -65,6 +68,32 @@ extern "C" void lambo_no_lod_draw_distance(uint8_t* rdram) {
             std::memcpy(&bits, &r, sizeof(bits));
             MEM_W((c * 5 + p) * 4, (gpr)(int32_t)kTableAddr) = bits;
         }
+    }
+
+    // Forward-view-cone rewrite (the FOV-boost pop-in axis): both cull paths above
+    // are AND-ed with a forward-cone cosine stored as a ROM double at 0x8008D8C0
+    // (coarse, read at 0x8000D38C) and 0x8008D8C8 (fine sub-point test, read at
+    // 0x8000D588) -- authored 0.886, a ~27.6-degree half-angle matched to the N64
+    // frustum. These two loads are the constants' only readers in the ROM. With
+    // camera_fov_add the rendered frustum widens past the cone, so peripheral
+    // segments stay culled until they cross the authored boundary -- visible
+    // pop-in at the screen edges regardless of draw distance. The bits are
+    // computed from each guPerspective call's authored/adjusted FOV pair
+    // (lambo_camera.cpp) and rewritten here per frame, same savestate rationale
+    // as the radii: a restore brings the ROM doubles back.
+    //
+    // Deliberately NOT gated on no_lod(): the cone is an FOV-frustum coupling,
+    // not an LOD reduction -- it must track camera_fov_add even for users who
+    // keep the ROM's authored radii and PVS rows. At camera_fov_add == 0 the
+    // stored bits are the exact ROM double, so this is a byte-stable no-op then.
+    {
+        const unsigned long long dbits = lambo_camera_view_cone_cos_bits();
+        const int32_t hi = (int32_t)(uint32_t)(dbits >> 32);
+        const int32_t lo = (int32_t)(uint32_t)dbits;
+        MEM_W(0, (gpr)(int32_t)0x8008D8C0u) = hi;
+        MEM_W(4, (gpr)(int32_t)0x8008D8C0u) = lo;
+        MEM_W(0, (gpr)(int32_t)0x8008D8C8u) = hi;
+        MEM_W(4, (gpr)(int32_t)0x8008D8C8u) = lo;
     }
 }
 

--- a/tests/test_camera_projection.cpp
+++ b/tests/test_camera_projection.cpp
@@ -1,4 +1,6 @@
 #include <cmath>
+#include <cstdint>
+#include <cstring>
 #include <cstdlib>
 #include <iostream>
 
@@ -48,6 +50,53 @@ int main() {
            "the lowest configured FOV must not create a singular projection");
     expect(lambo_clamp_vertical_fov(200.0) == 170.0,
            "unexpected future config values must remain projection-safe");
+
+    constexpr double authored_cone_cos = kAuthoredViewConeCos;
+    expect(lambo_view_cone_cos(authored_cone_cos, 40.0, 40.0) == authored_cone_cos,
+           "stock FOV must keep the authored view-cone constant bit-for-bit");
+    // Pipeline invariant: the identity result's double bits must equal the ROM
+    // constant at 0x8008D8C0 exactly (0x3FEC5A1CAC083127), so the per-frame
+    // RDRAM rewrite is a byte-stable no-op at stock FOV.
+    {
+        const double identity = lambo_view_cone_cos(authored_cone_cos, 40.0, 40.0);
+        std::uint64_t bits = 0;
+        std::memcpy(&bits, &identity, sizeof(bits));
+        expect(bits == 0x3FEC5A1CAC083127ull,
+               "stock view-cone cosine must carry the exact ROM double bits");
+    }
+    expect(lambo_view_cone_cos(authored_cone_cos, 40.0, 0.0) == authored_cone_cos,
+           "invalid adjusted FOV must leave the authored view cone untouched");
+    expect(lambo_view_cone_cos(authored_cone_cos, 0.0, 50.0) == authored_cone_cos,
+           "invalid authored FOV must leave the authored view cone untouched");
+    expect(lambo_view_cone_cos(1.5, 40.0, 60.0) == 1.5,
+           "out-of-domain cone constants must pass through untouched");
+
+    for (double authored : authored_fovs) {
+        double previous = authored_cone_cos;
+        for (double delta : positive_deltas) {
+            const double widened =
+                lambo_view_cone_cos(authored_cone_cos, authored, authored + delta);
+            expect(widened < previous && widened > 0.0,
+                   "a wider projection must widen the view cone monotonically toward 90 degrees");
+            previous = widened;
+
+            // The cone half-angle must track the horizontal frustum edge, whose
+            // tangent scales by tan(adjusted_v/2)/tan(authored_v/2) at fixed aspect.
+            constexpr double pi = 3.14159265358979323846;
+            const double cone_half = std::acos(authored_cone_cos);
+            const double expected_half =
+                std::atan(std::tan(cone_half) *
+                          std::tan((authored + delta) * pi / 360.0) /
+                          std::tan(authored * pi / 360.0));
+            expect(nearly_equal(widened, std::cos(expected_half)),
+                   "the widened cone must preserve the authored margin in tan space");
+
+            const double narrowed =
+                lambo_view_cone_cos(authored_cone_cos, authored + delta, authored);
+            expect(narrowed > authored_cone_cos,
+                   "a narrower projection must tighten the view cone");
+        }
+    }
 
     std::cout << "camera projection policy tests passed\n";
     return 0;


### PR DESCRIPTION
Closes #156

## Problem
With the FOV boost (\camera_fov_add\ > 0), scenery and world objects pop in at the screen periphery even with \
o_lod\ on, Full Track Visibility on, and Draw Distance: Unlimited.

## Root cause
The scene builder (func_8000A6C0) ANDs **both** segment cull paths (coarse test at 0x8000D370, fine 16-sub-point test at 0x8000D568) with an authored forward-view-cone cosine: ROM double \