### PR TITLE
Fix Windows startup memory allocation failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,18 @@ if(BUILD_TESTING)
     )
     add_test(NAME lambo_startup_state_machine COMMAND lambo_startup_tests)
 
+    if(WIN32)
+        add_executable(lambo_rdram_allocation_tests
+            tests/test_rdram_allocation.cpp
+            ${N64MR}/librecomp/src/rdram_memory.cpp
+        )
+        target_include_directories(lambo_rdram_allocation_tests PRIVATE
+            ${N64MR}/librecomp/include
+        )
+        target_compile_definitions(lambo_rdram_allocation_tests PRIVATE NOMINMAX)
+        add_test(NAME lambo_windows_rdram_reservation COMMAND lambo_rdram_allocation_tests)
+    endif()
+
     add_executable(lambo_input_gate_tests
         tests/test_input_gate.cpp
         src/lambo_input_gate.cpp

--- a/build.ps1
+++ b/build.ps1
@@ -15,7 +15,7 @@
       3. ROM check (skippable via -RomPath; CI forwards its $env:ROM_FILENAME).
       4. Defensive submodule reset before patching (a half-applied patch from a
          prior run would otherwise break the next apply).
-      5. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0008, 0009, 0010, 0011, 0005, 0004) with
+      5. Apply Lamborghini patches (Windows: 0001, 0007, 0012, 0006, 0008, 0009, 0010, 0011, 0005, 0004) with
          --ignore-whitespace (CRLF mismatches on Windows git). 0007 adds the
          save-state thread-context registry; without it, src/lambo_savestate.c
          fails to link with "undefined reference to ultramodern_relink_thread_contexts".
@@ -27,7 +27,8 @@
       9. SECOND CMake configure — picks up the newly generated sources via
          CONFIGURE_DEPENDS / EXISTS checks. Without this, src/aspMain.cpp is
          silently excluded.
-     10. Build lamborghini_modern.exe.
+     10. Build lamborghini_modern.exe and run the Windows RDRAM allocation
+         regression test.
 
     The output binary lands at build\lamborghini_modern.exe (run from the repo
     root so the ROM path resolves).
