### PR TITLE
Document the decoupled RT64 texture-pack workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ N64Recomp ports (Zelda 64: Recompiled et al.):
 | `wm_option` | `Windowed`, `Fullscreen` | `Windowed` | Window mode. **F11** or **Alt+Enter** toggles at runtime (and is remembered). |
 | `window_width` / `window_height` | pixels | `1600`/`900` | Windowed-mode size. |
 | `api_option` | `Auto`, `D3D12`, `Vulkan`, `Metal` | `Auto` | Graphics API. |
+| `texture_pack` | path to a directory or `.rtz` | `""` | Loads one native RT64 texture pack at startup. An empty value keeps the original textures. |
+| `texture_dump` | directory path | `""` | Dumps each texture used during play as RT64 TMEM/RDRAM data for pack authors. |
 | `widescreen_fog_match` | `true`, `false` | `true` | Widens the dense 3P/4P split-screen fog to the open 1P fog window/colour so the extra draw distance shows. Only affects 3+ player races. |
 | `widescreen_sky_match` | `true`, `false` | `true` | Draws the sky panorama in 3P/4P split screen (the original skips it, leaving a flat dark backdrop above the horizon). Only affects 3+ player races. |
 | `no_lod` | `true`, `false` | `true` | Removes the ROM's draw-distance reductions: the per-mode scenery-layer skip and the trimmed per-segment visibility lists, with reach then governed by `draw_distance` instead of the N64 fill-rate budgets. `false` restores the N64-authored behaviour entirely. |
@@ -48,6 +50,31 @@ N64Recomp ports (Zelda 64: Recompiled et al.):
 | `draw_distance_circuit` | array of 6 numbers | `[1,1,1,1,1,1]` | Per-circuit draw-distance multipliers (multiplied with `draw_distance`), e.g. extend just one short-sighted city track. |
 | `camera_fov_add` | `-20`–`60` degrees | `0` | Degrees added to each camera layout's authored field of view (sense-of-speed effect). The scene builder's view-cone cull widens to match, so higher values do not cause peripheral pop-in. Also settable live from the Enhancements menu. |
 | `show_launcher` | `true`, `false` | `false` | When `false`, the game auto-boots directly into gameplay with the in-game configuration overlay available during play. When `true`, presents the standalone launcher shell at boot. Overridable via `LAMBO_LAUNCHER=1/0`. |
+
+## Texture packs
+
+The port supports native RT64 replacement packs as either a loose development directory
+or a packaged `.rtz` file. Set `texture_pack` in `graphics.json` to the pack path and
+restart the game. The pack is optional and layered over the original textures; removing
+the setting restores the stock artwork.
+
+Texture-pack support is deliberately separate from any particular replacement artwork.
+This repository does not ship an HD or readable-text pack, so those packs can be created,
+versioned, and distributed independently. `.o2r` and legacy Rice packs use different
+resource identities and are not directly interchangeable with this port's RT64 packs.
+
+Pack authors can dump the textures encountered during a run without changing the saved
+configuration:
+
+```powershell
+$env:LAMBO_TEXTURE_DUMP = 'C:\path\to\dump'
+.\lamborghini_modern.exe
+```
+
+On Linux, use `LAMBO_TEXTURE_DUMP=/path/to/dump ./lamborghini_modern`. Exercise every
+menu, HUD, vehicle, and track that the pack should cover because dumping is runtime-driven.
+See **[Texture packs](./docs/TEXTURES.md)** for decoding the dump, authoring replacements,
+generating `rt64.json`, testing a loose pack, and packaging it as `.rtz`.
 
 ## In-Game Configuration & Controls
 

--- a/docs/TEXTURES.md
+++ b/docs/TEXTURES.md
@@ -1,17 +1,16 @@
-# Texture extraction & replacement (issue #9 foundation, 2026-07-06)
+# Texture packs
 
-Reference for anyone (human or LLM) adding replacement/HD textures — the first target
-being the game's hard-to-read text. Everything here was verified end-to-end on this port:
-a headless dump of the demo race, an offline decode, and a replacement texture visibly
-applied in-game (the speedometer's MPH digits and the title "COPYRIGHT 1997 TITUS" line
-turned solid magenta once their font-atlas texture was replaced).
+This is the end-to-end guide for creating native RT64 replacement packs for the port.
+Texture-pack support is content-agnostic: an HD-art pack, a readable-text pack, or a small
+one-texture experiment all use the same runtime facility, and the replacement artwork can
+live in a separate repository. Everything below was verified with a headless texture dump,
+an offline decode, a loose replacement directory, and a packaged `.rtz` loaded in-game.
 
 ## What RT64 already gives us (and what the port adds)
 
