### PR TITLE
Remember Player 1 name across runs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,11 +46,13 @@ if(BUILD_TESTING)
     add_executable(lambo_config_tests
         tests/test_live_config.cpp
         src/lambo_config.cpp
+        src/lambo_player_name.cpp
         src/lambo_log.cpp
     )
     target_include_directories(lambo_config_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${N64MR}/ultramodern/include
+        ${N64MR}/N64Recomp/include
         ${N64MR}/thirdparty
     )
     add_test(NAME lambo_config_live_updates COMMAND lambo_config_tests)
@@ -348,6 +350,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/stub_renderer.cpp
         src/lambo_audio.cpp    # SDL2 push-audio sink for the AI buffer (audio epic #53, PR 1 of 3)
         src/lambo_config.cpp   # persistent graphics.json -> ultramodern GraphicsConfig (enhancements #1/#2)
+        src/lambo_player_name.cpp # remember player one's confirmed name for later name-entry screens
         src/lambo_menu.cpp     # lightweight native Win32 menu bar; live config actions + persistence
         src/lambo_startup.cpp  # runtime-ready -> Play startup state machine (issue #126)
         src/lambo_input_gate.cpp # controller capture/neutral-release barrier (issue #126)

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -1091,3 +1091,20 @@ text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gp
 func = "func_800030F8"
 before_vram = 0x80004374
 text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gpr)(int32_t)lambo_camera_fov_bits((uint32_t)ctx->r6); }"
+
+# Remember player one's name across launches. The name editor owns four one-based,
+# 13-byte buffers at 0x800A4819 + driver*13 (12 chars + NUL); player one is therefore
+# 0x800A4826. The setup hook runs after the screen selects its driver but before the
+# ROM scans the buffer to calculate its length, so a saved name is immediately reflected
+# by both the text and cursor. The Done hook captures the final buffer before the ROM
+# advances to the next player / pak flow. Native persistence is in player.json via
+# lambo_player_name.cpp, separate from the main-thread-owned graphics configuration.
+[[patches.hook]]
+func = "func_8003CD84"
+before_vram = 0x8003CE68
+text = "{ extern void lambo_player_name_seed(uint8_t*); lambo_player_name_seed(rdram); }"
+
+[[patches.hook]]
+func = "func_800400EC"
+before_vram = 0x8003F4EC
+text = "{ extern void lambo_player_name_save(uint8_t*); lambo_player_name_save(rdram); }"

--- a/src/lambo_player_name.cpp
+++ b/src/lambo_player_name.cpp
@@ -1,0 +1,128 @@
+#include "lambo_player_name.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "json/json.hpp"
+#include "lambo_config.h"
+#include "lambo_log.h"
+#include "recomp.h"
+
+namespace {
+
+// Verified against the ROM's name editor (func_8003CD84 setup and the append /
+// delete helpers at 0x8003F3C0-0x8003F4E8). Driver indices are one-based and
+// each name occupies 13 bytes: up to 12 keyboard characters plus a NUL.
+constexpr uint32_t kCurrentDriverAddr = 0x800CE6A6u;
+constexpr uint32_t kDriverNamesBase = 0x800A4819u;
+constexpr int kPlayerOne = 1;
+constexpr int kNameStride = 13;
+constexpr int kMaxNameLength = 12;
+constexpr const char* kPlayerConfigFile = "player.json";
+
+gpr name_addr(int driver) {
+    return (gpr)(int32_t)(kDriverNamesBase + uint32_t(driver * kNameStride));
+}
+
+bool valid_name(const std::string& name) {
+    if (name.empty() || name.size() > kMaxNameLength) return false;
+    for (unsigned char ch : name) {
+        if (ch != ' ' && (ch < 'A' || ch > 'Z')) return false;
+    }
+    return true;
+}
+
+std::filesystem::path player_config_path() {
+    if (const char* path = std::getenv("LAMBO_PLAYER_CONFIG")) {
+        return std::filesystem::path{path};
+    }
+    return lambo::config::app_config_dir() / kPlayerConfigFile;
+}
+
+std::string load_saved_name() {
+    const std::filesystem::path path = player_config_path();
+    std::ifstream in{path};
+    if (!in.good()) return {};
+    try {
+        nlohmann::json json;
+        in >> json;
+        const auto field = json.find("name");
+        if (field == json.end() || !field->is_string()) return {};
+        std::string name = field->get<std::string>();
+        return valid_name(name) ? name : std::string{};
+    } catch (const nlohmann::json::exception& e) {
+        LAMBO_LOG("name", "%s unparseable (%s); keeping ROM default\n",
+                  path.string().c_str(), e.what());
+        return {};
+    }
+}
+
+void save_name(const std::string& name) {
+    const std::filesystem::path path = player_config_path();
+    const std::filesystem::path tmp = path.string() + ".tmp";
+    std::error_code ec;
+    std::filesystem::create_directories(path.parent_path(), ec);
+
+    std::ofstream out{tmp};
+    if (!out.good()) {
+        LAMBO_LOG("name", "cannot write %s\n", tmp.string().c_str());
+        return;
+    }
+    out << nlohmann::json{{"name", name}}.dump(4) << '\n';
+    out.flush();
+    if (!out.good()) {
+        LAMBO_LOG("name", "write to %s failed\n", tmp.string().c_str());
+        return;
+    }
+    out.close();
+
+    std::filesystem::rename(tmp, path, ec);
+#if defined(_WIN32)
+    if (ec) {
+        ec.clear();
+        std::filesystem::remove(path, ec);
+        ec.clear();
+        std::filesystem::rename(tmp, path, ec);
+    }
+#endif
+    if (ec) {
+        LAMBO_LOG("name", "cannot publish %s\n", path.string().c_str());
+    }
+}
+
+int current_driver(uint8_t* rdram) {
+    return (int16_t)MEM_H(0, (gpr)(int32_t)kCurrentDriverAddr);
+}
+
+} // namespace
+
+extern "C" void lambo_player_name_seed(uint8_t* rdram) {
+    if (current_driver(rdram) != kPlayerOne) return;
+
+    const std::string saved = load_saved_name();
+    if (!valid_name(saved)) return;
+
+    const gpr dst = name_addr(kPlayerOne);
+    for (int i = 0; i < kNameStride; ++i) {
+        MEM_B(i, dst) = i < (int)saved.size() ? saved[(size_t)i] : 0;
+    }
+    LAMBO_LOG("name", "seeded player name: %s\n", saved.c_str());
+}
+
+extern "C" void lambo_player_name_save(uint8_t* rdram) {
+    if (current_driver(rdram) != kPlayerOne) return;
+
+    const gpr src = name_addr(kPlayerOne);
+    std::string name;
+    for (int i = 0; i < kMaxNameLength; ++i) {
+        const unsigned char ch = MEM_BU(i, src);
+        if (ch == 0) break;
+        name.push_back((char)ch);
+    }
+    if (!valid_name(name)) return;
+
+    save_name(name);
+    LAMBO_LOG("name", "saved player name: %s\n", name.c_str());
+}