@@ -174,16 +175,24 @@ try {
     # apply would otherwise leave patches failing with "patch failed: ... file:N".
     Write-Host "[2/5] Resetting submodules to clean state before patching..." -ForegroundColor Cyan
     git -C lib/N64ModernRuntime checkout -- . | Out-Null
+    # checkout does not remove untracked files added by patch 0012. Remove its
+    # two known targets so an incremental build returns to a genuinely clean
+    # pre-patch state instead of looking like a partial application.
+    Remove-Item -Force -ErrorAction SilentlyContinue `
+        'lib/N64ModernRuntime/librecomp/include/librecomp/rdram_memory.hpp', `
+        'lib/N64ModernRuntime/librecomp/src/rdram_memory.cpp'
     git -C lib/rt64 checkout -- . | Out-Null
     git -C lib/rt64/src/contrib/plume checkout -- . | Out-Null
 
-    # --- 6. Apply Lamborghini patches (Windows: 0001, 0007, 0006, 0008, 0009, 0010, 0011, 0005, 0004) -
+    # --- 6. Apply Lamborghini patches (Windows: 0001, 0007, 0012, 0006, 0008, 0009, 0010, 0011, 0005, 0004) -
     # Mirrors CI's Windows job exactly (workflow lines 210-214). 0001 then 0007
     # both patch N64ModernRuntime with disjoint hunks (verified to apply
     # sequentially on the pinned commit). 0007 adds the save-state thread-
     # context registry + `ultramodern_relink_thread_contexts` (issue #22, all
     # platforms). Without it, src/lambo_savestate.c fails to link with
     # "undefined reference to `ultramodern_relink_thread_contexts`".
+    # 0012 reserves the 4 GiB guest address range while committing only the
+    # accessible 512 MiB, avoiding false out-of-memory failures on Windows.
     # Patch paths MUST be absolute — `git -C $sub apply $relpath` runs from
     # inside the submodule, where the relative path doesn't resolve. CI uses
     # "$(pwd)/patches/..." for the same reason.
@@ -191,6 +200,7 @@ try {
     $patches = @(
         @{ Sub = 'lib/N64ModernRuntime';       Patch = 'patches/0001-lamborghini-runtime-scheduler-audio-vi.patch' },
         @{ Sub = 'lib/N64ModernRuntime';       Patch = 'patches/0007-ultramodern-savestate-thread-context-relink.patch' },
+        @{ Sub = 'lib/N64ModernRuntime';       Patch = 'patches/0012-n64modernruntime-lazy-rdram-commit.patch' },
         @{ Sub = 'lib/rt64';                   Patch = 'patches/0006-rt64-interp-angular-velocity-matching.patch' },
         @{ Sub = 'lib/rt64';                   Patch = 'patches/0008-rt64-skybox-stretch-parallaxless-backdrop.patch' },
         @{ Sub = 'lib/rt64';                   Patch = 'patches/0005-rt64-mingw-gcc-compat.patch' },
@@ -284,7 +294,17 @@ try {
     & $cmake --build build --target lamborghini_modern -j
     if ($LASTEXITCODE -ne 0) { throw 'lamborghini_modern build failed.' }
 
-    # --- 13. Done -------------------------------------------------------------
+    # --- 13. Run the startup-allocation regression ---------------------------
+    # This reproduces the old eager 4 GiB commit under a 1 GiB process limit,
+    # then proves the production allocator can reserve 4 GiB while committing
+    # only its accessible 512 MiB prefix.
+    Write-Host "[5/5] Testing Windows RDRAM allocation..." -ForegroundColor Cyan
+    & $cmake --build build --target lambo_rdram_allocation_tests -j
+    if ($LASTEXITCODE -ne 0) { throw 'RDRAM allocation test build failed.' }
+    & ctest.exe --test-dir build -R '^lambo_windows_rdram_reservation$' --output-on-failure
+    if ($LASTEXITCODE -ne 0) { throw 'RDRAM allocation regression test failed.' }
+
+    # --- 14. Done -------------------------------------------------------------
     $exe = Join-Path $RepoRoot 'build\lamborghini_modern.exe'
     if (Test-Path $exe) {
         $stamp = (Get-Item $exe).LastWriteTime

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@
 #   3. Submodule init (recursive; core.longpaths isn't needed on Linux).
 #   4. Defensive submodule reset before patching (half-applied patches from a
 #      prior run would otherwise break the next apply with "patch failed: ...").
-#   5. Apply Lamborghini patches (Linux: 0001, 0007, 0006, 0008, 0009, 0010, 0011 — no MinGW/D3D12
+#   5. Apply Lamborghini patches (Linux: 0001, 0007, 0012, 0006, 0008, 0009, 0010, 0011 — no MinGW/D3D12
 #      fixes needed; no plume patch). 0007 adds the save-state thread-context
 #      registry; without it, src/lambo_savestate.c fails to link with
 #      "undefined reference to ultramodern_relink_thread_contexts".
@@ -93,22 +93,27 @@ git submodule update --init --recursive
 # --- 5. Defensive submodule reset (mirrors CI) ------------------------------
 log "[2/5] Resetting submodules to clean state before patching..."
 git -C lib/N64ModernRuntime checkout -- .
+# checkout does not remove untracked files added by patch 0012. Remove its two
+# known targets so incremental builds return to a clean pre-patch state.
+rm -f \
+    lib/N64ModernRuntime/librecomp/include/librecomp/rdram_memory.hpp \
+    lib/N64ModernRuntime/librecomp/src/rdram_memory.cpp
 git -C lib/rt64 checkout -- .
 git -C lib/rt64/src/contrib/plume checkout -- . 2>/dev/null || true
 
-# --- 6. Apply Lamborghini patches (Linux: 0001, 0007, 0006, 0008, 0009, 0010, 0011, 0012) ----------------
+# --- 6. Apply Lamborghini patches (Linux: 0001, 0007, 0012, 0006, 0008, 0009, 0010, 0011) ----------------
 # Mirrors CI's Linux job exactly (workflow lines 93-95). 0001 then 0007 both
 # patch N64ModernRuntime with disjoint hunks (verified to apply sequentially
 # on the pinned commit). 0007 adds the save-state thread-context registry +
 # `ultramodern_relink_thread_contexts` (issue #22, all platforms). Without it,
 # src/lambo_savestate.c fails to link with "undefined reference to
-# `ultramodern_relink_thread_contexts`". 0012 adds <cstdint>/<cstddef> to
-# RmlUi's robin_hood.h — gcc 16 on windows-latest no longer pulls them in
-# transitively, so the bitness check fails with "Unsupported bitness".
+# `ultramodern_relink_thread_contexts`". 0012 reserves the 4 GiB guest address
+# range while committing only the accessible 512 MiB.
 log "[2/5] Applying Lamborghini submodule patches..."
 PATCHES=(
     "lib/N64ModernRuntime:0001-lamborghini-runtime-scheduler-audio-vi.patch"
     "lib/N64ModernRuntime:0007-ultramodern-savestate-thread-context-relink.patch"
+    "lib/N64ModernRuntime:0012-n64modernruntime-lazy-rdram-commit.patch"
     "lib/rt64:0006-rt64-interp-angular-velocity-matching.patch"
     "lib/rt64:0008-rt64-skybox-stretch-parallaxless-backdrop.patch"
     "lib/rt64:0009-rt64-widescreen-split-subviewport.patch"

--- a/patches/0012-n64modernruntime-lazy-rdram-commit.patch
+++ b/patches/0012-n64modernruntime-lazy-rdram-commit.patch
@@ -1,0 +1,142 @@
+diff --git a/librecomp/CMakeLists.txt b/librecomp/CMakeLists.txt
+index fcc3337..89a0a6c 100644
+--- a/librecomp/CMakeLists.txt
++++ b/librecomp/CMakeLists.txt
+@@ -28,6 +28,7 @@ add_library(librecomp STATIC
+     "${CMAKE_CURRENT_SOURCE_DIR}/src/pi.cpp"
+     "${CMAKE_CURRENT_SOURCE_DIR}/src/print.cpp"
+     "${CMAKE_CURRENT_SOURCE_DIR}/src/recomp.cpp"
++    "${CMAKE_CURRENT_SOURCE_DIR}/src/rdram_memory.cpp"
+     "${CMAKE_CURRENT_SOURCE_DIR}/src/rsp.cpp"
+     "${CMAKE_CURRENT_SOURCE_DIR}/src/sp.cpp"
+     "${CMAKE_CURRENT_SOURCE_DIR}/src/ultra_stubs.cpp"
+diff --git a/librecomp/include/librecomp/rdram_memory.hpp b/librecomp/include/librecomp/rdram_memory.hpp
+new file mode 100644
+index 0000000..c8d05dd
+--- /dev/null
++++ b/librecomp/include/librecomp/rdram_memory.hpp
+@@ -0,0 +1,13 @@
++#ifndef RECOMP_RDRAM_MEMORY_HPP
++#define RECOMP_RDRAM_MEMORY_HPP
++
++#include <cstddef>
++#include <cstdint>
++
++namespace recomp {
++    std::uint8_t* allocate_rdram_memory(std::size_t allocation_size,
++                                        std::size_t accessible_size);
++    bool release_rdram_memory(std::uint8_t* rdram, std::size_t allocation_size);
++}
++
++#endif
+diff --git a/librecomp/src/rdram_memory.cpp b/librecomp/src/rdram_memory.cpp
+new file mode 100644
+index 0000000..5d6adfa
+--- /dev/null
++++ b/librecomp/src/rdram_memory.cpp
+@@ -0,0 +1,44 @@
++#include "librecomp/rdram_memory.hpp"
++
++#ifdef _WIN32
++#include <windows.h>
++#else
++#include <sys/mman.h>
++#endif
++
++std::uint8_t* recomp::allocate_rdram_memory(std::size_t allocation_size,
++                                            std::size_t accessible_size) {
++#ifdef _WIN32
++    auto* rdram = reinterpret_cast<std::uint8_t*>(
++        VirtualAlloc(nullptr, allocation_size, MEM_RESERVE, PAGE_NOACCESS));
++    if (rdram == nullptr) return nullptr;
++
++    // Reserving the full guest address space keeps invalid addresses guarded,
++    // but only the prefix that librecomp can access needs backing-store commit.
++    // Committing the whole 4 GiB reservation can exceed the system/pagefile
++    // commit limit even when plenty of physical RAM is available.
++    if (VirtualAlloc(rdram, accessible_size, MEM_COMMIT, PAGE_READWRITE) == nullptr) {
++        VirtualFree(rdram, 0, MEM_RELEASE);
++        return nullptr;
++    }
++    return rdram;
++#else
++    auto* rdram = reinterpret_cast<std::uint8_t*>(
++        mmap(nullptr, allocation_size, PROT_NONE, MAP_ANON | MAP_PRIVATE, -1, 0));
++    if (rdram == reinterpret_cast<std::uint8_t*>(MAP_FAILED)) return nullptr;
++    if (mprotect(rdram, accessible_size, PROT_READ | PROT_WRITE) == -1) {
++        munmap(rdram, allocation_size);
++        return nullptr;
++    }
++    return rdram;
++#endif
++}
++
++bool recomp::release_rdram_memory(std::uint8_t* rdram, std::size_t allocation_size) {
++#ifdef _WIN32
++    (void)allocation_size;
++    return VirtualFree(rdram, 0, MEM_RELEASE) != 0;
++#else
++    return munmap(rdram, allocation_size) != -1;
++#endif
++}
+diff --git a/librecomp/src/recomp.cpp b/librecomp/src/recomp.cpp
+index ea17675..d271bca 100644
+--- a/librecomp/src/recomp.cpp
++++ b/librecomp/src/recomp.cpp
+@@ -18,3 +18,4 @@
+ #include "recomp.h"
++#include "librecomp/rdram_memory.hpp"
+ #include "librecomp/overlays.hpp"
+ #include "librecomp/game.hpp"
+@@ -768,31 +769,7 @@ void recomp::start(const recomp::Configuration& cfg) {
+-    // Allocate rdram without comitting it. Use a platform-specific virtual allocation function
+-    // that initializes to zero. Protect the region above the memory size to catch accesses to invalid addresses.
+-    uint8_t* rdram;
+-    bool alloc_failed;
+-#ifdef _WIN32
+-    rdram = reinterpret_cast<uint8_t*>(VirtualAlloc(nullptr, allocation_size, MEM_COMMIT | MEM_RESERVE, PAGE_NOACCESS));
+-    DWORD old_protect = 0;
+-    alloc_failed = (rdram == nullptr);
+-    if (!alloc_failed) {
+-        // VirtualProtect returns 0 on failure.
+-        alloc_failed = (VirtualProtect(rdram, mem_size, PAGE_READWRITE, &old_protect) == 0);
+-        if (alloc_failed) {
+-            VirtualFree(rdram, 0, MEM_RELEASE);
+-        }
+-    }
+-#else
+-    rdram = (uint8_t*)mmap(NULL, allocation_size, PROT_NONE, MAP_ANON | MAP_PRIVATE, -1, 0);
+-    alloc_failed = rdram == reinterpret_cast<uint8_t*>(MAP_FAILED);
+-    if (!alloc_failed) {
+-        // mprotect returns -1 on failure.
+-        alloc_failed = (mprotect(rdram, mem_size, PROT_READ | PROT_WRITE) == -1);
+-        if (alloc_failed) {
+-            munmap(rdram, allocation_size);
+-        }
+-    }
+-#endif
+-
+-    if (alloc_failed) {
++    // Reserve the full guest address space so invalid addresses remain guarded,
++    // while committing only the prefix that the runtime can access.
++    uint8_t* rdram = recomp::allocate_rdram_memory(allocation_size, mem_size);
++    if (rdram == nullptr) {
+         ultramodern::error_handling::message_box("Failed to allocate memory!");
+         return;
+     }
+@@ -830,14 +807,4 @@ void recomp::start(const recomp::Configuration& cfg) {
+-    // Free rdram.
+-    bool free_failed;
+-#ifdef _WIN32
+-    // VirtualFree returns zero on failure.
+-    free_failed = (VirtualFree(rdram, 0, MEM_RELEASE) == 0);
+-#else
+-    // munmap returns -1 on failure.
+-    free_failed = (munmap(rdram, allocation_size) == -1);
+-#endif
+-
+-    if (free_failed) {
++    if (!recomp::release_rdram_memory(rdram, allocation_size)) {
+         printf("Failed to free rdram\n");
+     }
+ }

--- a/tests/test_rdram_allocation.cpp
+++ b/tests/test_rdram_allocation.cpp
@@ -1,0 +1,69 @@
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+
+#include <windows.h>
+
+#include "librecomp/rdram_memory.hpp"
+
+namespace {
+constexpr std::size_t kMiB = 1024ULL * 1024ULL;
+constexpr std::size_t kAddressSpaceSize = 4096ULL * kMiB;
+constexpr std::size_t kAccessibleSize = 512ULL * kMiB;
+
+int failures = 0;
+
+void expect(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+}
+
+int main() {
+    HANDLE job = CreateJobObjectW(nullptr, nullptr);
+    expect(job != nullptr, "create a memory-limited job object");
+    if (job == nullptr) return 1;
+
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits{};
+    limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_PROCESS_MEMORY;
+    limits.ProcessMemoryLimit = 1024ULL * kMiB;
+    expect(SetInformationJobObject(job, JobObjectExtendedLimitInformation,
+                                   &limits, sizeof(limits)) != 0,
+           "set the process commit limit");
+    expect(AssignProcessToJobObject(job, GetCurrentProcess()) != 0,
+           "put the test process in the memory-limited job");
+    if (failures != 0) {
+        CloseHandle(job);
+        return failures;
+    }
+
+    void* eager = VirtualAlloc(nullptr, kAddressSpaceSize,
+                               MEM_RESERVE | MEM_COMMIT, PAGE_NOACCESS);
+    expect(eager == nullptr,
+           "the previous eager 4 GiB commit reproduces under a 1 GiB commit limit");
+    if (eager != nullptr) VirtualFree(eager, 0, MEM_RELEASE);
+
+    std::uint8_t* rdram = recomp::allocate_rdram_memory(kAddressSpaceSize,
+                                                        kAccessibleSize);
+    expect(rdram != nullptr,
+           "reserve 4 GiB while committing only the accessible 512 MiB");
+    if (rdram != nullptr) {
+        MEMORY_BASIC_INFORMATION accessible{};
+        MEMORY_BASIC_INFORMATION guard{};
+        expect(VirtualQuery(rdram, &accessible, sizeof(accessible)) != 0 &&
+                   accessible.State == MEM_COMMIT &&
+                   accessible.Protect == PAGE_READWRITE,
+               "the accessible RDRAM prefix is committed read-write");
+        expect(VirtualQuery(rdram + kAccessibleSize, &guard, sizeof(guard)) != 0 &&
+                   guard.State == MEM_RESERVE &&
+                   guard.Protect == 0,
+               "the remainder stays reserved and inaccessible as a guard");
+        expect(recomp::release_rdram_memory(rdram, kAddressSpaceSize),
+               "release the complete RDRAM address-space reservation");
+    }
+
+    CloseHandle(job);
+    return failures;
+}


### PR DESCRIPTION
## Summary

- reserve librecomp's 4 GiB guest address range without eagerly committing all of it on Windows
- commit only the accessible 512 MiB prefix while preserving the inaccessible guard range
- add a constrained-commit regression test and run it from the Windows release build flow
- make submodule patch reset idempotent for the new helper files

## Root cause

N64ModernRuntime used MEM_COMMIT | MEM_RESERVE for the full 4 GiB range even though its comment said the range should be reserved without commitment. That consumes system/pagefile commit budget and can fail on machines that have ample physical RAM. The added test reproduces the old failure under a 1 GiB process commit limit and verifies the split reserve/commit path.

## Verification

- ./build.ps1 (full Windows release build; allocator regression runs automatically)
- ctest --test-dir build -R '^lambo_' --output-on-failure (15/15 passed)
- headless boot smoke to 30 VIs (BOOT_EXIT:0, first VI reached)

Closes #158