### PR TITLE
Document ROM-owned leaderboard insertion and add regression coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,6 @@ if(BUILD_TESTING)
     add_executable(lambo_config_tests
         tests/test_live_config.cpp
         src/lambo_config.cpp
-        src/lambo_player_name.cpp
         src/lambo_log.cpp
     )
     target_include_directories(lambo_config_tests PRIVATE
@@ -68,6 +67,21 @@ if(BUILD_TESTING)
     )
     target_link_libraries(lambo_log_tests PRIVATE Threads::Threads)
     add_test(NAME lambo_logging_policy COMMAND lambo_log_tests)
+
+    add_executable(lambo_player_name_tests
+        tests/test_player_name.cpp
+        src/lambo_player_name.cpp
+        src/lambo_config.cpp
+        src/lambo_log.cpp
+    )
+    target_include_directories(lambo_player_name_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${N64MR}/ultramodern/include
+        ${N64MR}/N64Recomp/include
+        ${N64MR}/thirdparty
+    )
+    target_link_libraries(lambo_player_name_tests PRIVATE Threads::Threads)
+    add_test(NAME lambo_player_name_persistence COMMAND lambo_player_name_tests)
 
     add_executable(lambo_camera_projection_tests
         tests/test_camera_projection.cpp

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -1141,10 +1141,12 @@ text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gp
 
 # Remember player one's name across launches. The name editor owns four one-based,
 # 13-byte buffers at 0x800A4819 + driver*13 (12 chars + NUL); player one is therefore
-# 0x800A4826. The setup hook runs after the screen selects its driver but before the
-# ROM scans the buffer to calculate its length, so a saved name is immediately reflected
-# by both the text and cursor. The Done hook captures the final buffer before the ROM
-# advances to the next player / pak flow. Native persistence is in player.json via
+# 0x800A4826. The ROM's result insertion at 0x8003F8E8 copies 13 bytes from this buffer
+# to 0x800A4160 + 0x402 + (rank * 14), updating only the earned leaderboard row. The
+# setup hook runs after the screen selects its driver but before the ROM scans the buffer
+# to calculate its length, so a saved name is immediately reflected by both the text and
+# cursor and is available to that insertion path. The Done hook captures the final buffer
+# before the ROM advances to the next player / pak flow. Native persistence is in player.json via
 # lambo_player_name.cpp, separate from the main-thread-owned graphics configuration.
 [[patches.hook]]
 func = "func_8003CD84"

--- a/src/lambo_player_name.cpp
+++ b/src/lambo_player_name.cpp
@@ -1,5 +1,6 @@
 #include "lambo_player_name.h"
 
+#include <cstddef>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -15,15 +16,19 @@ namespace {
 // Verified against the ROM's name editor (func_8003CD84 setup and the append /
 // delete helpers at 0x8003F3C0-0x8003F4E8). Driver indices are one-based and
 // each name occupies 13 bytes: up to 12 keyboard characters plus a NUL.
+// The ROM's result insertion at 0x8003F8E8 copies 13 bytes from these buffers
+// into only the leaderboard row earned by that driver.
 constexpr uint32_t kCurrentDriverAddr = 0x800CE6A6u;
 constexpr uint32_t kDriverNamesBase = 0x800A4819u;
 constexpr int kPlayerOne = 1;
-constexpr int kNameStride = 13;
-constexpr int kMaxNameLength = 12;
+constexpr std::size_t kNameStride = 13;
+constexpr std::size_t kMaxNameLength = kNameStride - 1;
 constexpr const char* kPlayerConfigFile = "player.json";
 
 gpr name_addr(int driver) {
-    return (gpr)(int32_t)(kDriverNamesBase + uint32_t(driver * kNameStride));
+    return (gpr)(int32_t)(kDriverNamesBase +
+                          static_cast<uint32_t>(driver) *
+                              static_cast<uint32_t>(kNameStride));
 }
 
 bool valid_name(const std::string& name) {
@@ -96,6 +101,23 @@ int current_driver(uint8_t* rdram) {
     return (int16_t)MEM_H(0, (gpr)(int32_t)kCurrentDriverAddr);
 }
 
+std::string read_name(uint8_t* rdram, gpr src) {
+    std::string name;
+    for (std::size_t i = 0; i < kMaxNameLength; ++i) {
+        const unsigned char ch = MEM_BU(i, src);
+        if (ch == 0) break;
+        name.push_back(static_cast<char>(ch));
+    }
+    return name;
+}
+
+void write_name(uint8_t* rdram, gpr dst, const std::string& name) {
+    for (std::size_t i = 0; i < kNameStride; ++i) {
+        const bool has_character = i < kMaxNameLength && i < name.size();
+        MEM_B(i, dst) = has_character ? static_cast<unsigned char>(name[i]) : 0;
+    }
+}
+
 } // namespace
 
 extern "C" void lambo_player_name_seed(uint8_t* rdram) {
@@ -104,23 +126,14 @@ extern "C" void lambo_player_name_seed(uint8_t* rdram) {
     const std::string saved = load_saved_name();
     if (!valid_name(saved)) return;
 
-    const gpr dst = name_addr(kPlayerOne);
-    for (int i = 0; i < kNameStride; ++i) {
-        MEM_B(i, dst) = i < (int)saved.size() ? saved[(size_t)i] : 0;
-    }
+    write_name(rdram, name_addr(kPlayerOne), saved);
     LAMBO_LOG_INFO("name", "seeded player name: %s\n", saved.c_str());
 }
 
 extern "C" void lambo_player_name_save(uint8_t* rdram) {
     if (current_driver(rdram) != kPlayerOne) return;
 
-    const gpr src = name_addr(kPlayerOne);
-    std::string name;
-    for (int i = 0; i < kMaxNameLength; ++i) {
-        const unsigned char ch = MEM_BU(i, src);
-        if (ch == 0) break;
-        name.push_back((char)ch);
-    }
+    const std::string name = read_name(rdram, name_addr(kPlayerOne));
     if (!valid_name(name)) return;
 
     save_name(name);

--- a/tests/test_live_config.cpp
+++ b/tests/test_live_config.cpp
@@ -3,12 +3,9 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
-#include <vector>
 
 #include "json/json.hpp"
 #include "lambo_config.h"
-#include "lambo_player_name.h"
-#include "recomp.h"
 
 namespace {
 
@@ -46,13 +43,10 @@ int main() {
     const auto dir = std::filesystem::temp_directory_path() /
                      ("lambo-config-test-" + std::to_string(unique));
     const auto path = dir / "graphics.json";
-    const auto player_path = dir / "player.json";
 #if defined(_WIN32)
     _putenv_s("LAMBO_GRAPHICS_CONFIG", path.string().c_str());
-    _putenv_s("LAMBO_PLAYER_CONFIG", player_path.string().c_str());
 #else
     setenv("LAMBO_GRAPHICS_CONFIG", path.string().c_str(), 1);
-    setenv("LAMBO_PLAYER_CONFIG", player_path.string().c_str(), 1);
 #endif
 
     auto cfg = lambo::config::load_and_apply_graphics();
@@ -146,26 +140,6 @@ int main() {
     lambo::config::flush_pending_graphics_updates();
     expect(lambo::config::show_launcher() == true, "show_launcher toggle updates snapshot");
     expect(read_json(path).at("show_launcher") == true, "show_launcher persists to json");
-
-    std::vector<uint8_t> memory(0x800000);
-    uint8_t* rdram = memory.data();
-    const gpr driver_index = (gpr)(int32_t)0x800CE6A6u;
-    const gpr player_one_name = (gpr)(int32_t)0x800A4826u;
-    MEM_H(0, driver_index) = 1;
-    const std::string edited = "CHAMP";
-    for (int i = 0; i < 13; ++i) {
-        MEM_B(i, player_one_name) = i < (int)edited.size() ? edited[(size_t)i] : 0;
-    }
-    lambo_player_name_save(rdram);
-    expect(read_json(player_path).at("name") == edited, "confirmed ROM name persists");
-
-    for (int i = 0; i < 13; ++i) MEM_B(i, player_one_name) = 0;
-    lambo_player_name_seed(rdram);
-    std::string seeded;
-    for (int i = 0; i < 13 && MEM_BU(i, player_one_name) != 0; ++i) {
-        seeded.push_back((char)MEM_BU(i, player_one_name));
-    }
-    expect(seeded == edited, "next run seeds the persisted name into the ROM buffer");
 
     std::error_code ec;
     std::filesystem::remove_all(dir, ec);

--- a/tests/test_player_name.cpp
+++ b/tests/test_player_name.cpp
@@ -1,0 +1,158 @@
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "json/json.hpp"
+#include "lambo_config.h"
+#include "lambo_player_name.h"
+#include "recomp.h"
+
+namespace {
+
+constexpr uint32_t kCurrentDriverAddress = 0x800CE6A6u;
+constexpr uint32_t kPlayerOneNameAddress = 0x800A4826u;
+constexpr uint32_t kRecordsProfileAddress = 0x800A4160u;
+constexpr std::size_t kNameBufferSize = 13;
+constexpr std::size_t kRecordsProfileSize = 12;
+constexpr std::size_t kRecordsTableOffset = 0x402;
+constexpr std::size_t kLeaderboardNameStride = 14;
+constexpr std::size_t kLeaderboardNameSlots = 5;
+
+int failures = 0;
+
+void expect(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+nlohmann::json read_json(const std::filesystem::path& path) {
+    std::ifstream in(path);
+    nlohmann::json result;
+    in >> result;
+    return result;
+}
+
+void write_guest_bytes(uint8_t* rdram, gpr address, const std::string& text,
+                       std::size_t size) {
+    for (std::size_t i = 0; i < size; ++i) {
+        MEM_B(i, address) =
+            i < text.size() ? static_cast<unsigned char>(text[i]) : 0;
+    }
+}
+
+std::string read_guest_string(uint8_t* rdram, gpr address, std::size_t max_length) {
+    std::string result;
+    for (std::size_t i = 0; i < max_length; ++i) {
+        const unsigned char ch = MEM_BU(i, address);
+        if (ch == 0) break;
+        result.push_back(static_cast<char>(ch));
+    }
+    return result;
+}
+
+std::vector<uint8_t> read_guest_bytes(uint8_t* rdram, gpr address,
+                                      std::size_t size) {
+    std::vector<uint8_t> result;
+    result.reserve(size);
+    for (std::size_t i = 0; i < size; ++i) {
+        result.push_back(MEM_BU(i, address));
+    }
+    return result;
+}
+
+} // namespace
+
+// lambo_player_name.cpp uses the config module only for its default config path.
+// The player-name test overrides that path with LAMBO_PLAYER_CONFIG, but still
+// links lambo_config.cpp for the production dependency.
+namespace ultramodern::renderer {
+void set_graphics_config(const GraphicsConfig&) {}
+}
+
+int main() {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto dir = std::filesystem::temp_directory_path() /
+                     ("lambo-player-name-test-" + std::to_string(unique));
+    const auto player_path = dir / "player.json";
+#if defined(_WIN32)
+    _putenv_s("LAMBO_PLAYER_CONFIG", player_path.string().c_str());
+#else
+    setenv("LAMBO_PLAYER_CONFIG", player_path.string().c_str(), 1);
+#endif
+
+    std::vector<uint8_t> memory(0x800000);
+    uint8_t* rdram = memory.data();
+    const gpr driver_index = (gpr)(int32_t)kCurrentDriverAddress;
+    const gpr player_one_name = (gpr)(int32_t)kPlayerOneNameAddress;
+    const gpr records_profile = (gpr)(int32_t)kRecordsProfileAddress;
+    const gpr high_score_names = records_profile +
+                                 static_cast<gpr>(kRecordsTableOffset);
+
+    MEM_H(0, driver_index) = 1;
+    const std::string edited = "CHAMP";
+    write_guest_bytes(rdram, player_one_name, edited, kNameBufferSize);
+    write_guest_bytes(rdram, records_profile, "TITUS LAM64", kRecordsProfileSize);
+    for (std::size_t slot = 0; slot < kLeaderboardNameSlots; ++slot) {
+        write_guest_bytes(rdram, high_score_names +
+                                      static_cast<gpr>(slot * kLeaderboardNameStride),
+                          "TITUS" + std::to_string(slot),
+                          kLeaderboardNameStride);
+    }
+    const auto original_profile =
+        read_guest_bytes(rdram, records_profile, kRecordsProfileSize);
+    const auto original_high_scores = read_guest_bytes(
+        rdram, high_score_names, kLeaderboardNameSlots * kLeaderboardNameStride);
+
+    lambo_player_name_save(rdram);
+    expect(read_json(player_path).at("name") == edited,
+           "confirmed ROM name persists");
+    expect(read_guest_bytes(rdram, records_profile, kRecordsProfileSize) ==
+               original_profile,
+           "saving a name does not overwrite the records profile");
+    expect(read_guest_bytes(rdram, high_score_names,
+                            kLeaderboardNameSlots * kLeaderboardNameStride) ==
+               original_high_scores,
+           "saving a name does not overwrite any leaderboard row");
+
+    write_guest_bytes(rdram, player_one_name, std::string{}, kNameBufferSize);
+    lambo_player_name_seed(rdram);
+    expect(read_guest_string(rdram, player_one_name, kNameBufferSize) == edited,
+           "next run seeds the persisted name into the ROM buffer");
+    expect(read_guest_bytes(rdram, records_profile, kRecordsProfileSize) ==
+               original_profile,
+           "seeding a name does not overwrite the records profile");
+    expect(read_guest_bytes(rdram, high_score_names,
+                            kLeaderboardNameSlots * kLeaderboardNameStride) ==
+               original_high_scores,
+           "seeding a name does not overwrite any leaderboard row");
+
+    const std::string max_length_name = "ABCDEFGHIJKL";
+    write_guest_bytes(rdram, player_one_name, max_length_name, kNameBufferSize);
+    lambo_player_name_save(rdram);
+    expect(read_json(player_path).at("name") == max_length_name,
+           "the ROM's 12-character name limit persists");
+    for (std::size_t i = 0; i < kNameBufferSize; ++i) {
+        MEM_B(i, player_one_name) = static_cast<int8_t>(0xCC);
+    }
+    MEM_B(kNameBufferSize, player_one_name) = static_cast<int8_t>(0xA5);
+    lambo_player_name_seed(rdram);
+    expect(read_guest_string(rdram, player_one_name, kNameBufferSize) ==
+               max_length_name,
+           "a 12-character name is seeded intact");
+    expect(MEM_BU(kNameBufferSize - 1, player_one_name) == 0,
+           "a 12-character name is NUL-terminated inside its 13-byte buffer");
+    expect(MEM_BU(kNameBufferSize, player_one_name) == 0xA5,
+           "seeding a maximum-length name does not cross the buffer boundary");
+
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
This PR documents and tests the ROM-owned leaderboard insertion path. It does not fix issue #170 or change the records/high-score data that the ROM owns.

## Scope

At `0x8003F8E8`, the ROM copies 13 bytes from the qualifying driver's name buffer (`0x800A4160 + 0x6C6 + driver*13`) into only the earned leaderboard row (`0x800A4160 + 0x402 + rank*14`). For Player 1, the source is `0x800A4826`, which the existing persistence hook seeds.

The native seed/save path therefore remains scoped to the player-one editor buffer. It does not write the records profile or pre-populate any leaderboard row.

The code cleanup adds symmetric bounded name read/write helpers, guarantees the final byte of the 13-byte buffer is NUL, and moves player-name coverage into `tests/test_player_name.cpp`. The dedicated regression test verifies that saving and seeding leave the records profile and all five leaderboard rows unchanged, and that a 12-character name cannot cross its buffer boundary.

## Verification

- Both focused test executables compile and pass with the pinned C++20 runtime headers.
- `git diff --check` is clean.
- Full CMake configure was attempted but is blocked on this Windows environment's MSYS2 CMake/Ninja path translation before project generation; this is separate from the source and focused-test checks above.

## Issue #170

Issue #170 remains open. The reported season-end symptom still needs an end-to-end reproduction or watchpoint trace through the qualification/insertion path before a production fix is justified.