### PR TITLE
Embed PerMonitorV2 DPI-awareness manifest (Closes #161)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,6 +505,23 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
     )
 
     if(WIN32)
+        # Per-Monitor V2 DPI awareness (issue #161): embed src/app.manifest so the
+        # process gets true physical pixel dimensions at >100% display scaling --
+        # without it DWM bitmap-stretches the window by the scale factor and a
+        # 1600x900 window overflows 1080p screens at 175% scaling. MinGW ld has no
+        # /MANIFEST switch, so compile the .rc (which references the manifest) with
+        # windres and link the object.
+        find_program(LAMBO_WINDRES_EXECUTABLE NAMES windres REQUIRED)
+        set(LAMBO_MANIFEST_OBJ ${CMAKE_CURRENT_BINARY_DIR}/lambo_manifest.rc.o)
+        add_custom_command(OUTPUT ${LAMBO_MANIFEST_OBJ}
+            COMMAND ${LAMBO_WINDRES_EXECUTABLE}
+                -I ${CMAKE_CURRENT_SOURCE_DIR}/src
+                -O coff -o ${LAMBO_MANIFEST_OBJ}
+                ${CMAKE_CURRENT_SOURCE_DIR}/src/lambo_manifest.rc
+            DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/lambo_manifest.rc
+                    ${CMAKE_CURRENT_SOURCE_DIR}/src/app.manifest
+            COMMENT "Embedding DPI-awareness manifest (windres)")
+        target_sources(lamborghini_modern PRIVATE ${LAMBO_MANIFEST_OBJ})
         # Native crash backtrace (#13 / A14): CaptureStackBackTrace lives in
         # dbghelp.dll. MinGW64 ships the import lib (libdbghelp.a) so an explicit
         # target_link_libraries entry is enough; we don't ship the DLL — the

--- a/src/app.manifest
+++ b/src/app.manifest
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- Per-Monitor V2 DPI awareness (issue #161): without this the process runs
+           DPI-unaware and DWM bitmap-stretches the window by the system scale
+           factor (e.g. 1600x900 -> ~2800x1575 at 175%), overflowing 1080p
+           screens. The modern key needs Win10 1703+; the legacy dpiAware entry
+           is the fallback for older Windows and is ignored when the modern key
+           is understood. -->
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/lambo_manifest.rc
+++ b/src/lambo_manifest.rc
@@ -1,0 +1,7 @@
+// Embeds app.manifest into lamborghini_modern.exe as resource ID 1 of type
+// RT_MANIFEST (24) -- the ID Windows looks for in an exe. Compiled by windres
+// (see CMakeLists.txt WIN32 block); MinGW ld has no /MANIFEST switch.
+#ifndef RT_MANIFEST
+#define RT_MANIFEST 24
+#endif
+1 RT_MANIFEST "app.manifest"


### PR DESCRIPTION
## Problem

#161: on Windows 11 with >100% display scaling (reporter: 175% on a 1920x1080 panel), the game window starts oversized and runs off the screen; only Alt+Enter (fullscreen) restores it.

## Root cause

The process had **no DPI-awareness declaration** anywhere — no manifest, no `SetProcessDpiAwareness*` call. It therefore ran DPI-unaware, and DWM bitmap-stretched the window by the system scale factor: the default 1600x900 windowed-mode window rendered at ~2800x1575 physical pixels, overflowing a 1080p display. Alt+Enter fixed it because `SDL_WINDOW_FULLSCREEN_DESKTOP` fills the desktop exactly.

This has been latent since v0.1.0 — not a 0.6.0 regression (the window-creation path is unchanged between v0.5.0 and v0.6.0).

## Fix

Embed an application manifest declaring **PerMonitorV2** DPI awareness (with the legacy `True/PM` fallback for pre-Win10-1703), matching the approach of other recomp ports (e.g. Zelda64Recomp):

- `src/app.manifest` — the manifest itself
- `src/lambo_manifest.rc` — embeds it as RT_MANIFEST resource ID 1
- `CMakeLists.txt` — Windows-only windres compile + link into `lamborghini_modern` (MinGW ld has no `/MANIFEST` switch)

No code changes; non-Windows builds are untouched (`if(WIN32)`-gated).

## Verification

- Fresh full build green (recompilers, recompiled game code, all 105 targets)
- All 14 project tests pass (`ctest -R lambo_`)
- Boot smoke: 30s run through attract mode, no crash, clean stderr
- Empirical OS check: queried the live game window via `GetWindowDpiAwarenessContext` → awareness level **2 = PerMonitorV2** (was 0 = Unaware before this change)

Closes #161