### PR TITLE
Fix Alt+F4 shutdown race

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,8 +192,13 @@ if(BUILD_TESTING)
                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ui_assets.py
                 ${CMAKE_CURRENT_SOURCE_DIR}
         )
+        add_test(NAME lambo_quit_path
+            COMMAND ${LAMBO_PYTHON_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_quit_path.py
+                ${CMAKE_CURRENT_SOURCE_DIR}
+        )
     else()
-        message(WARNING "Python not found; lambo_ui_asset_references will not be registered")
+        message(WARNING "Python not found; Python-based tests will not be registered")
     endif()
 endif()
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,7 +123,12 @@ static void thread_create_cb(uint8_t*, recomp_context*) {
 
 [[noreturn]] static void application_exit_success() {
     LAMBO_LOG("probe", "application exit requested; status=success\n");
-    lambo::ui::shutdown();
+    // update_gfx_stub runs on librecomp's primary thread, while RT64 invokes the
+    // UI render hooks on its presentation thread. Calling ui::shutdown() here
+    // races that thread: it clears RT64's unsynchronised hook pointers and tears
+    // down RmlUi while a draw hook can still be using it. This path deliberately
+    // terminates the process below, so there is no cleanup benefit that can
+    // justify touching either subsystem first.
     std::fflush(nullptr);
     std::_Exit(0);
 }

--- a/tests/test_quit_path.py
+++ b/tests/test_quit_path.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def function_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    opening_brace = source.index("{", start)
+    depth = 0
+    for index in range(opening_brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening_brace + 1:index]
+    raise AssertionError(f"unterminated function: {signature}")
+
+
+def main() -> None:
+    source = (Path(sys.argv[1]).resolve() / "src" / "main.cpp").read_text(encoding="utf-8")
+    exit_body = function_body(source, "static void application_exit_success()")
+
+    # This function runs on librecomp's primary thread while RT64 can still invoke
+    # draw hooks from its presentation thread. It must not touch RmlUi or RT64 before
+    # process termination (issue #163).
+    require("std::_Exit(0)" in exit_body,
+            "the window-close path must terminate without falling into runtime teardown")
+    require("lambo::ui::shutdown" not in exit_body,
+            "the window-close path must not destroy UI state while RT64 may render it")
+
+    event_loop = function_body(source, "static void update_gfx_stub(void*")
+    require("event.type == SDL_QUIT" in event_loop and
+            "SDL_WINDOWEVENT_CLOSE" in event_loop and
+            "application_exit_success();" in event_loop,
+            "SDL quit and window-close events must use the immediate safe exit path")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- avoid tearing down RmlUi from the SDL quit handler while RT64 can still render it
- retain immediate process termination for the live runtime thread model
- add a regression guard for both SDL quit and window-close routes

## Tests
- python tests/test_quit_path.py .
- python tests/test_ui_assets.py .
- build/startup-smoke.exe

Closes #163