### PR TITLE
Refactor graphics menu persistence and updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ cmake_minimum_required(VERSION 3.20)
 project(lamborghini_modern VERSION 0.5.0 LANGUAGES C CXX)
 
 include(CTest)
+find_package(Threads REQUIRED)
 
 set(CMAKE_C_STANDARD 17)
 set(CMAKE_CXX_STANDARD 20)
@@ -234,6 +235,23 @@ if(WIN32)
     set(FREETYPE_LIBRARY ${LAMBO_FREETYPE_ROOT}/lib/x64/freetype.lib CACHE FILEPATH "" FORCE)
     set(FREETYPE_LIBRARY_RELEASE ${LAMBO_FREETYPE_ROOT}/lib/x64/freetype.lib CACHE FILEPATH "" FORCE)
 endif()
+
+# lambo_config.cpp coalesces menu persistence on a portable std::thread. Keep
+# every executable that compiles it explicitly linked to the platform thread
+# implementation; relying on a transitive SDL/runtime dependency breaks test
+# targets and older Linux toolchains.
+foreach(lambo_config_thread_target
+        lambo_config_tests
+        lambo_controls_tests
+        lambo_controls_capture_tests
+        lambo_ui_controls_tests
+        lambo_ui_settings_tests
+        lambo_controls_sdl_tests
+        lamborghini_modern)
+    if(TARGET ${lambo_config_thread_target})
+        target_link_libraries(${lambo_config_thread_target} PRIVATE Threads::Threads)
+    endif()
+endforeach()
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/lib/RmlUi/CMakeLists.txt)
     message(FATAL_ERROR "lib/RmlUi submodule is missing. Initialise it first:\n"
         "  git submodule update --init --recursive")
@@ -334,6 +352,7 @@ if(BUILD_TESTING)
     else()
         target_link_libraries(lambo_controls_sdl_tests PRIVATE ${SDL2_LIBRARIES})
     endif()
+    target_link_libraries(lambo_controls_sdl_tests PRIVATE Threads::Threads)
     add_test(NAME lambo_controls_sdl_registry COMMAND lambo_controls_sdl_tests)
 endif()
 
@@ -461,6 +480,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
     target_link_libraries(lamborghini_modern PRIVATE
         librecomp
         ultramodern
+        Threads::Threads
     )
     if(TARGET RecompiledFuncs)
         target_link_libraries(lamborghini_modern PRIVATE RecompiledFuncs)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ N64Recomp ports (Zelda 64: Recompiled et al.):
 | `hpfb_option` | `Auto`, `On`, `Off` | `Auto` | High-precision framebuffer. |
 | `wm_option` | `Windowed`, `Fullscreen` | `Windowed` | Window mode. **F11** or **Alt+Enter** toggles at runtime (and is remembered). |
 | `window_width` / `window_height` | pixels | `1600`/`900` | Windowed-mode size. |
-| `api_option` | `Auto`, `D3D12`, `Vulkan`, `Metal` | `Auto` | Graphics API. |
+| `api_option` | `Auto`, `D3D12`, `Vulkan`, `Metal` | `Auto` | Graphics API; takes effect on the next launch. |
 | `texture_pack` | path to a directory or `.rtz` | `""` | Loads one native RT64 texture pack at startup. An empty value keeps the original textures. |
 | `texture_dump` | directory path | `""` | Dumps each texture used during play as RT64 TMEM/RDRAM data for pack authors. |
 | `widescreen_fog_match` | `true`, `false` | `true` | Widens the dense 3P/4P split-screen fog to the open 1P fog window/colour so the extra draw distance shows. Only affects 3+ player races. |

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -8,9 +8,12 @@
 
 #include <array>
 #include <atomic>
+#include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <mutex>
+#include <thread>
 
 #include "lambo_log.h"
 
@@ -32,6 +35,8 @@ lambo::config::WindowSize g_window_size{kDefaultWindowWidth, kDefaultWindowHeigh
 // keys alongside the GraphicsConfig fields (like the window size). Empty = feature off.
 std::string g_texture_pack;
 std::string g_texture_dump;
+std::mutex g_texture_mutex;
+std::mutex g_graphics_file_mutex;
 
 // Widen the dense 3P/4P split-screen fog to the open 1P window/colour (issue #83).
 // Enhancement default-on, consistent with the widescreen wave; 1P/2P are unaffected
@@ -77,6 +82,11 @@ std::atomic<double> g_camera_fov_add{0.0};
 // runtime's reference-returning getter while another thread may be applying a change.
 ultramodern::renderer::GraphicsConfig g_current_graphics{};
 
+// The renderer's API is selected when it is constructed. Keep its last applied
+// API separately so a later live-safe setting cannot smuggle a persisted,
+// restart-only API choice into RT64's update queue.
+ultramodern::renderer::GraphicsConfig g_live_graphics{};
+
 // Read a key into `out`, keeping the existing (default) value when the key is
 // missing or invalid. NLOHMANN_JSON_SERIALIZE_ENUM does NOT throw on an
 // unrecognised string -- it silently maps it to the FIRST enumerator, which for
@@ -100,7 +110,7 @@ void from_or_default(const nlohmann::json& j, const char* key, T& out) {
     }
 }
 
