### PR TITLE
no_lod: zero car-distance halfword (fixes car-model distance LOD)

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -45,6 +45,10 @@ git -C lib/N64ModernRuntime apply ../../patches/0001-lamborghini-runtime-schedul
 # ultramodern save-state thread-context relink (issue #22, all platforms):
 git -C lib/N64ModernRuntime apply ../../patches/0007-ultramodern-savestate-thread-context-relink.patch
 
+# lazy RDRAM commit + rdram_memory.cpp (issue #158; the port's CMakeLists links
+# librecomp/src/rdram_memory.cpp directly, so configure fails without this):
+git -C lib/N64ModernRuntime apply ../../patches/0012-n64modernruntime-lazy-rdram-commit.patch
+
 # RT64 renderer — all platforms (frame-interpolation transform matching, issue #30):
 git -C lib/rt64 apply "$(pwd)/patches/0006-rt64-interp-angular-velocity-matching.patch"
 

--- a/docs/no_lod_audit.md
+++ b/docs/no_lod_audit.md
@@ -351,6 +351,83 @@ audit had classified as "frame-coherent view culling, not pop-in" and left untou
   `0x3FEC5A1CAC083127`), pinned by test.
 
 ---
+## 12. Addendum (2026-08-27): the car-distance halfword (and the `func_80060464` reclassification)
+
+A user report that "car models still change with distance" after the scenery work
+shipped sent the camera back into `func_8000A6C0`. The same builder that draws
+the segments also draws the cars, and the chosen-car-model axis lived in a place
+none of the previous work touched.
+
+**The mechanism (issue #165).** Each frame the builder computes a per-car scaled
+camera distance (sqrt of scaled dx²+dy²+dz² between the viewport position and
+the per-car record at `0x800B69B0 + i*268`, indexed by the sp+0x1B2 car
+counter), truncates it to a halfword at guest `0x80098720` (sqrt at vram
+`0x8000C0A4`, store at `0x8000C0BC`, 3P/4P ×1.5 re-store at `0x8000C104`), and
+an 8-entry threshold ladder over each car-type struct's halfwords picks which
+model DL to emit from the struct's `models[8]` array (ladder at
+`0x8000C17C-0x8000C1DC`, emit at `0x8000C218-0x8000C25C`). A second overlay
+pass repeats the ladder at `0x8000E210-0x8000E2C4`. A `>=150` check at
+`0x8000C2C4` gates the far path. The structs are runtime asset data (e.g.
+`0x8018F0C0`: thresholds `[25,10,50,32,200,...]`, models
+`[full, mid, mid, low×5]`). The low-tail entries are the simplified meshes
+the user sees swap in with distance.
+
+Verified empirically (2026-08-27): read-watchpoint on the struct threshold
+table at `0x801AB3F0` (the function rom offset of the struct row for the
+near-detail family) fired with consistent `0x8000C0AC` and `0x8000C1B4` return-
+address candidates, both inside `func_8000A6C0` (the scene builder). DL-walk
+diff (`LAMBO_RACE_DL_DUMP_AT`) of the same send_dl count with stock vs. patched
+showed the level-varying model family (`0x801A9E68`) swapping to its
+near-detail entry (`0x801A9998`) under the fix.
+
+**The fix (issue #165, shipped in this branch).** Native
+`lambo_no_lod_car_detail(rdram)` in `src/lambo_no_lod.cpp` zeroes the
+halfword at `0x80098720` after both stores and before all readers (hooked
+at `before_vram = 0x8000C108`, `func_8000A6C0`). With `no_lod()` on, every
+consumer takes its closest/most-detailed branch. With `no_lod()` off, the
+native returns immediately and ROM behavior is bit-for-bit preserved. Native
+is gated on the existing `no_lod()` graphics.json key — no new toggle. Hook
+block lives in both `lamborghini.us.toml` and `scripts/gen_syms_toml.py`'s
+`PATCH_BLOCKS` per the repo's documented gotcha (gen must carry live blocks
+or a regen silently drops them).
+
+**Reclassification of `func_80060464` (issue #4, the "A4" patch).** The
+audit §1 Axis A classified `func_80060464` as "per-car geometry detail vs
+100.0u — the A4 patch; branch already NOP'd at recompile". On re-reading the
+disassembly this is wrong: the function is a nested pair loop over cars,
+computing `dist - (radius_i + radius_j)` and a separate threshold at 100.0,
+then dispatching to either a detailed OBB contact test (`func_80063D80`)
+and an impact handler (`func_8005EC74`) or a simple far-path collision
+update. It's car-*pair collision/proximity processing*, not render LOD. The
+patch (bc1f at `0x8005FA3C` NOP'd to always fall through) was therefore
+silently neutral — harmless, but it never addressed the user's visible
+symptom. The audit table entry should be read as "neutralised car-pair
+collision branch", not "geometry-LOD gate". Future readers: do not trust
+the original classification without re-reading the disassembly. The
+isometric pair-loop shape, the per-pair `-0x17D0` record-base computation
+(`lui $t9, 0x800D; addiu $t9, -0x17D0` = `0x800CE830`), and the calls to
+`func_800631F8`/`func_8006364C`/`func_80064364` are all characteristic of the
+collision system, not the render system.
+
+**Why `scan_lod_patterns.py` missed it.** The scan fingerprints
+single-precision FP compares against immediates; this mechanism uses (a) a
+truncated integer halfword (single-precision *output* of a sqrt, stored as
+`signed short`), (b) threshold values loaded from runtime asset data via
+`lhu $at, 0($t6)` (table load, no immediate), and (c) integer `slt`
+comparisons in a ladder. Two of the three primary blind spots this report
+already documents (§7: integer gates; §9: table-loaded thresholds), but the
+scan was never re-run to catch this on the runtime data because it's
+deployed during races from a non-ROM address. `tools/scan_lod_patterns.py`
+should grow an integer-ladder fingerprint if it's to catch future cases.
+
+**Makes #93 a partial no-op.** Issue #93 ("Per-mode car-mesh identity check")
+predicted a per-mode car-mesh axis gated under `no_lod() && players >= 3`. That
+prediction was wrong — the actual axis is per-frame and shared across player
+counts, so `no_lod()` alone is sufficient. The per-mode identity check (do
+3P/4P render simpler meshes?) is still worth running but no longer motivates
+its own hook ticket.
+
+---
 *Method note: MIPS classification used `tools/scan_lod_patterns.py` output cross-read
 against the recompiled C (per-instruction VRAM comments) rather than raw disassembly;
 extraction script preserved in the session scratchpad. ROM scans were byte-pattern

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -746,6 +746,24 @@ func = "func_8000A6C0"
 before_vram = 0x8000D920
 text = "{ extern uint32_t lambo_no_lod_seg_list_clamp(uint8_t*, uint32_t); ctx->r25 = lambo_no_lod_seg_list_clamp(rdram, (uint32_t)ctx->r25); }"
 
+# Issue #165 -- no_lod car-model detail (the last distance axis). The scene
+# builder also draws the cars and keeps a per-car scaled camera distance as a
+# halfword at 0x80098720 (sqrt at 0x8000C0A4, trunc + store at 0x8000C0AC/
+# 0x8000C0BC, 3P/4P x1.5 re-store at 0x8000C104). Every car-model choice reads
+# that one halfword: an 8-entry threshold ladder over the car-type struct
+# picks models[level] (0x8000C17C-0x8000C25C; structs are runtime asset data
+# like 0x8018F0C0 whose tail entries are the simplified far meshes), a second
+# overlay pass repeats the ladder at 0x8000E210-0x8000E2C4, and a >=150 check
+# gates the far path (0x8000C2C4) -- this is the mechanism behind car models
+# visibly swapping with distance. Hooked after both stores (0x8000C108, before
+# any reader): zeroing the halfword under no_lod() makes every consumer take
+# its closest/most-detailed branch. Per frame by construction; with no_lod()
+# off the native leaves RDRAM untouched. Native in src/lambo_no_lod.cpp.
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000C108
+text = "{ extern void lambo_no_lod_car_detail(uint8_t*); lambo_no_lod_car_detail(rdram); }"
+
 # Issue #78 — 3P/4P per-quadrant HUD text pinning. The quad section (L_800517A8) draws
 # each player's RANK (x=0x20/0x110), speed readout (x=0x14-0x46 / 0xEB-0x11D), lap-notify
 # glyph (x=0x19/0x118) and the inline per-player tag texrects in the outer columns, plus

--- a/scripts/gen_syms_toml.py
+++ b/scripts/gen_syms_toml.py
@@ -1076,6 +1076,24 @@ func = "func_8000A6C0"
 before_vram = 0x8000D920
 text = "{ extern uint32_t lambo_no_lod_seg_list_clamp(uint8_t*, uint32_t); ctx->r25 = lambo_no_lod_seg_list_clamp(rdram, (uint32_t)ctx->r25); }"
 
+# Issue #165 -- no_lod car-model detail (the last distance axis). The scene
+# builder also draws the cars and keeps a per-car scaled camera distance as a
+# halfword at 0x80098720 (sqrt at 0x8000C0A4, trunc + store at 0x8000C0AC/
+# 0x8000C0BC, 3P/4P x1.5 re-store at 0x8000C104). Every car-model choice reads
+# that one halfword: an 8-entry threshold ladder over the car-type struct
+# picks models[level] (0x8000C17C-0x8000C25C; structs are runtime asset data
+# like 0x8018F0C0 whose tail entries are the simplified far meshes), a second
+# overlay pass repeats the ladder at 0x8000E210-0x8000E2C4, and a >=150 check
+# gates the far path (0x8000C2C4) -- this is the mechanism behind car models
+# visibly swapping with distance. Hooked after both stores (0x8000C108, before
+# any reader): zeroing the halfword under no_lod() makes every consumer take
+# its closest/most-detailed branch. Per frame by construction; with no_lod()
+# off the native leaves RDRAM untouched. Native in src/lambo_no_lod.cpp.
+[[patches.hook]]
+func = "func_8000A6C0"
+before_vram = 0x8000C108
+text = "{ extern void lambo_no_lod_car_detail(uint8_t*); lambo_no_lod_car_detail(rdram); }"
+
 # Issue #78 — 3P/4P per-quadrant HUD text pinning. The quad section (L_800517A8) draws
 # each player's RANK (x=0x20/0x110), speed readout (x=0x14-0x46 / 0xEB-0x11D), lap-notify
 # glyph (x=0x19/0x118) and the inline per-player tag texrects in the outer columns, plus

--- a/src/lambo_no_lod.cpp
+++ b/src/lambo_no_lod.cpp
@@ -210,3 +210,36 @@ extern "C" uint32_t lambo_no_lod_seg_list_clamp(uint8_t* rdram, uint32_t count) 
     if (!lambo::config::no_lod()) return count;
     return (int32_t)count > 20 ? 20u : count;
 }
+
+// Per-car model LOD (issue #165, the last distance axis -- a user report that car
+// models still swap with distance after the scenery work shipped). The same scene
+// builder draws the cars and keeps a per-car scaled camera distance as a halfword
+// at 0x80098720: each frame it computes sqrt of the scaled dx^2+dy^2+dz^2 between
+// the viewport position (indexed by 0x800CE6A6 into 0x800A2DD0) and the per-car
+// record at 0x800B69B0 + i*268 (the struct pointer -- a sibling field at
+// 0x800B69BC carries the position), truncs to int (0x8000C0AC) and stores it
+// there (0x8000C0BC; the 3P/4P pass multiplies by 1.5 and stores again at
+// 0x8000C104). Every car-model choice hangs off that one halfword, all inside
+// this builder: an 8-entry threshold ladder over the car-type struct's halfwords
+// (first index whose threshold exceeds the distance) selects a display list from
+// the struct's models[8] array (ladder at 0x8000C17C-0x8000C1DC, emit at
+// 0x8000C218-0x8000C25C), a second consumer repeats the pattern for its own
+// overlay pass (0x8000E210-0x8000E2C4), and a >=150 check gates the far path
+// (0x8000C2C4). The structs are runtime asset data (e.g. 0x8018F0C0:
+// thresholds [25,10,50,32,200,...], models [full, mid, mid, low...]) -- the low
+// entries are the simplified meshes that swap in with distance.
+//
+// Fix: zero the halfword after both stores (hooked at 0x8000C108, before any
+// reader -- 0x8000C0BC stores, 0x8000C104 re-stores in 3P/4P, first read at
+// 0x8000C160; verified in ares with a read-watchpoint on the struct threshold
+// table) when no_lod() is on, so every consumer takes its closest/most-detailed
+// branch: level 0 on both ladders (for typical positive-threshold structs;
+// structs with a zero or negative threshold[0] would still pick level 0 since
+// "dist<threshold" with dist=0 fails for any negative threshold) and the near
+// path on the 150 gate. Per frame, not once at load -- the builder recomputes
+// the value every car, every frame. With no_lod() off the native returns
+// without touching RDRAM and the ROM's authored LOD selection runs bit-for-bit.
+extern "C" void lambo_no_lod_car_detail(uint8_t* rdram) {
+    if (!lambo::config::no_lod()) return;
+    MEM_H(0, (gpr)(int32_t)0x80098720u) = 0;
+}


### PR DESCRIPTION
Closes #165

Follows on from the scenery-side `no_lod` work (#87, #91). The scene builder `func_8000A6C0` also draws the cars and the chosen-car-model axis lived in a place none of the scenery work touched.

## Mechanism

Each frame the builder computes a per-car scaled camera distance (sqrt of scaled dx²+dy²+dz² between the viewport position and the per-car record at `0x800B69B0 + i*268`, indexed by the sp+0x1B2 car counter), truncates it to a halfword at guest `0x80098720` (sqrt at vram `0x8000C0A4`, store at `0x8000C0BC`, 3P/4P ×1.5 re-store at `0x8000C104`), and an 8-entry threshold ladder over each car-type struct's halfwords picks a model DL from the struct's `models[8]` array. A second overlay pass at `0x8000E210-0x8000E2C4` repeats the ladder; a ≥150 gate at `0x8000C2C4` gates the far path. The structs are runtime asset data (e.g. `0x8018F0C0`: thresholds `[25,10,50,32,200,...]`, models `[full, mid, mid, low×5]`); the tail entries are the simplified meshes that swap in with distance.

Verified empirically in ares with a read-watchpoint on the struct threshold table at `0x801AB3F0` (consistent `0x8000C0AC` and `0x8000C1B4` return-address candidates, both inside `func_8000A6C0`) and via headless A/B DL walks (`LAMBO_RACE_DL_DUMP_AT`) showing the level-varying model family switching to its near-detail entry under the fix.

## Fix

Native `lambo_no_lod_car_detail(rdram)` in `src/lambo_no_lod.cpp` zeroes the halfword after both stores and before all readers (hooked at `before_vram = 0x8000C108`, `func_8000A6C0`). With `no_lod()` on, every consumer takes its closest/most-detailed branch; with `no_lod()` off the native returns immediately and ROM behavior is bit-for-bit preserved. Hook block mirrored into `scripts/gen_syms_toml.py` PATCH_BLOCKS per the repo's documented gotcha.

## Verification

- All 19 ctest targets pass (full rebuild + tests).
- Boot smoke reaches race state.
- Headless A/B DL walks confirm: stock `0x801A9E68` → patched `0x801A9998` (same struct, lower level pinned). `LAMBO_NO_LOD=0` leaves RDRAM untouched (no-op early-return).

## Doc corrections

- `docs/no_lod_audit.md` §12: addendum capturing the mechanism, the reclassification of `func_80060464` (issue #4 / the A4 patch — it's a car-pair collision test, not the render LOD — the original audit table entry was wrong), the `scan_lod_patterns.py` blind spots that hid this, and the supersession of the per-mode hook ticket predicted by #93.
- Comment on #4 recording the reclassification.
- Comment on #93 noting the predicted shape was wrong and the per-mode check is still worth running but its predicted hook ticket is not needed.

## BUILDING.md fix

Add the missing 'apply patch 0012' step. The port's CMakeLists links `librecomp/src/rdram_memory.cpp` directly, which patch 0012 creates; without it a fresh clone fails configure. CI gets it via `build.sh` but the doc was stale.

## Files changed

`BUILDING.md`, `docs/no_lod_audit.md`, `lamborghini.us.toml`, `scripts/gen_syms_toml.py`, `src/lambo_no_lod.cpp`.