-RT64 (`lib/rt64`) ships the **entire** texture-replacement system — hashing, a dump mode,
-a pack database, DDS/PNG loading, `.rtz` packaging tools. The port previously wired **none**
-of it (`src/rt64_renderer.cpp` was "adapted from Zelda64Recomp minus the texture-pack
-plumbing"). Issue #9's foundation is just to *expose* it:
+RT64 (`lib/rt64`) ships the texture-replacement system: hashing, a dump mode, a pack
+database, DDS/PNG loading, and `.rtz` packaging tools. The port exposes those facilities
+through startup configuration and supplies the dump-decoding and manifest-generation tools:
 
 | Capability | Provided by | Where |
 |---|---|---|
@@ -24,9 +23,9 @@ plumbing"). Issue #9's foundation is just to *expose* it:
 | Generate `rt64.json` from replacement files | **port** | `tools/make_pack.py` |
 | Build `.rtz` (+ low-mip cache) | RT64 | `build/rt64/src/tools/texture_packer/texture_packer.exe` |
 
-Texture identity is the **TMEM content hash**, not an RDRAM address — so a replacement keyed
-by hash survives the asset moving in memory, but the *same on-screen text drawn at a
-different scale/palette is a different hash* (see the coverage gotcha below).
+Texture identity is the **TMEM content hash**, not an RDRAM address. A replacement keyed by
+hash survives the source asset moving in memory, but a different palette or tile state can
+produce another hash for artwork that otherwise looks identical.
 
 ## Config keys (graphics.json)
 
@@ -54,9 +53,9 @@ LAMBO_TEXTURE_DUMP=/path/to/dump  ./build/lamborghini_modern
 ```
 
 Coverage is **runtime-driven**: a texture is only dumped once the game uploads it to TMEM.
-Exercise every screen whose text you care about — attract intro, PRESS START title,
-menus (RACE / NAME / records), and the in-race HUD. The dev warp menu (`LAMBO_WARP`,
-F1–F6) reaches race screens quickly. Missed screen ⇒ missing texture in the pack.
+Exercise every screen and scene the pack should cover: attract/title, menus, every relevant
+HUD state, vehicles, rivals, and each track. The dev warp menu (`LAMBO_WARP`, F1–F6) reaches
+race screens quickly. A scene not visited can leave its textures out of the dump.
 
 Each unique texture writes `<hash>.v5.tmem`, `<hash>.v5.tile.json` (fmt/siz/dims/tlut),
 plus `.rice.rdram` / `.rice.palette.rdram` for CI textures. These are **raw data, not
@@ -86,13 +85,13 @@ Open `index.html` (a contact sheet) to eyeball the whole dump. **Decode fidelity
   `aec01187` 512×8 font atlas reads as legible characters and the sky/cloud CI4 tiles show
   clean blue/gold. RT64's live F1 inspector still gives a GPU-decoded cross-check.
 
-### 3. Identify the text
+### 3. Choose textures to replace
 
-The HUD/menu font atlases are **CI4/CI8 banner-shaped** textures (e.g. the small HUD font is
-`aec01187…`, a 512×8 CI4 strip of glyphs). Filter the dump for `fmt2` (CI) textures that are
-wide-and-short. There are **several** font atlases — replacing the small-HUD one changed the
-speedo digits and the title copyright line but **not** "LAP/TIME/RANK/GET READY", which use a
-different atlas. Expect to find and replace each.
+Browse the generated contact sheet and copy only the PNGs you want to change into a separate
+pack directory. Keep each 16-hex hash as the filename: it is the identity RT64 uses at runtime.
+Some artwork appears under several hashes because its palette or tile state changes, so verify
+all variants in-game. Fonts are commonly CI4/CI8 strips, while HUD art, logos, vehicles, and
+track textures may use unrelated formats and dimensions.
 
 ### 4. Author replacements
 
@@ -100,9 +99,12 @@ different atlas. Expect to find and replace each.
   dump filename prefix.
 - **PNG** loads directly and is fine for iteration. **DDS** (BC7 + mipmaps, e.g. via Texconv
   / Compressonator's *CPU* encoder) is what you ship — never ship PNG.
-- Keep `shift: half` for modern-tool exports.
-- Coverage gotcha restated: a CI font re-hashes when its palette changes (highlighted vs.
-  normal menu item), so the same glyphs can need replacing under several hashes.
+- The default `shift: half` is appropriate for modern-tool exports that bake a half-texel
+  origin offset. A grid-aligned integer upscale of the decoded PNG instead needs
+  `python tools/make_pack.py /path/to/pack --shift none`; test atlas and tiled textures
+  carefully because the wrong shift produces sampling offsets or neighbouring-texel bleed.
+- Paletted textures re-hash when their palette changes (for example, highlighted versus normal
+  menu art), so visually identical pixels can require replacements under several hashes.
 
 ### 5. Build the manifest + pack
 

--- a/docs/TEXTURES.md
+++ b/docs/TEXTURES.md
@@ -29,15 +29,13 @@ produce another hash for artwork that otherwise looks identical.
 
 ## Config keys (graphics.json)
 
-Extra string/bool keys alongside the standard `GraphicsConfig` fields, each overridable
-by an env var so a headless capture never has to touch the user's `graphics.json`:
+Two string keys alongside the standard `GraphicsConfig` fields, each overridable by an
+environment variable so a capture or test run never has to modify `graphics.json`:
 
 | Key | Type | Default | Env override | Effect |
 |---|---|---|---|---|
 | `texture_pack` | string | `""` | `LAMBO_TEXTURE_PACK` | Directory or `.rtz` auto-loaded at startup. |
 | `texture_dump` | string | `""` | `LAMBO_TEXTURE_DUMP` | Directory RT64 writes every used texture to. |
-| `widescreen_fog_match` | bool | `true` | `LAMBO_FOG_MATCH_1P=1/0` | Issue #83: widen the dense 3P/4P split-screen fog to the 1P window/colour (rewrite of `G_MW_FOG` + `gDPSetFogColor` on the shared RDRAM DL, gated `players >= 3`). 1P/2P stay faithful. |
-| `widescreen_sky_match` | bool | `true` | `LAMBO_SKY_MATCH_1P=1/0` | Issue #84: draw the sky panorama in 3P/4P split screen (a `patches.hook` routes the player-count guard on the game's per-viewport sky-emitter call through `src/lambo_sky_widescreen.cpp`). 1P/2P take that path natively. |
 
 Both are independent of `developer_mode`, so an end-user pack loads **without** the F1
 developer overlay. On success the log prints `[rt64] texture pack loaded: …` /
@@ -143,7 +141,6 @@ expect the warp keys to also trigger.
 ## Files
 
 - `src/rt64_renderer.cpp` — startup wiring (dump dir + `loadReplacementDirectory`).
-- `src/lambo_config.{h,cpp}` — `texture_pack` / `texture_dump` / `widescreen_fog_match` keys + env overrides.
-- `src/lambo_fog_widescreen.cpp` — issue #83 3P/4P fog-widening DL rewrite.
+- `src/lambo_config.{h,cpp}` — `texture_pack` / `texture_dump` keys + env overrides.
 - `tools/decode_dump.py` — dump → PNG (+ contact sheet).
 - `tools/make_pack.py` — replacement files → `rt64.json`.

--- a/docs/TEXTURES.md
+++ b/docs/TEXTURES.md
@@ -3,7 +3,7 @@
 This is the end-to-end guide for creating native RT64 replacement packs for the port.
 Texture-pack support is content-agnostic: an HD-art pack, a readable-text pack, or a small
 one-texture experiment all use the same runtime facility, and the replacement artwork can
-live in a separate repository. Everything below was verified with a headless texture dump,
+live in a separate repository. Everything below was verified with a config-driven texture dump,
 an offline decode, a loose replacement directory, and a packaged `.rtz` loaded in-game.
 
 ## What RT64 already gives us (and what the port adds)
@@ -46,7 +46,7 @@ developer overlay. On success the log prints `[rt64] texture pack loaded: …` /
 ### 1. Dump
 
 ```bash
-# headless: no dev overlay needed
+# config-driven: no developer overlay needed (do not set LAMBO_HEADLESS=1)
 LAMBO_TEXTURE_DUMP=/path/to/dump  ./build/lamborghini_modern
 ```
 
@@ -59,7 +59,7 @@ Each unique texture writes `<hash>.v5.tmem`, `<hash>.v5.tile.json` (fmt/siz/dims
 plus `.rice.rdram` / `.rice.palette.rdram` for CI textures. These are **raw data, not
 images**.
 
-> The in-repo `tools/drive_input.py` drives the window headlessly (PostMessage + PrintWindow)
+> The in-repo `tools/drive_input.py` drives the window automatically (PostMessage + PrintWindow)
 > and is how the captures for this doc were produced. It matches SDL's `SDL_app` window
 > class, so an editor/browser with the repo open in a tab won't be captured by mistake.
 

--- a/tools/decode_dump.py
+++ b/tools/decode_dump.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Decode an RT64 texture dump into viewable PNGs (issue #9).
+"""Decode an RT64 texture dump into viewable PNGs.
 
 RT64's "Start dumping textures" (or this port's `texture_dump` config / LAMBO_TEXTURE_DUMP
 env) writes, per unique texture, a set of files named by the 64-bit texture hash:
@@ -12,9 +12,9 @@ env) writes, per unique texture, a set of files named by the 64-bit texture hash
     <hash>.v5.rice.palette.rdram  raw TLUT bytes, CI textures only -- the palette source
 
 Neither RT64 nor its texture_hasher/texture_packer tools turn these into an image, so you
-cannot *see* a texture to decide whether it is the hard-to-read text you want to replace.
-This tool does that decode, emitting <hash>.png per texture plus an index.html contact
-sheet for eyeballing the whole dump at once.
+cannot *see* a texture to decide whether it belongs in a replacement pack. This tool does
+that decode, emitting <hash>.png per texture plus an index.html contact sheet for eyeballing
+the whole dump at once.
 
 The PNG the tool emits is only for identification/upscaling reference -- the actual
 replacement texture is authored fresh at higher resolution, so a close-enough decode is

--- a/tools/decode_dump.py
+++ b/tools/decode_dump.py
@@ -16,9 +16,8 @@ cannot *see* a texture to decide whether it belongs in a replacement pack. This 
 that decode, emitting <hash>.png per texture plus an index.html contact sheet for eyeballing
 the whole dump at once.
 
-The PNG the tool emits is only for identification/upscaling reference -- the actual
-replacement texture is authored fresh at higher resolution, so a close-enough decode is
-fine. Byte-order/swizzle flags exist because the port hands RT64 its RDRAM in a
+The PNG the tool emits is a viewable reference for editing at native or higher resolution.
+Byte-order/swizzle flags exist because the port hands RT64 its RDRAM in a
 mupen/N64Recomp convention; calibrate once against an in-game screenshot, then leave the
 working flags as the defaults.
 

--- a/tools/make_pack.py
+++ b/tools/make_pack.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate an RT64 texture-pack manifest (rt64.json) from replacement images (issue #9).
+"""Generate an RT64 texture-pack manifest (rt64.json) from replacement images.
 
 RT64 loads a texture pack by reading rt64.json from the pack directory (or .rtz) -- it
 does NOT auto-scan for hash-named files. RT64's own `texture_hasher` only *upgrades* an


### PR DESCRIPTION
## Why

Generic texture replacement is already present on `main` via commit `5746fe7`: RT64 dump capture, loose-directory/`.rtz` loading, config and environment overrides, dump decoding, and manifest generation.

PRs #66 and #99 are pack-authoring experiments for issue #52, not runtime texture-pack support. This PR makes that boundary explicit so readable text and other replacement artwork can be developed and distributed as independent packs.

## What

- documents `texture_pack` and `texture_dump` in the README
- adds a short install/dump workflow and links the complete author guide
- rewrites the texture guide around arbitrary replacement art instead of readable text
- explains that this port consumes native RT64 directories/`.rtz`, not `.o2r` or legacy Rice packs
- documents the verified `shift: half` versus grid-aligned `shift: none` distinction
- removes issue/text-specific wording from the generic dump and manifest tools

No replacement textures, font renderers, upscalers, or game-derived assets are included.

## Verification

- `git diff --check`
- `python -m py_compile tools/decode_dump.py tools/make_pack.py`
- `python -m unittest test_decode_dump.py` (from `tools/`; 7 tests pass)
- `python tools/make_pack.py --help`

Refs #9 and #52. Review context: #66 and #99.