-nlohmann::json to_json(const ultramodern::renderer::GraphicsConfig& c) {
+nlohmann::json graphics_config_json(const ultramodern::renderer::GraphicsConfig& c) {
     return nlohmann::json{
         {"res_option", c.res_option},
         {"wm_option", c.wm_option},
@@ -113,6 +123,13 @@ nlohmann::json to_json(const ultramodern::renderer::GraphicsConfig& c) {
         {"rr_manual_value", c.rr_manual_value},
         {"ds_option", c.ds_option},
         {"developer_mode", c.developer_mode},
+    };
+}
+
+nlohmann::json to_json(const ultramodern::renderer::GraphicsConfig& c) {
+    std::lock_guard<std::mutex> lock(g_texture_mutex);
+    nlohmann::json result = graphics_config_json(c);
+    result.update({
         {"window_width", g_window_size.width},
         {"window_height", g_window_size.height},
         {"texture_pack", g_texture_pack},
@@ -132,10 +149,12 @@ nlohmann::json to_json(const ultramodern::renderer::GraphicsConfig& c) {
         {"camera_height_scale", g_camera_height_scale.load()},
         {"camera_fov_add", g_camera_fov_add.load()},
         {"show_launcher", g_show_launcher.load()},
-    };
+    });
+    return result;
 }
 
 void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c) {
+    std::lock_guard<std::mutex> lock(g_texture_mutex);
     from_or_default(j, "res_option", c.res_option);
     from_or_default(j, "wm_option", c.wm_option);
     from_or_default(j, "hr_option", c.hr_option);
@@ -228,6 +247,122 @@ std::filesystem::path graphics_json_path() {
     return lambo::config::app_config_dir() / kGraphicsFile;
 }
 
+bool write_graphics_json(const std::filesystem::path& path, const nlohmann::json& json) {
+    std::error_code ec;
+    std::filesystem::create_directories(path.parent_path(), ec);
+    std::ofstream out{path};
+    if (!out.good()) {
+        LAMBO_LOG("config", "cannot write %s\n", path.string().c_str());
+        return false;
+    }
+    out << json.dump(4) << "\n";
+    out.flush();
+    if (!out.good()) {
+        LAMBO_LOG("config", "write to %s FAILED (disk full / permissions?)"
+                            " -- settings may not persist\n", path.string().c_str());
+        return false;
+    }
+    return true;
+}
+
+// Merge a narrow update over the current file so menu interaction never removes
+// hand-edited or forward-compatible graphics.json keys. A malformed file is left
+// untouched so it remains recoverable by the user.
+void save_graphics_updates_sync(const nlohmann::json& updates) {
+    if (updates.empty()) return;
+    std::lock_guard<std::mutex> file_lock(g_graphics_file_mutex);
+    const std::filesystem::path path = graphics_json_path();
+    nlohmann::json current;
+    std::ifstream in{path};
+    if (!in.good()) {
+        // Startup creates a complete file synchronously. If it is removed while
+        // the game is running, write the requested delta rather than reading the
+        // main-thread snapshot from this worker thread.
+        current = nlohmann::json::object();
+    } else {
+        try {
+            in >> current;
+            if (!current.is_object()) {
+                LAMBO_LOG("config", "%s is not a JSON object; leaving it untouched\n",
+                          path.string().c_str());
+                return;
+            }
+        } catch (const nlohmann::json::exception& e) {
+            LAMBO_LOG("config", "%s unparseable (%s); leaving it untouched\n",
+                      path.string().c_str(), e.what());
+            return;
+        }
+    }
+    current.update(updates);
+    write_graphics_json(path, current);
+}
+
+class GraphicsUpdateWriter {
+public:
+    GraphicsUpdateWriter() : worker_([this] { run(); }) {}
+
+    ~GraphicsUpdateWriter() {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            stopping_ = true;
+        }
+        wake_.notify_one();
+        worker_.join();
+    }
+
+    void enqueue(const nlohmann::json& updates) {
+        if (updates.empty()) return;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            pending_.update(updates);
+        }
+        wake_.notify_one();
+    }
+
+    void flush() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        wake_.notify_one();
+        drained_.wait(lock, [this] { return pending_.empty() && !writing_; });
+    }
+
+private:
+    void run() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        for (;;) {
+            wake_.wait(lock, [this] { return stopping_ || !pending_.empty(); });
+            if (stopping_ && pending_.empty()) break;
+            nlohmann::json updates = std::move(pending_);
+            pending_ = nlohmann::json::object();
+            writing_ = true;
+            lock.unlock();
+            save_graphics_updates_sync(updates);
+            lock.lock();
+            writing_ = false;
+            drained_.notify_all();
+        }
+        drained_.notify_all();
+    }
+
+    std::mutex mutex_;
+    std::condition_variable wake_;
+    std::condition_variable drained_;
+    nlohmann::json pending_ = nlohmann::json::object();
+    bool writing_ = false;
+    bool stopping_ = false;
+    std::thread worker_;
+};
+
+GraphicsUpdateWriter& graphics_update_writer() {
+    // Function-local lifetime ensures the worker is created only after startup has
+    // configured the graphics snapshot and is joined during ordinary process exit.
+    static GraphicsUpdateWriter writer;
+    return writer;
+}
+
+void save_graphics_updates(const nlohmann::json& updates) {
+    graphics_update_writer().enqueue(updates);
+}
+
 } // anonymous namespace
 
 namespace lambo {
@@ -293,6 +428,7 @@ ultramodern::renderer::GraphicsConfig load_and_apply_graphics() {
 
     ultramodern::renderer::set_graphics_config(cfg);
     g_current_graphics = cfg;
+    g_live_graphics = cfg;
     // Write the merged config back so the on-disk file is always complete and
     // editable (new keys appear with their defaults after an upgrade) -- but NEVER
     // overwrite a file that failed to parse: a hand-edit typo must stay recoverable,
@@ -308,10 +444,28 @@ ultramodern::renderer::GraphicsConfig current_graphics() {
     return g_current_graphics;
 }
 
-void apply_graphics(const ultramodern::renderer::GraphicsConfig& cfg) {
+void apply_graphics(const ultramodern::renderer::GraphicsConfig& cfg, bool apply_live) {
+    const auto before = g_current_graphics;
     g_current_graphics = cfg;
-    ultramodern::renderer::set_graphics_config(cfg);
-    save_graphics(cfg);
+    nlohmann::json updates = nlohmann::json::object();
+    if (before.res_option != cfg.res_option) updates["res_option"] = cfg.res_option;
+    if (before.wm_option != cfg.wm_option) updates["wm_option"] = cfg.wm_option;
+    if (before.hr_option != cfg.hr_option) updates["hr_option"] = cfg.hr_option;
+    if (before.api_option != cfg.api_option) updates["api_option"] = cfg.api_option;
+    if (before.ar_option != cfg.ar_option) updates["ar_option"] = cfg.ar_option;
+    if (before.msaa_option != cfg.msaa_option) updates["msaa_option"] = cfg.msaa_option;
+    if (before.rr_option != cfg.rr_option) updates["rr_option"] = cfg.rr_option;
+    if (before.hpfb_option != cfg.hpfb_option) updates["hpfb_option"] = cfg.hpfb_option;
+    if (before.rr_manual_value != cfg.rr_manual_value) updates["rr_manual_value"] = cfg.rr_manual_value;
+    if (before.ds_option != cfg.ds_option) updates["ds_option"] = cfg.ds_option;
+    if (before.developer_mode != cfg.developer_mode) updates["developer_mode"] = cfg.developer_mode;
+    if (apply_live) {
+        auto live_cfg = cfg;
+        live_cfg.api_option = g_live_graphics.api_option;
+        ultramodern::renderer::set_graphics_config(live_cfg);
+        g_live_graphics = live_cfg;
+    }
+    save_graphics_updates(updates);
 }
 
 void update_saved_window_mode(ultramodern::renderer::WindowMode wm) {
@@ -319,24 +473,15 @@ void update_saved_window_mode(ultramodern::renderer::WindowMode wm) {
     // from_json here: its enhancement fields are read by the game/render threads.
     // Mutating those arrays during an F11 press would introduce a data race.
     g_current_graphics.wm_option = wm;
-    save_graphics(g_current_graphics);
+    save_graphics_updates({{"wm_option", wm}});
 }
 
 void save_graphics(const ultramodern::renderer::GraphicsConfig& cfg) {
-    const std::filesystem::path path = graphics_json_path();
-    std::error_code ec;
-    std::filesystem::create_directories(path.parent_path(), ec);
-    std::ofstream out{path};
-    if (!out.good()) {
-        LAMBO_LOG("config", "cannot write %s\n", path.string().c_str());
-        return;
-    }
-    out << to_json(cfg).dump(4) << "\n";
-    out.flush();
-    if (!out.good()) {
-        LAMBO_LOG("config", "write to %s FAILED (disk full / permissions?)"
-                     " -- settings may not persist\n", path.string().c_str());
-    }
+    save_graphics_updates_sync(to_json(cfg));
+}
+
+void flush_pending_graphics_updates() {
+    graphics_update_writer().flush();
 }
 
 WindowSize window_size() {
@@ -353,10 +498,12 @@ static std::string path_from_env_or(const char* env, const std::string& fallback
 }
 
 std::string texture_pack_path() {
+    std::lock_guard<std::mutex> lock(g_texture_mutex);
     return path_from_env_or("LAMBO_TEXTURE_PACK", g_texture_pack);
 }
 
 std::string texture_dump_dir() {
+    std::lock_guard<std::mutex> lock(g_texture_mutex);
     return path_from_env_or("LAMBO_TEXTURE_DUMP", g_texture_dump);
 }
 
@@ -370,7 +517,7 @@ bool widescreen_fog_match() {
 
 void set_widescreen_fog_match(bool enabled) {
     g_widescreen_fog_match.store(enabled);
-    save_graphics(g_current_graphics);
+    save_graphics_updates({{"widescreen_fog_match", enabled}});
 }
 
 // LAMBO_SKY_MATCH_1P=1/0 overrides the JSON key for headless capture/testing.
@@ -383,7 +530,7 @@ bool widescreen_sky_match() {
 
 void set_widescreen_sky_match(bool enabled) {
     g_widescreen_sky_match.store(enabled);
-    save_graphics(g_current_graphics);
+    save_graphics_updates({{"widescreen_sky_match", enabled}});
 }
 
 // LAMBO_NO_LOD=1/0 overrides the JSON key for headless capture/testing.
@@ -396,7 +543,7 @@ bool no_lod() {
 
 void set_no_lod(bool enabled) {
     g_no_lod.store(enabled);
-    save_graphics(g_current_graphics);
+    save_graphics_updates({{"no_lod", enabled}});
 }
 
 // Per-circuit refinement of no_lod (see lambo_config.h). No env var: the JSON
@@ -412,7 +559,10 @@ bool no_lod_circuit(int circuit) {
 void set_no_lod_circuit(int circuit, bool enabled) {
     if (circuit < 0 || circuit >= (int)g_no_lod_circuit.size()) return;
     g_no_lod_circuit[(size_t)circuit].store(enabled);
-    save_graphics(g_current_graphics);
+    save_graphics_updates({{"no_lod_circuit", nlohmann::json::array({
+        g_no_lod_circuit[0].load(), g_no_lod_circuit[1].load(),
+        g_no_lod_circuit[2].load(), g_no_lod_circuit[3].load(),
+        g_no_lod_circuit[4].load(), g_no_lod_circuit[5].load()})}});
 }
 
 // LAMBO_FOG_SCALE=<float> overrides both JSON keys for headless capture/testing.
@@ -439,7 +589,7 @@ void set_global_fog_scale(double scale) {
     if (scale < 0.0) scale = 0.0;
     if (scale > 8.0) scale = 8.0;
     g_fog_scale.store(scale);
-    save_graphics(g_current_graphics);
+    save_graphics_updates({{"fog_scale", scale}});
 }
 
 // LAMBO_DRAW_DISTANCE=<float> overrides both JSON keys for capture/testing.
@@ -469,7 +619,7 @@ void set_global_draw_distance(double scale) {
     if (scale > 0.0 && scale < 0.1) scale = 0.1;
     if (scale > 100.0) scale = 100.0;
     g_draw_distance.store(scale <= 0.0 ? 0.0 : scale);
-    save_graphics(g_current_graphics);
+    save_graphics_updates({{"draw_distance", g_draw_distance.load()}});
 }
 
 // LAMBO_CAMERA_DISTANCE_SCALE=<float> overrides the JSON key for capture/testing.
@@ -490,7 +640,7 @@ void set_camera_distance_scale(double v) {
     if (v < 0.2) v = 0.2;
     if (v > 3.0) v = 3.0;
     g_camera_distance_scale.store(v);
-    save_graphics(g_current_graphics);
+    save_graphics_updates({{"camera_distance_scale", v}});
 }
 
 // LAMBO_CAMERA_HEIGHT_SCALE=<float> overrides the JSON key for capture/testing.
@@ -511,7 +661,7 @@ void set_camera_height_scale(double v) {
     if (v < 0.2) v = 0.2;
     if (v > 3.0) v = 3.0;
     g_camera_height_scale.store(v);
-    save_graphics(g_current_graphics);
+    save_graphics_updates({{"camera_height_scale", v}});
 }
 
 // LAMBO_CAMERA_FOV_ADD=<float> overrides the JSON key for capture/testing.
@@ -533,7 +683,7 @@ void set_camera_fov_add(double v) {
     if (v < -20.0) v = -20.0;
     if (v > 60.0) v = 60.0;
     g_camera_fov_add.store(v);
-    save_graphics(g_current_graphics);
+    save_graphics_updates({{"camera_fov_add", v}});
 }
 
 bool show_launcher() {
@@ -542,7 +692,7 @@ bool show_launcher() {
 
 void set_show_launcher(bool enabled) {
     g_show_launcher.store(enabled);
-    save_graphics(g_current_graphics);
+    save_graphics_updates({{"show_launcher", enabled}});
 }
 
 } // namespace config

--- a/src/lambo_config.h
+++ b/src/lambo_config.h
@@ -34,13 +34,17 @@ ultramodern::renderer::GraphicsConfig default_graphics_config();
 // users always have a complete, editable file on disk. Returns the applied config.
 ultramodern::renderer::GraphicsConfig load_and_apply_graphics();
 
-// Snapshot/apply helpers for the in-app menu. apply_graphics() updates RT64 live
-// through ultramodern's config action queue and persists the same value.
+// Snapshot/apply helpers for the in-app menu. apply_graphics() persists the changed
+// fields and, unless apply_live is false, updates RT64 through ultramodern's config
+// action queue. API selection is startup-only, so its callers pass false.
 ultramodern::renderer::GraphicsConfig current_graphics();
-void apply_graphics(const ultramodern::renderer::GraphicsConfig& cfg);
+void apply_graphics(const ultramodern::renderer::GraphicsConfig& cfg, bool apply_live = true);
 
-// Persist the given config (full overwrite of graphics.json).
+// Persist known fields without removing unrelated graphics.json keys. Runtime
+// updates are coalesced onto a background writer; this waits for that writer and
+// is primarily useful before shutdown and in deterministic tests.
 void save_graphics(const ultramodern::renderer::GraphicsConfig& cfg);
+void flush_pending_graphics_updates();
 
 // Persist a runtime window-mode change (F11/menu) in the main-thread snapshot.
 void update_saved_window_mode(ultramodern::renderer::WindowMode wm);

--- a/src/lambo_menu.cpp
+++ b/src/lambo_menu.cpp
@@ -4,6 +4,9 @@
 #include <array>
 #include <cmath>
 #include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
 
 #include <SDL.h>
 
@@ -109,13 +112,49 @@ enum Command : UINT {
     CMD_FOV_PLUS20,
 };
 
-void append_item(HMENU menu, UINT id, const char* label) {
-    AppendMenuA(menu, MF_STRING, id, label);
+constexpr std::array<UINT, 4> kSupersamplingCommands{
+    CMD_SS_1X, CMD_SS_2X, CMD_SS_3X, CMD_SS_4X};
+constexpr std::array<std::pair<int, UINT>, 7> kManualRefreshCommands{{
+    {30, CMD_RATE_30}, {60, CMD_RATE_60}, {90, CMD_RATE_90}, {120, CMD_RATE_120},
+    {144, CMD_RATE_144}, {165, CMD_RATE_165}, {240, CMD_RATE_240}}};
+constexpr std::array<UINT, 6> kPvsCircuitCommands{
+    CMD_PVS_CIRCUIT_1, CMD_PVS_CIRCUIT_2, CMD_PVS_CIRCUIT_3,
+    CMD_PVS_CIRCUIT_4, CMD_PVS_CIRCUIT_5, CMD_PVS_CIRCUIT_6};
+constexpr std::array<std::pair<double, UINT>, 5> kDrawDistanceCommands{{
+    {1.0, CMD_DRAW_1X}, {1.5, CMD_DRAW_1_5X}, {2.0, CMD_DRAW_2X},
+    {3.0, CMD_DRAW_3X}, {0.0, CMD_DRAW_UNLIMITED}}};
+constexpr std::array<std::pair<double, UINT>, 6> kFogDensityCommands{{
+    {0.0, CMD_FOG_OFF}, {0.5, CMD_FOG_50}, {0.75, CMD_FOG_75},
+    {1.0, CMD_FOG_100}, {1.5, CMD_FOG_150}, {2.0, CMD_FOG_200}}};
+constexpr std::array<std::pair<double, UINT>, 4> kCameraDistanceCommands{{
+    {1.0, CMD_CAM_DIST_ORIG}, {0.8, CMD_CAM_DIST_80},
+    {0.65, CMD_CAM_DIST_65}, {0.5, CMD_CAM_DIST_50}}};
+constexpr std::array<std::pair<double, UINT>, 3> kCameraHeightCommands{{
+    {1.0, CMD_CAM_HEIGHT_ORIG}, {0.66, CMD_CAM_HEIGHT_LOWER},
+    {0.4, CMD_CAM_HEIGHT_LOWEST}}};
+constexpr std::array<std::pair<double, UINT>, 5> kFovCommands{{
+    {0.0, CMD_FOV_ORIG}, {5.0, CMD_FOV_PLUS5}, {10.0, CMD_FOV_PLUS10},
+    {15.0, CMD_FOV_PLUS15}, {20.0, CMD_FOV_PLUS20}}};
+
+std::wstring utf8_to_wide(std::string_view text) {
+    const int size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text.data(),
+                                         static_cast<int>(text.size()), nullptr, 0);
+    if (size <= 0) return {};
+    std::wstring result(static_cast<size_t>(size), L'\0');
+    MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text.data(),
+                        static_cast<int>(text.size()), result.data(), size);
+    return result;
 }
 
-HMENU append_submenu(HMENU parent, const char* label) {
+void append_item(HMENU menu, UINT id, std::string_view label) {
+    const std::wstring wide_label = utf8_to_wide(label);
+    AppendMenuW(menu, MF_STRING, id, wide_label.c_str());
+}
+
+HMENU append_submenu(HMENU parent, std::string_view label) {
     HMENU child = CreatePopupMenu();
-    AppendMenuA(parent, MF_POPUP, reinterpret_cast<UINT_PTR>(child), label);
+    const std::wstring wide_label = utf8_to_wide(label);
+    AppendMenuW(parent, MF_POPUP, reinterpret_cast<UINT_PTR>(child), wide_label.c_str());
     return child;
 }
 
@@ -131,6 +170,32 @@ bool close(double a, double b) {
     return std::abs(a - b) < 0.0001;
 }
 
+template <typename T, size_t Size>
+UINT command_for_value(T value, const std::array<std::pair<T, UINT>, Size>& commands) {
+    const auto it = std::find_if(commands.begin(), commands.end(), [value](const auto& entry) {
+        if constexpr (std::is_floating_point_v<T>) return close(value, entry.first);
+        else return value == entry.first;
+    });
+    return it == commands.end() ? 0 : it->second;
+}
+
+template <typename T, size_t Size>
+bool value_for_command(UINT command, const std::array<std::pair<T, UINT>, Size>& commands,
+                       T& value) {
+    const auto it = std::find_if(commands.begin(), commands.end(), [command](const auto& entry) {
+        return entry.second == command;
+    });
+    if (it == commands.end()) return false;
+    value = it->first;
+    return true;
+}
+
+void set_window_menu(HMENU menu) {
+    SetMenu(g_hwnd, menu);
+    SetWindowPos(g_hwnd, nullptr, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+}
+
 void refresh() {
     using namespace ultramodern::renderer;
     const GraphicsConfig cfg = lambo::config::current_graphics();
@@ -141,7 +206,8 @@ void refresh() {
           cfg.res_option == Resolution::Auto ? CMD_RES_AUTO :
           cfg.res_option == Resolution::Original2x ? CMD_RES_ORIGINAL_2X : CMD_RES_ORIGINAL);
     radio(g_supersampling_menu, CMD_SS_1X, CMD_SS_4X,
-          cfg.ds_option >= 1 && cfg.ds_option <= 4 ? CMD_SS_1X + cfg.ds_option - 1 : 0);
+          cfg.ds_option >= 1 && cfg.ds_option <= 4
+              ? kSupersamplingCommands[static_cast<size_t>(cfg.ds_option - 1)] : 0);
     radio(g_aspect_menu, CMD_ASPECT_ORIGINAL, CMD_ASPECT_EXPAND,
           cfg.ar_option == AspectRatio::Expand ? CMD_ASPECT_EXPAND :
           cfg.ar_option == AspectRatio::Original ? CMD_ASPECT_ORIGINAL : 0);
@@ -149,13 +215,10 @@ void refresh() {
           cfg.hr_option == HUDRatioMode::Full ? CMD_HUD_FULL :
           cfg.hr_option == HUDRatioMode::Clamp16x9 ? CMD_HUD_CLAMP_16X9 : CMD_HUD_ORIGINAL);
 
-    UINT rate = CMD_RATE_ORIGINAL;
-    if (cfg.rr_option == RefreshRate::Display) rate = CMD_RATE_DISPLAY;
-    else if (cfg.rr_option == RefreshRate::Manual) {
-        constexpr std::array<int, 7> values{30, 60, 90, 120, 144, 165, 240};
-        auto it = std::find(values.begin(), values.end(), cfg.rr_manual_value);
-        rate = it == values.end() ? 0 : CMD_RATE_30 + UINT(it - values.begin());
-    }
+    UINT rate = cfg.rr_option == RefreshRate::Display ? CMD_RATE_DISPLAY :
+                cfg.rr_option == RefreshRate::Manual
+                    ? command_for_value(cfg.rr_manual_value, kManualRefreshCommands)
+                    : CMD_RATE_ORIGINAL;
     radio(g_rate_menu, CMD_RATE_ORIGINAL, CMD_RATE_240, rate);
     radio(g_aa_menu, CMD_AA_NONE, CMD_AA_8X,
           cfg.msaa_option == Antialiasing::MSAA8X ? CMD_AA_8X :
@@ -172,43 +235,37 @@ void refresh() {
     check(g_enhancements_menu, CMD_FOG_MATCH, lambo::config::widescreen_fog_match());
     check(g_enhancements_menu, CMD_SKY_MATCH, lambo::config::widescreen_sky_match());
     check(g_enhancements_menu, CMD_NO_LOD, lambo::config::no_lod());
-    for (int i = 0; i < 6; ++i) check(g_pvs_menu, CMD_PVS_CIRCUIT_1 + i, lambo::config::no_lod_circuit(i));
+    for (size_t i = 0; i < kPvsCircuitCommands.size(); ++i) {
+        check(g_pvs_menu, kPvsCircuitCommands[i], lambo::config::no_lod_circuit(static_cast<int>(i)));
+    }
 
-    const double draw = lambo::config::global_draw_distance();
     radio(g_draw_menu, CMD_DRAW_1X, CMD_DRAW_UNLIMITED,
-          draw <= 0.0 ? CMD_DRAW_UNLIMITED : close(draw, 3.0) ? CMD_DRAW_3X :
-          close(draw, 2.0) ? CMD_DRAW_2X : close(draw, 1.5) ? CMD_DRAW_1_5X :
-          close(draw, 1.0) ? CMD_DRAW_1X : 0);
-    const double fog = lambo::config::global_fog_scale();
+          command_for_value(lambo::config::global_draw_distance(), kDrawDistanceCommands));
     radio(g_fog_menu, CMD_FOG_OFF, CMD_FOG_200,
-          close(fog, 2.0) ? CMD_FOG_200 : close(fog, 1.5) ? CMD_FOG_150 :
-          close(fog, 1.0) ? CMD_FOG_100 : close(fog, 0.75) ? CMD_FOG_75 :
-          close(fog, 0.5) ? CMD_FOG_50 : close(fog, 0.0) ? CMD_FOG_OFF : 0);
-    const double dist = lambo::config::camera_distance_scale();
+          command_for_value(lambo::config::global_fog_scale(), kFogDensityCommands));
     radio(g_cam_dist_menu, CMD_CAM_DIST_ORIG, CMD_CAM_DIST_50,
-          close(dist, 0.5) ? CMD_CAM_DIST_50 : close(dist, 0.65) ? CMD_CAM_DIST_65 :
-          close(dist, 0.8) ? CMD_CAM_DIST_80 : close(dist, 1.0) ? CMD_CAM_DIST_ORIG : 0);
-    const double height = lambo::config::camera_height_scale();
+          command_for_value(lambo::config::camera_distance_scale(), kCameraDistanceCommands));
     radio(g_cam_height_menu, CMD_CAM_HEIGHT_ORIG, CMD_CAM_HEIGHT_LOWEST,
-          close(height, 0.4) ? CMD_CAM_HEIGHT_LOWEST : close(height, 0.66) ? CMD_CAM_HEIGHT_LOWER :
-          close(height, 1.0) ? CMD_CAM_HEIGHT_ORIG : 0);
-    const double fov = lambo::config::camera_fov_add();
+          command_for_value(lambo::config::camera_height_scale(), kCameraHeightCommands));
     radio(g_fov_menu, CMD_FOV_ORIG, CMD_FOV_PLUS20,
-          close(fov, 20.0) ? CMD_FOV_PLUS20 : close(fov, 15.0) ? CMD_FOV_PLUS15 :
-          close(fov, 10.0) ? CMD_FOV_PLUS10 : close(fov, 5.0) ? CMD_FOV_PLUS5 :
-          close(fov, 0.0) ? CMD_FOV_ORIG : 0);
+          command_for_value(lambo::config::camera_fov_add(), kFovCommands));
     if (g_hwnd != nullptr) DrawMenuBar(g_hwnd);
 }
 
 void apply_graphics_command(UINT command) {
     using namespace ultramodern::renderer;
     GraphicsConfig cfg = lambo::config::current_graphics();
+    bool apply_live = true;
     switch (command) {
         case CMD_RES_AUTO: cfg.res_option = Resolution::Auto; break;
         case CMD_RES_ORIGINAL: cfg.res_option = Resolution::Original; break;
         case CMD_RES_ORIGINAL_2X: cfg.res_option = Resolution::Original2x; break;
-        case CMD_SS_1X: case CMD_SS_2X: case CMD_SS_3X: case CMD_SS_4X:
-            cfg.ds_option = int(command - CMD_SS_1X) + 1; break;
+        case CMD_SS_1X: case CMD_SS_2X: case CMD_SS_3X: case CMD_SS_4X: {
+            const auto it = std::find(kSupersamplingCommands.begin(), kSupersamplingCommands.end(), command);
+            if (it == kSupersamplingCommands.end()) return;
+            cfg.ds_option = static_cast<int>(std::distance(kSupersamplingCommands.begin(), it)) + 1;
+            break;
+        }
         case CMD_ASPECT_ORIGINAL: cfg.ar_option = AspectRatio::Original; break;
         case CMD_ASPECT_EXPAND: cfg.ar_option = AspectRatio::Expand; break;
         case CMD_HUD_ORIGINAL: cfg.hr_option = HUDRatioMode::Original; break;
@@ -218,9 +275,10 @@ void apply_graphics_command(UINT command) {
         case CMD_RATE_DISPLAY: cfg.rr_option = RefreshRate::Display; break;
         case CMD_RATE_30: case CMD_RATE_60: case CMD_RATE_90: case CMD_RATE_120:
         case CMD_RATE_144: case CMD_RATE_165: case CMD_RATE_240: {
-            constexpr std::array<int, 7> values{30, 60, 90, 120, 144, 165, 240};
+            int refresh_rate = 0;
+            if (!value_for_command(command, kManualRefreshCommands, refresh_rate)) return;
             cfg.rr_option = RefreshRate::Manual;
-            cfg.rr_manual_value = values[command - CMD_RATE_30];
+            cfg.rr_manual_value = refresh_rate;
             break;
         }
         case CMD_AA_NONE: cfg.msaa_option = Antialiasing::None; break;
@@ -232,12 +290,12 @@ void apply_graphics_command(UINT command) {
         case CMD_HPFB_OFF: cfg.hpfb_option = HighPrecisionFramebuffer::Off; break;
         // RT64 selects its backend while constructing the renderer. Persist this
         // immediately, but the menu label is explicit that activation is next launch.
-        case CMD_API_AUTO: cfg.api_option = GraphicsApi::Auto; break;
-        case CMD_API_D3D12: cfg.api_option = GraphicsApi::D3D12; break;
-        case CMD_API_VULKAN: cfg.api_option = GraphicsApi::Vulkan; break;
+        case CMD_API_AUTO: cfg.api_option = GraphicsApi::Auto; apply_live = false; break;
+        case CMD_API_D3D12: cfg.api_option = GraphicsApi::D3D12; apply_live = false; break;
+        case CMD_API_VULKAN: cfg.api_option = GraphicsApi::Vulkan; apply_live = false; break;
         default: return;
     }
-    lambo::config::apply_graphics(cfg);
+    lambo::config::apply_graphics(cfg, apply_live);
 }
 
 void dispatch(UINT command) {
@@ -256,8 +314,11 @@ void dispatch(UINT command) {
         case CMD_NO_LOD: lambo::config::set_no_lod(!lambo::config::no_lod()); break;
         case CMD_PVS_CIRCUIT_1: case CMD_PVS_CIRCUIT_2: case CMD_PVS_CIRCUIT_3:
         case CMD_PVS_CIRCUIT_4: case CMD_PVS_CIRCUIT_5: case CMD_PVS_CIRCUIT_6: {
-            int circuit = int(command - CMD_PVS_CIRCUIT_1);
-            lambo::config::set_no_lod_circuit(circuit, !lambo::config::no_lod_circuit(circuit));
+            const auto it = std::find(kPvsCircuitCommands.begin(), kPvsCircuitCommands.end(), command);
+            if (it == kPvsCircuitCommands.end()) return;
+            const int circuit = static_cast<int>(std::distance(kPvsCircuitCommands.begin(), it));
+            lambo::config::set_no_lod_circuit(circuit,
+                !lambo::config::no_lod_circuit(circuit));
             break;
         }
         case CMD_DRAW_1X: lambo::config::set_global_draw_distance(1.0); break;
@@ -304,7 +365,7 @@ void attach(SDL_Window* window) {
     append_item(game, CMD_FULLSCREEN, "&Fullscreen\tF11");
     append_item(game, CMD_SETTINGS, "&Settings...");
     append_item(game, CMD_CONTROLS, "&Controls...");
-    AppendMenuA(game, MF_SEPARATOR, 0, nullptr);
+    AppendMenuW(game, MF_SEPARATOR, 0, nullptr);
     append_item(game, CMD_QUIT, "E&xit");
 
     HMENU graphics = append_submenu(g_menu_bar, "&Graphics");
@@ -324,7 +385,7 @@ void attach(SDL_Window* window) {
     append_item(hud, CMD_HUD_FULL, "Full width");
     HMENU rate = g_rate_menu = append_submenu(graphics, "Frame rate");
     append_item(rate, CMD_RATE_ORIGINAL, "Original"); append_item(rate, CMD_RATE_DISPLAY, "Display refresh rate");
-    AppendMenuA(rate, MF_SEPARATOR, 0, nullptr);
+    AppendMenuW(rate, MF_SEPARATOR, 0, nullptr);
     append_item(rate, CMD_RATE_30, "30 FPS"); append_item(rate, CMD_RATE_60, "60 FPS");
     append_item(rate, CMD_RATE_90, "90 FPS"); append_item(rate, CMD_RATE_120, "120 FPS");
     append_item(rate, CMD_RATE_144, "144 FPS"); append_item(rate, CMD_RATE_165, "165 FPS");
@@ -344,9 +405,9 @@ void attach(SDL_Window* window) {
     append_item(enhancements, CMD_SKY_MATCH, "3P/4P widescreen sky");
     append_item(enhancements, CMD_NO_LOD, "Remove N64 LOD reductions");
     HMENU pvs = g_pvs_menu = append_submenu(enhancements, "Full-track visibility by circuit");
-    for (int i = 0; i < 6; ++i) {
+    for (size_t i = 0; i < kPvsCircuitCommands.size(); ++i) {
         std::string label = "Circuit " + std::to_string(i + 1);
-        append_item(pvs, CMD_PVS_CIRCUIT_1 + i, label.c_str());
+        append_item(pvs, kPvsCircuitCommands[i], label);
     }
     HMENU draw = g_draw_menu = append_submenu(enhancements, "Draw distance");
     append_item(draw, CMD_DRAW_1X, "Original (1x)"); append_item(draw, CMD_DRAW_1_5X, "1.5x");
@@ -368,7 +429,7 @@ void attach(SDL_Window* window) {
     append_item(fov, CMD_FOV_PLUS20, "+20 degrees");
 
     if ((SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0) {
-        SetMenu(g_hwnd, g_menu_bar);
+        set_window_menu(g_menu_bar);
     }
     SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE);
     refresh();
@@ -389,7 +450,7 @@ void toggle_fullscreen() {
         LAMBO_LOG("config", "fullscreen toggle FAILED: %s\n", SDL_GetError());
         return;
     }
-    SetMenu(g_hwnd, fullscreen ? nullptr : g_menu_bar);
+    set_window_menu(fullscreen ? nullptr : g_menu_bar);
     auto cfg = lambo::config::current_graphics();
     cfg.wm_option = fullscreen ? ultramodern::renderer::WindowMode::Fullscreen
                                : ultramodern::renderer::WindowMode::Windowed;

--- a/src/ui/lambo_ui_settings.cpp
+++ b/src/ui/lambo_ui_settings.cpp
@@ -142,6 +142,7 @@ std::optional<SettingAction> setting_action_from_name(std::string_view name) {
 bool apply_setting_action(SettingAction action) {
     using namespace ultramodern::renderer;
     auto cfg = lambo::config::current_graphics();
+    bool apply_live = true;
 
     switch (action) {
         case SettingAction::ResolutionNext:
@@ -186,6 +187,7 @@ bool apply_setting_action(SettingAction action) {
             cfg.api_option = next_value(cfg.api_option,
                 std::array{GraphicsApi::Auto, GraphicsApi::Vulkan});
 #endif
+            apply_live = false;
             break;
         case SettingAction::FogMatchToggle:
             lambo::config::set_widescreen_fog_match(!lambo::config::widescreen_fog_match()); return true;
@@ -208,7 +210,7 @@ bool apply_setting_action(SettingAction action) {
                 lambo::config::global_fog_scale(), std::array{0.0, 0.5, 0.75, 1.0, 1.5, 2.0})); return true;
     }
 
-    lambo::config::apply_graphics(cfg);
+    lambo::config::apply_graphics(cfg, apply_live);
     return true;
 }
 

--- a/tests/test_live_config.cpp
+++ b/tests/test_live_config.cpp
@@ -33,7 +33,12 @@ nlohmann::json read_json(const std::filesystem::path& path) {
 // lambo_config.cpp normally calls into the runtime. This focused test only needs
 // to verify the port-owned snapshot and persistent representation.
 namespace ultramodern::renderer {
-void set_graphics_config(const GraphicsConfig&) {}
+int graphics_config_apply_count = 0;
+GraphicsConfig last_live_graphics{};
+void set_graphics_config(const GraphicsConfig& cfg) {
+    ++graphics_config_apply_count;
+    last_live_graphics = cfg;
+}
 }
 
 int main() {
@@ -55,13 +60,42 @@ int main() {
     expect(cfg.ar_option == ultramodern::renderer::AspectRatio::Expand,
            "enhancement-oriented aspect default is preserved");
 
+    // Runtime updates must merge over hand edits rather than reconstructing the
+    // whole document from the fixed C++ schema.
+    auto hand_edited = read_json(path);
+    hand_edited["custom_renderer_tweak"] = "keep me";
+    hand_edited["texture_pack"] = "manual-texture-pack";
+    {
+        std::ofstream output(path);
+        output << hand_edited.dump(4) << '\n';
+    }
+
     cfg.msaa_option = ultramodern::renderer::Antialiasing::MSAA4X;
     cfg.rr_option = ultramodern::renderer::RefreshRate::Manual;
     cfg.rr_manual_value = 120;
     lambo::config::apply_graphics(cfg);
+    lambo::config::flush_pending_graphics_updates();
     expect(lambo::config::current_graphics().msaa_option ==
                ultramodern::renderer::Antialiasing::MSAA4X,
            "graphics menu changes update the live snapshot");
+    expect(read_json(path).at("custom_renderer_tweak") == "keep me" &&
+               read_json(path).at("texture_pack") == "manual-texture-pack",
+           "graphics menu changes preserve unrelated hand edits");
+
+    const int live_apply_count_before_api_change = ultramodern::renderer::graphics_config_apply_count;
+    cfg.api_option = ultramodern::renderer::GraphicsApi::Vulkan;
+    lambo::config::apply_graphics(cfg, false);
+    lambo::config::flush_pending_graphics_updates();
+    expect(ultramodern::renderer::graphics_config_apply_count == live_apply_count_before_api_change,
+           "restart-only graphics API changes do not reconfigure the live renderer");
+    expect(read_json(path).at("api_option") == "Vulkan",
+           "restart-only graphics API changes persist");
+
+    cfg.hpfb_option = ultramodern::renderer::HighPrecisionFramebuffer::On;
+    lambo::config::apply_graphics(cfg);
+    expect(ultramodern::renderer::last_live_graphics.api_option ==
+               ultramodern::renderer::GraphicsApi::Auto,
+           "later live updates retain the renderer's startup API");
 
     lambo::config::set_widescreen_fog_match(false);
     lambo::config::set_widescreen_sky_match(false);
@@ -83,6 +117,7 @@ int main() {
     expect(lambo::config::camera_fov_add() == 10.0, "camera FOV delta updates live");
 
     lambo::config::update_saved_window_mode(ultramodern::renderer::WindowMode::Fullscreen);
+    lambo::config::flush_pending_graphics_updates();
     const auto json = read_json(path);
     expect(json.at("wm_option") == "Fullscreen", "fullscreen selection persists");
     expect(json.at("msaa_option") == "MSAA4X", "graphics selection persists");
@@ -108,6 +143,7 @@ int main() {
     expect(lambo::config::camera_fov_add() == 60.0, "camera FOV delta clamps high");
 
     lambo::config::set_show_launcher(true);
+    lambo::config::flush_pending_graphics_updates();
     expect(lambo::config::show_launcher() == true, "show_launcher toggle updates snapshot");
     expect(read_json(path).at("show_launcher") == true, "show_launcher persists to json");
 

--- a/tests/test_ui_settings.cpp
+++ b/tests/test_ui_settings.cpp
@@ -40,7 +40,8 @@ nlohmann::json read_json(const std::filesystem::path& path) {
 } // namespace
 
 namespace ultramodern::renderer {
-void set_graphics_config(const GraphicsConfig&) {}
+int graphics_config_apply_count = 0;
+void set_graphics_config(const GraphicsConfig&) { ++graphics_config_apply_count; }
 }
 
 int main() {
@@ -84,8 +85,12 @@ int main() {
 
     expect(apply("res:next") && apply("ss:next") && apply("aspect:next") &&
            apply("hud:next") && apply("rate:next") && apply("msaa:next") &&
-           apply("hpfb:next") && apply("api:next"),
+           apply("hpfb:next"),
            "graphics cycle bindings apply through the typed settings seam");
+    const int live_apply_count_before_api_change = ultramodern::renderer::graphics_config_apply_count;
+    expect(apply("api:next"), "graphics API setting applies through the typed settings seam");
+    expect(ultramodern::renderer::graphics_config_apply_count == live_apply_count_before_api_change,
+           "graphics API setting does not reconfigure the live renderer");
     const auto graphics = lambo::config::current_graphics();
     using namespace ultramodern::renderer;
     expect(graphics.res_option == Resolution::Original, "resolution cycle updates config");
@@ -158,6 +163,7 @@ int main() {
     expect_cycle_wraps("fogdensity:next", 6, snapshot.fog_density,
                        &lambo::ui::SettingsSnapshot::fog_density, "fog-density cycle wraps");
 
+    lambo::config::flush_pending_graphics_updates();
     const auto persisted = read_json(config_path);
 #if defined(_WIN32)
     expect(persisted.at("api_option") == "D3D12", "graphics API persists");


### PR DESCRIPTION
## Summary
- preserve hand-edited and forward-compatible graphics.json keys with merged runtime deltas
- keep restart-only API selections out of RT64 live updates, including subsequent live setting changes
- modernize the Windows menu's UTF-16 handling, frame invalidation, and command lookups
- serialize texture/file access, coalesce runtime persistence off the UI thread, and add Linux thread linkage
- add regression coverage for persistence and restart-only API behavior

## Validation
- git diff --check`n- cmake -S . -B build-review-unix -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug *(CMake found Threads; configuration then stopped because this worktree has uninitialized N64ModernRuntime, RmlUi, and RT64 submodules)*