--- a/src/lambo_player_name.h
+++ b/src/lambo_player_name.h
@@ -1,0 +1,19 @@
+#ifndef LAMBO_PLAYER_NAME_H
+#define LAMBO_PLAYER_NAME_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Hooks at the ROM's name-screen setup and Done handler. Both operate only on
+// player one; multiplayer guests keep the game's independent DRIVER 2-4 names.
+void lambo_player_name_seed(uint8_t* rdram);
+void lambo_player_name_save(uint8_t* rdram);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tests/test_live_config.cpp
+++ b/tests/test_live_config.cpp
@@ -3,9 +3,12 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <vector>
 
 #include "json/json.hpp"
 #include "lambo_config.h"
+#include "lambo_player_name.h"
+#include "recomp.h"
 
 namespace {
 
@@ -38,10 +41,13 @@ int main() {
     const auto dir = std::filesystem::temp_directory_path() /
                      ("lambo-config-test-" + std::to_string(unique));
     const auto path = dir / "graphics.json";
+    const auto player_path = dir / "player.json";
 #if defined(_WIN32)
     _putenv_s("LAMBO_GRAPHICS_CONFIG", path.string().c_str());
+    _putenv_s("LAMBO_PLAYER_CONFIG", player_path.string().c_str());
 #else
     setenv("LAMBO_GRAPHICS_CONFIG", path.string().c_str(), 1);
+    setenv("LAMBO_PLAYER_CONFIG", player_path.string().c_str(), 1);
 #endif
 
     auto cfg = lambo::config::load_and_apply_graphics();
@@ -104,6 +110,26 @@ int main() {
     lambo::config::set_show_launcher(true);
     expect(lambo::config::show_launcher() == true, "show_launcher toggle updates snapshot");
     expect(read_json(path).at("show_launcher") == true, "show_launcher persists to json");
+
+    std::vector<uint8_t> memory(0x800000);
+    uint8_t* rdram = memory.data();
+    const gpr driver_index = (gpr)(int32_t)0x800CE6A6u;
+    const gpr player_one_name = (gpr)(int32_t)0x800A4826u;
+    MEM_H(0, driver_index) = 1;
+    const std::string edited = "CHAMP";
+    for (int i = 0; i < 13; ++i) {
+        MEM_B(i, player_one_name) = i < (int)edited.size() ? edited[(size_t)i] : 0;
+    }
+    lambo_player_name_save(rdram);
+    expect(read_json(player_path).at("name") == edited, "confirmed ROM name persists");
+
+    for (int i = 0; i < 13; ++i) MEM_B(i, player_one_name) = 0;
+    lambo_player_name_seed(rdram);
+    std::string seeded;
+    for (int i = 0; i < 13 && MEM_BU(i, player_one_name) != 0; ++i) {
+        seeded.push_back((char)MEM_BU(i, player_one_name));
+    }
+    expect(seeded == edited, "next run seeds the persisted name into the ROM buffer");
 
     std::error_code ec;
     std::filesystem::remove_all(dir, ec);


### PR DESCRIPTION
## Summary
- remember Player 1's confirmed name in `player.json` across launches
- seed the saved name when the Player 1 name-entry screen opens
- add focused save/reload test coverage and ROM hooks at the verified name-editor seams

## Validation
- `build.ps1` completed successfully, including ROM recompilation and `lamborghini_modern.exe`
- focused persistence test passed with warnings treated as errors
- launched the rebuilt executable successfully