### PR TITLE
Prevent non-finite RT64 car-part interpolation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,21 @@ if(BUILD_TESTING)
     )
     add_test(NAME lambo_camera_projection_policy COMMAND lambo_camera_projection_tests)
 
+    add_executable(lambo_rt64_angular_velocity_tests
+        tests/test_rt64_angular_velocity.cpp
+        lib/rt64/src/hle/rt64_rigid_body.cpp
+        lib/rt64/src/common/rt64_math.cpp
+    )
+    target_include_directories(lambo_rt64_angular_velocity_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/rt64/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/rt64/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/rt64/src/contrib/hlslpp/include
+    )
+    if(WIN32)
+        target_compile_definitions(lambo_rt64_angular_velocity_tests PRIVATE NOMINMAX)
+    endif()
+    add_test(NAME lambo_rt64_angular_velocity_finite COMMAND lambo_rt64_angular_velocity_tests)
+
     add_executable(lambo_controller_pak_tests
         tests/test_controller_pak.c
         src/libultra_stubs.c

--- a/patches/0006-rt64-interp-angular-velocity-matching.patch
+++ b/patches/0006-rt64-interp-angular-velocity-matching.patch
@@ -1,5 +1,5 @@
 diff --git a/src/hle/rt64_game_frame.cpp b/src/hle/rt64_game_frame.cpp
-index 87392d0..936f488 100644
+index 87392d0..99b9078 100644
 --- a/src/hle/rt64_game_frame.cpp
 +++ b/src/hle/rt64_game_frame.cpp
 @@ -2,6 +2,12 @@
@@ -15,7 +15,7 @@ index 87392d0..936f488 100644
  #include "common/rt64_math.h"
  
  #include "rt64_game_frame.h"
-@@ -236,11 +242,22 @@ namespace RT64 {
+@@ -236,11 +242,25 @@ namespace RT64 {
          matchResult.positionDifference = hlslpp::length(curPos - prevPos);
  
          // Compute the dot product difference between the normalized XYZ vectors of the 3x3 matrices.
@@ -30,7 +30,10 @@ index 87392d0..936f488 100644
 +        // Raw comparison makes fast-spinning meshes (car wheels) prefer a phase-aliased sibling over
 +        // their own previous transform, locking interpolation into a front/rear wheel swap.
 +        float expectedOrientationDifference = 0.0f;
-+        if (prevRigidBody != nullptr) {
++        if ((prevRigidBody != nullptr) && (!prevRigidBody->angularVelocityValid || !std::isfinite(prevRigidBody->angularVelocity))) {
++            return matchResult;
++        }
++        else if (prevRigidBody != nullptr) {
 +            expectedOrientationDifference = 2.0f * (1.0f - std::cos(prevRigidBody->angularVelocity));
 +        }
 +
@@ -39,7 +42,21 @@ index 87392d0..936f488 100644
          // Compute the difference between the screen-space position of both transforms on their respective projections.
          hlslpp::float4 prevScreenPos = hlslpp::mul(prevTransform[3], prevViewProj);
          hlslpp::float4 curScreenPos = hlslpp::mul(curTransform[3], curViewProj);
-@@ -606,6 +623,93 @@ namespace RT64 {
+@@ -248,7 +268,12 @@ namespace RT64 {
+         curScreenPos = (fabs(curScreenPos.w) < 1e-6f) ? curScreenPos : curScreenPos / curScreenPos.w;
+         matchResult.screenSpaceDifference = hlslpp::length(curScreenPos.xyz - prevScreenPos.xyz);
+         
+-        matchResult.valid = true;
++        // A non-finite score violates the strict weak ordering required by stable_sort and can make
++        // an unrelated car part win this anonymous transform match. Transitional or degenerate
++        // matrices are safer left unmatched for one frame than interpolated from the wrong object.
++        matchResult.valid = std::isfinite(matchResult.positionDifference) &&
++            std::isfinite(matchResult.orientationDifference) &&
++            std::isfinite(matchResult.screenSpaceDifference);
+         return matchResult;
+     }
+ 
+@@ -606,6 +631,93 @@ namespace RT64 {
              matchTransform(firstCurWorkload, firstPrevWorkload, firstCurWorkloadMap, firstPrevWorkloadMap, candidate.curIndex, candidate.prevIndex, modifiedBuffers);
          }
  
@@ -133,3 +150,52 @@ index 87392d0..936f488 100644
          if (!modifiedBuffers.empty()) {
              workloadsModified[firstCurProjIndices.workloadIndex].merge(modifiedBuffers);
          }
+diff --git a/src/hle/rt64_rigid_body.cpp b/src/hle/rt64_rigid_body.cpp
+index fd8b3eb..940823a 100644
+--- a/src/hle/rt64_rigid_body.cpp
++++ b/src/hle/rt64_rigid_body.cpp
+@@ -2,6 +2,9 @@
+ // RT64
+ //
+ 
++#include <algorithm>
++#include <cmath>
++
+ #include "rt64_rigid_body.h"
+ 
+ #include "../include/rt64_extended_gbi.h"
+@@ -48,9 +51,11 @@ namespace RT64 {
+             // Track angular velocity.
+             const hlslpp::float3x3 invPrevRotation = hlslpp::inverse(rotationFrom3x3(extract3x3(prevTransform)));
+             const hlslpp::float3x3 diffRotation = hlslpp::mul(invPrevRotation, rotationFrom3x3(extract3x3(curTransform)));
+-            float diffTrace = traceFrom3x3(diffRotation);
+-            float curAngularVelocity = std::acos((diffTrace - 1.0f) / 2.0f);
+-            angularVelocity = curAngularVelocity;
++            const float diffTrace = traceFrom3x3(diffRotation);
++            const float angularCosine = (diffTrace - 1.0f) / 2.0f;
++            angularVelocityValid = std::isfinite(angularCosine);
++            angularVelocity = angularVelocityValid
++                ? std::acos(std::clamp(angularCosine, -1.0f, 1.0f)) : 0.0f;
+ 
+             // FIXME: Defaults to always interpolate.
+             lerpRotation = true;
+@@ -67,6 +72,7 @@ namespace RT64 {
+         else {
+             lerpRotation = (rotInterpolation == G_EX_COMPONENT_INTERPOLATE);
+             angularVelocity = 0.0f;
++            angularVelocityValid = true;
+         }
+     }
+ 
+diff --git a/src/hle/rt64_rigid_body.h b/src/hle/rt64_rigid_body.h
+index 778e08b..3112abe 100644
+--- a/src/hle/rt64_rigid_body.h
++++ b/src/hle/rt64_rigid_body.h
+@@ -12,6 +12,7 @@ namespace RT64 {
+         DecomposedTransform transforms[2];
+         hlslpp::float3 linearVelocity = {};
+         float angularVelocity = 0.0f;
++        bool angularVelocityValid = true;
+         uint8_t transformIndex = 0;
+         bool lerpTranslation = false;
+         bool lerpRotation = false;

--- a/tests/test_rt64_angular_velocity.cpp
+++ b/tests/test_rt64_angular_velocity.cpp
@@ -1,0 +1,77 @@
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+
+#include "hle/rt64_rigid_body.h"
+#include "rt64_extended_gbi.h"
+
+namespace {
+
+void expect_finite(float value, const char* context) {
+    if (!std::isfinite(value)) {
+        std::cerr << "FAIL: " << context << " produced a non-finite angular velocity\n";
+        std::exit(1);
+    }
+}
+
+void expect_near(float actual, float expected, float tolerance, const char* context) {
+    if (std::abs(actual - expected) > tolerance) {
+        std::cerr << "FAIL: " << context << " expected " << expected << ", got " << actual << '\n';
+        std::exit(1);
+    }
+}
+
+hlslpp::float4x4 flat_transform(int zero_axis) {
+    hlslpp::float4x4 transform = hlslpp::float4x4::identity();
+    transform[zero_axis][0] = 0.0f;
+    transform[zero_axis][1] = 0.0f;
+    transform[zero_axis][2] = 0.0f;
+    return transform;
+}
+
+} // namespace
+
+int main() {
+    // Lamborghini's car-part matrices can be singular (the live matcher reports
+    // determinant zero). RT64 normalizes and inverts their 3x3 basis while deriving
+    // angular velocity. Before the fix, each of these cases stores NaN, which then
+    // reaches the transform candidate score and invalidates stable_sort's ordering.
+    for (int zero_axis = 0; zero_axis < 3; zero_axis++) {
+        const hlslpp::float4x4 transform = flat_transform(zero_axis);
+        RT64::RigidBody body;
+        body.updateAngular(transform, transform, G_EX_COMPONENT_AUTO,
+            G_EX_COMPONENT_AUTO, G_EX_COMPONENT_AUTO);
+        expect_finite(body.angularVelocity, "singular car-part transform");
+        if (body.angularVelocityValid) {
+            std::cerr << "FAIL: singular car-part transform was marked measurable\n";
+            return 1;
+        }
+    }
+
+    RT64::RigidBody ordinary;
+    const hlslpp::float4x4 identity = hlslpp::float4x4::identity();
+    ordinary.updateAngular(identity, identity, G_EX_COMPONENT_AUTO,
+        G_EX_COMPONENT_AUTO, G_EX_COMPONENT_AUTO);
+    expect_finite(ordinary.angularVelocity, "identity transform");
+    if (!ordinary.angularVelocityValid) {
+        std::cerr << "FAIL: identity transform was marked unmeasurable\n";
+        return 1;
+    }
+
+    hlslpp::float4x4 quarter_turn = identity;
+    quarter_turn[0][0] = 0.0f;
+    quarter_turn[0][2] = 1.0f;
+    quarter_turn[2][0] = -1.0f;
+    quarter_turn[2][2] = 0.0f;
+    RT64::RigidBody rotating;
+    rotating.updateAngular(identity, quarter_turn, G_EX_COMPONENT_AUTO,
+        G_EX_COMPONENT_AUTO, G_EX_COMPONENT_AUTO);
+    if (!rotating.angularVelocityValid) {
+        std::cerr << "FAIL: ordinary rotation was marked unmeasurable\n";
+        return 1;
+    }
+    expect_near(rotating.angularVelocity, std::acos(0.0f), 1e-5f, "quarter-turn rotation");
+
+    std::cout << "RT64 angular velocity remains finite\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- keep RT64 angular velocity finite while recording whether the estimate is measurable
- refuse anonymous transform matches with invalid/non-finite history before they reach stable_sort
- add focused singular, identity, and quarter-turn angular-velocity regression coverage

## Root cause
At race start, some car-part transforms briefly have a degenerate basis. RT64 inverted that basis and passed the resulting NaN through acos into the anonymous transform-match score. A NaN score violates stable_sort's ordering contract, allowing a wheel or larger car piece to inherit another transform's prior pose and visibly swivel, detach, or skip ahead.

This is a downstream RT64 patch and is not intended as an upstream RT64 submission.

## Validation
- clean build.ps1 patch/apply and game build
- 17/17 project CTest tests pass
- regression covers three singular axes, identity, and a normal 90-degree rotation
- 12 live race starts across six circuits and two car selections: zero split five-part car groups, zero large part displacements
- RT64 zstd fullbench passed; its standalone unbounded fuzzer was stopped after several error-free minutes

Refs #51 (addresses one matcher failure mode; does not close the broader actor-tagging work).