### PR TITLE
fix: distinguish car models from difficulty and verify vehicle data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ __pycache__/
 
 # --- Local AI Artefacts ----------------------------------------------------
 .codex/
+.commandcode/
+.agents/
 .claude/settings.local.json
 .claude/worktrees/
 CLAUDE.local.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,6 +591,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/lambo_warp.c       # issue #12: developer warp menu (F1-F6 / LAMBO_WARP race-track warp)
         src/lambo_savestate.c  # issue #22: developer save-state (F7/F8 / LAMBO_STATE_LOAD RDRAM snapshot)
         src/lambo_log.cpp      # file-first levelled logging + --console/--verbose CLI policy
+        src/lambo_car_trace.c  # car-differences campaign: LAMBO_CAR_TRACE per-frame vehicle-record trace
     )
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/aspMain.cpp)
         list(APPEND LAMBO_SOURCES src/aspMain.cpp)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ For development it is useful to jump straight into a race without driving the me
   (3 laps, first car).
 - **`LAMBO_WARP=circuit[:laps[:car[:players]]]`** (environment variable, circuit `1`–`6`)
   performs the warp automatically at boot — handy for headless/scripted runs.
+  `car` is the model cursor `0`-`23` (three variants per category), copied to
+  every requested player; this development path can select locked models. See
+  [car data](docs/CAR_DIFFERENCES.md).
+- **`LAMBO_WARP_DIFFICULTY=0|1`** fixes Novice/Expert difficulty for a warp.
+  When unset, the current difficulty is retained.
 
 The warp performs the same stores the game's own menu makes when you confirm RACE
 (selection cursors + audio quiesce + game-state 7), so the race it starts is a normal

--- a/docs/CAR_DIFFERENCES.md
+++ b/docs/CAR_DIFFERENCES.md
@@ -1,0 +1,233 @@
+# Car differences: verified identities and measurement
+
+The earlier six-selector campaign measured **difficulty overrides, not six
+cars**. Its car rankings, cornering groups and suggested top-speed caps are
+withdrawn. Do not use the tables in commit `f831078` for a car-selection UI.
+
+The USA ROM has **24 model descriptors mapping to eight physics categories**.
+Each category has three consecutive model variants. Car identity, difficulty,
+player channel and live vehicle slot are separate dimensions.
+
+## Reproduce the evidence
+
+From the repository root, with Python 3.11 or newer:
+
+```powershell
+python tools/emu_instrumentation/audit_car_data.py "Automobili Lamborghini (USA).z64" --output scratch/car-data.json
+python tools/emu_instrumentation/probe_car_models.py --out scratch/car-launch --vis 1000 --reps 2
+```
+
+Create `scratch` first for the audit output. The audit checks the ROM hash,
+menu callback instructions, menu text, model range and descriptor mapping,
+then extracts the small parameter tables. The probe uses the corrected
+[developer warp](../src/lambo_warp.c), holds difficulty fixed, and rejects
+traces without a moving player of the expected physics category. It records
+raw-trace hashes alongside measurements. Reusing an output directory rejects
+mismatched ROM, executable, source revision, or scenario configuration
+metadata, and scenario-prefixed trace/log names keep launch and steering runs
+separate. Outputs are local artifacts.
+
+The retained [measurement evidence](evidence/car-models-usa.json) was collected
+on 2026-09-05 from clean revision `984a91a`. It records the executable hash,
+environment configuration, automatic-gearbox check, and individual trace
+hashes. The probe emits the same top-level scenario/configuration/runs shape;
+failed attempts are kept separately and make the command fail.
+
+The runtime gate for the trace and warp hooks was `cmake --build build
+--target lamborghini_modern -j 4`, followed by a clean boot-smoke probe for
+models 3 and 9 at `--vis 1000 --reps 1`; both reached the controlled cap with no
+native-crash banner. The full retained campaign used the same executable and
+recorded its hashes above.
+
+Source artifact: `Automobili Lamborghini (USA).z64`, USA, big-endian;
+SHA-256 `cab2467684a58bc19c787423d704a961aa497629763367d9fe691172de58591c`.
+Code addresses below are **runtime addresses**, not the address embedded in
+an original/splat function name. Code ROM offset = runtime - `0x80000000`
++ `0xC00`. Asset banks have separate load mappings; do not apply that formula
+to every data address.
+
+## The actual car-selection path
+
+| Dimension | Address / shape | Proven use |
+| --- | --- | --- |
+| Player model cursor | `0x800CE7E8 + player*2`, zero-based player | Selects one of 24 descriptors. |
+| Model descriptor | `0x8013D490 + model*24`, ROM `0xAEE80 + model*24` | First halfword is the physics category; pointers select model assets. |
+| Vehicle category | Vehicle record `+0x12` | Indexes eight-row engine and physics tables. |
+| Difficulty cursor | `0x800CE7A4` | Menu text is DIFFICULTY, NOVICE / EXPERT. |
+| Race difficulty | `0x800CE79C` | Copied from difficulty cursor by race finalization. Valid menu values are 0/1. |
+| Live vehicle slot | `0x80098398` | Index into records at `0x800B69A8`, stride `0x10C`; not a model ID. |
+
+The menu's right-arrow handler at `0x8003E96C` increments the selected
+player's model cursor, wraps at 24 (`slti ..., 0x18` at `0x8003E9A8`),
+reads the descriptor's category and skips unavailable categories. The left
+handler at `0x8003E80C` wraps to 23. Race setup reads the cursor at
+`0x8000722C`, scales it by 24, and passes the descriptor's first halfword to
+the body constructor. The constructor stores it at vehicle `+0x12`
+(`0x800116AC`). This is also the path the corrected warp now exercises.
+
+The difficulty menu record at ROM `0x14A180` points to `0x800CE7A4` and
+callback `0x8003DA98`. That callback executes `xori ..., 1` at `0x8003DAB8`.
+The following display record selects text IDs 20/21, NOVICE/EXPERT; its
+label is text ID 19, DIFFICULTY. This is stronger evidence than inferring a
+car count from neighboring numeric constants.
+
+| Model cursors | Physics category | Availability in the decoded menu gate |
+| --- | ---: | --- |
+| 0-2 | 0 | Unconditional |
+| 3-5 | 4 | Unconditional |
+| 6-8 | 1 | Progress bit `0x04` |
+| 9-11 | 2 | Progress bit `0x08` |
+| 12-14 | 3 | Progress bit `0x02` |
+| 15-17 | 5 | Progress bit `0x01` |
+| 18-20 | 6 | Progress bit `0x20` |
+| 21-23 | 7 | Progress bit `0x10` |
+
+The gate at `0x8003C7A4-0x8003C908` clears eight availability halfwords at
+`0x800985C0`, enables categories 0 and 4, then enables the others from
+`0x800A4170`. This establishes the bit-to-category mapping, not which
+championship or victory code awards each bit. The development warp bypasses
+this availability gate. Retail names and the meaning of the three visual
+variants remain unverified; identify UI entries by descriptor/category until
+names have evidence.
+
+## Real engine and transmission differences
+
+`0x8013E0F0` (ROM `0xAFAE0`) contains eight 52-byte records indexed by
+vehicle category. It is separate from the two-column difficulty tables.
+
+| Category | Idle engine value | Shift reference | Upper engine reference | Gears | Ratio multiplier | Gear ratios, 1 through highest |
+| ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 0 | 1100 | 6800 | 7000 | 5 | 2.31 | 2.31, 1.52, 1.12, .88, .68 |
+| 1 | 1080 | 6500 | 6700 | 6 | 2.42 | 2.85, 2.08, 1.41, 1.03, .81, .62 |
+| 2 | 1300 | 8500 | 8700 | 6 | 1.93 | 3.27, 2.42, 1.88, 1.50, 1.26, 1.01 |
+| 3 | 1200 | 7400 | 7600 | 6 | 1.87 | 3.16, 2.30, 1.77, 1.40, 1.12, .89 |
+| 4 | 1150 | 7000 | 7200 | 5 | 2.40 | 2.432, 1.695, 1.207, .907, .707 |
+| 5 | 1250 | 8000 | 8200 | 6 | 1.92 | 3.057, 2.321, 1.834, 1.424, 1.148, .949 |
+| 6 | 980 | 5800 | 6000 | 5 | 2.08 | 2.47, 1.53, 1.12, .83, .67 |
+| 7 | 1060 | 6300 | 6500 | 5 | 1.70 | 3.139, 2.014, 1.526, 1.161, .875 |
+
+The halfwords at row offsets `+0/+2/+4` feed engine-speed clamping and
+shifting; `+8` limits the selected gear (`0x8001A228-0x8001A250`). The float
+at `+0x0C` and gear-indexed float at `+0x10 + gear*4` are multiplied in the
+live physics path (`0x800225AC-0x800225DC`) and engine updater
+(`0x80025D10-0x80025D78`). Gear zero's ratio is zero. The gear state lives
+at vehicle `+0xA8` (`LamboVehicleRecord.gear_state`); the engine-speed state is
+at `+0x9E`. The adjacent `+0xB0` halfword is not the gear state. The row's
+`+8` value is the inclusive maximum gear state; since neutral is zero, it is
+also the number of forward ratios shown in the table.
+
+Each row also has its own engine-output curve pointer at `+0x30`. The engine
+updater indexes signed halfword samples by engine speed shifted right by 6
+(`0x80025ED8-0x80025EF4`), multiplies by applied throttle and a shared scale,
+then stores a driving contribution at vehicle `+0x94` (`0x80026400`). These
+curves and gear ratios are concrete per-car inputs to acceleration. Their
+raw values are not yet calibrated as horsepower or torque in physical units.
+The row's `+0x2C` coefficient participates in fuel depletion when enabled
+(`0x80026470-0x800264CC`); it is not a grip rating.
+
+## Difficulty-dependent steering and physics
+
+Novice uses steering slew 4; Expert uses 7. Novice uses response data at
+`0x800891F0`; Expert uses `0x80089174`. The latter starts **four bytes after**
+the slew base `0x80089170`: the subsequent halfwords are already response
+lookup data. Eight readable halfwords `[4,7,1,1,1,1,1,2]` do not prove an
+eight-car slew table.
+
+Likewise the eight readable floats beginning at ROM `0x89F0C` are
+`0.75, 0.45, 1e-5, 1e-6, 8e-5, 8e-6, 1e-5, 1e-6`. The reviewer correctly
+identified the original copy/paste error at indices 4/5. The relevant lookup
+uses **difficulty**, so only `0.75/0.45` are legal values at this seam.
+At `0x8001FC58-0x8001FCA0` it imposes a lower bound on a working physics
+quantity using the category/difficulty parameter. It is not a top-speed
+array or a per-car grip table.
+
+Tables `0x8013E290` / `0x8013E2D0` use `category*8 + difficulty*4`.
+Their eight rows are identical: `.54/.27` and `.90/.45` respectively.
+They cannot explain differences between categories at fixed difficulty.
+Difficulty 2 aliases the next row's Novice entry, and 3 aliases its Expert
+entry. That explains the previous campaign's misleading parity correlation.
+The `0.91` scratch scaling at `0x8001D658-0x8001D868` is conditional;
+it must not be asserted for every frame or difficulty.
+
+`func_8001E01C` is listed in [force_stub.txt](../force_stub.txt) and has the
+symbol entry at `lamborghini.syms.toml:79`; the force-stub configuration leaves
+its standalone generated body empty. However, the enlarged `func_80019D20`
+starts at runtime `0x80019120`, has size `0x4EFC`, and includes the entire
+`0x8001D41C-0x8001E01C` tail. The scratch stores at `0x8001D6D4` etc. are
+present inside that live generated body. The review's inference that these
+calculations are all dead because the tail symbol is stubbed is incorrect.
+The static audit tool checks this symbol-range containment.
+
+## Shared record schema and controls
+
+[lambo_vehicle.h](../src/lambo_vehicle.h) defines the verified fields with
+compile-time size/offset assertions. Trace, analog throttle and analog brake
+use this schema. It is an offset schema, **not a struct to cast onto RDRAM**:
+librecomp memory is word-swizzled, so guest reads/writes still use MEM_H/MEM_W.
+Position is at `+0x14`, not the review's overlapping `+0x08` vector.
+
+The stock throttle ramp is +/-10 per update. Brake demand ramps to 16 and
+contributes demand*10 while its latch is active. Those shared control laws
+do not prove equal total stopping distances across cars or surfaces. See
+[throttle](analog-throttle.md) and [brake](analog-brake.md).
+
+## Measurements with the actual model cursor (2026-09-05)
+
+Headless port, Circuit 1, time trial (no AI opponents), Novice difficulty,
+boot-default automatic transmission, held A with zero stick. Two runs per
+category, 1000 VIs each; times below count dispatcher updates from first
+positive speed, not seconds. The probe captures a varying number of updates
+at a VI-limited exit, but all threshold times below repeat exactly.
+
+| Model cursor tested | Category | Updates to 50 | Updates to 100 |
+| ---: | ---: | ---: | ---: |
+| 0 | 0 | 57 | 107 |
+| 3 | 4 | 34 | 78 |
+| 6 | 1 | 37 | 89 |
+| 9 | 2 | 49 | 96 |
+| 12 | 3 | 41 | 83 |
+| 15 | 5 | 38 | 81 |
+| 18 | 6 | 34 | 81 |
+| 21 | 7 | 44 | 97 |
+
+These are controlled **Circuit 1 launch observations in HUD speed-field
+units**, not real-world 0-100 km/h times. Through the 100 threshold, speed
+never decreases and maximum lateral departure from the start-to-end line is
+under 0.11 position units in all tested categories. This is evidence of a
+straight launch window, not an instrumented assertion that no contact event
+occurred. The tool retains 150-threshold/peak observations for investigation;
+they are not published here as clean acceleration or terminal-speed ratings.
+
+One additional full-left launch per category (`--scenario steering --vis 650
+--reps 1`) measured maximum launch steering-command slew **4 in all eight
+categories**. This confirms the shared Novice input law; it does not establish
+equal turning radii or grip. No new yaw-rate rating is claimed.
+
+The earlier `0xFFFFFFFF` reports were probe failures, not model-table faults.
+They had no native-crash banner, and the same model 9 case completed without
+the trace enabled. The old tracer performed one `fprintf` per guest word and
+flushed every frame; that I/O load changed the game-thread timing and could
+leave the process short of its controlled VI-cap exit. The tracer now builds
+each record in a bounded line buffer, flushes periodically, reports I/O errors,
+and closes its stream at teardown. Repeated model 3 and model 9 runs with the
+new writer reached the controlled exit and reproduced their threshold values.
+The probe records any future early exit with its last trace frame and whether a
+native-crash banner or controlled-cap message was observed; a failed case makes
+the campaign fail instead of contributing a measurement. The clean retained
+campaign contains 16 launch runs and eight steering runs with no excluded
+attempts.
+
+## Readiness for car-selection stats
+
+The cursor-to-category mapping and inclusive maximum gear states are ready to
+use. Launch comparisons must hold difficulty, transmission, track and input
+fixed.
+Top speed still needs a collision-free equilibrium measurement; maximum
+observed circuit speed is not a terminal-speed rating. Handling comparisons
+must use the actual categories at matched speed, not the old illegal
+difficulty overrides. Port measurements also need reference-emulator
+comparison before being advertised as exact retail performance.
+
+The former claims of a selector-4 ~149 cap, six-car steering groups, and
+selector-to-name mappings are not retained. The old raw traces remain local
+for investigating that invalid experiment, not as car specifications.

--- a/docs/evidence/car-models-usa.json
+++ b/docs/evidence/car-models-usa.json
@@ -1,0 +1,656 @@
+{
+  "date": "2026-09-05",
+  "rom_sha256": "cab2467684a58bc19c787423d704a961aa497629763367d9fe691172de58591c",
+  "executable_sha256": "02ad048946f9a3b1921fd4c5743eedda42c10e8355a503ed2f389f1a72e606b7",
+  "source_base_revision": "984a91a4bd0f849ef18733a5764de81303ee271e",
+  "source_dirty": false,
+  "launch": {
+    "configuration": {
+      "headless": true,
+      "warp": "1:2:<model_cursor>:1",
+      "difficulty": 0,
+      "mode": 0,
+      "input": "8000",
+      "max_vis": 1000
+    },
+    "runs": [
+      {
+        "model_cursor": 0,
+        "category": 0,
+        "difficulty": 0,
+        "samples": 470,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 57,
+          "100": 107,
+          "150": 182
+        },
+        "peak_observed_speed": 162,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "243dc6c0f681f4ed9022bfb5f69a54f1fdbcd3f99e02c20fdb19ed252d80f44c",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.010134124917983893
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      },
+      {
+        "model_cursor": 0,
+        "category": 0,
+        "difficulty": 0,
+        "samples": 470,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 57,
+          "100": 107,
+          "150": 182
+        },
+        "peak_observed_speed": 162,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "243dc6c0f681f4ed9022bfb5f69a54f1fdbcd3f99e02c20fdb19ed252d80f44c",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.010134124917983893
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 2
+      },
+      {
+        "model_cursor": 3,
+        "category": 4,
+        "difficulty": 0,
+        "samples": 395,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 34,
+          "100": 78,
+          "150": 153
+        },
+        "peak_observed_speed": 167,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "c574c3d297d8ef74568eccc84e97cb31b7f7253c2e480d9e3f64870c3f96cd2d",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.010190573269873406
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      },
+      {
+        "model_cursor": 3,
+        "category": 4,
+        "difficulty": 0,
+        "samples": 323,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 34,
+          "100": 78,
+          "150": 153
+        },
+        "peak_observed_speed": 167,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "18afb82a0fe623de6fdc34aff32608d3f9e1cb28a1db20f68b502731680e8a38",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.010190573269873406
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 2
+      },
+      {
+        "model_cursor": 6,
+        "category": 1,
+        "difficulty": 0,
+        "samples": 393,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 37,
+          "100": 89,
+          "150": 178
+        },
+        "peak_observed_speed": 156,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "5be34071b5c0637b31dded36d9b7efdf553af3752e1f145678521462fe9dc93b",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.010051602157277614
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      },
+      {
+        "model_cursor": 6,
+        "category": 1,
+        "difficulty": 0,
+        "samples": 466,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 37,
+          "100": 89,
+          "150": 178
+        },
+        "peak_observed_speed": 156,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "4ecaabc7c9ab7c1bc8c9f9cf1b00325b1c17e004ea8735b183d624e082a4ee04",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.010051602157277614
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 2
+      },
+      {
+        "model_cursor": 9,
+        "category": 2,
+        "difficulty": 0,
+        "samples": 469,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 49,
+          "100": 96,
+          "150": 172
+        },
+        "peak_observed_speed": 163,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "0daf30c2975e9a2d1f55ba1038a4290b4da803542084880546339905ae20433b",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.01146297008501787
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      },
+      {
+        "model_cursor": 9,
+        "category": 2,
+        "difficulty": 0,
+        "samples": 472,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 49,
+          "100": 96,
+          "150": 172
+        },
+        "peak_observed_speed": 163,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "0e25e105298cc6bd61fc8b98c6768ffc9b3b97116c2314709599938388adca13",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.01146297008501787
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 2
+      },
+      {
+        "model_cursor": 12,
+        "category": 3,
+        "difficulty": 0,
+        "samples": 469,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 41,
+          "100": 83,
+          "150": 150
+        },
+        "peak_observed_speed": 169,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "3ed6e5658111c636c77a15d6927ae8fa0bef8cc32219651fe7620967bb905e24",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.007699357534989741
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      },
+      {
+        "model_cursor": 12,
+        "category": 3,
+        "difficulty": 0,
+        "samples": 469,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 41,
+          "100": 83,
+          "150": 150
+        },
+        "peak_observed_speed": 169,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "3ed6e5658111c636c77a15d6927ae8fa0bef8cc32219651fe7620967bb905e24",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.007699357534989741
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 2
+      },
+      {
+        "model_cursor": 15,
+        "category": 5,
+        "difficulty": 0,
+        "samples": 469,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 38,
+          "100": 81,
+          "150": 155
+        },
+        "peak_observed_speed": 166,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "79033012d1d655e700a333caa69ed7d859b236c0e418bb4e2d94265bf5e00970",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.007408326432052596
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      },
+      {
+        "model_cursor": 15,
+        "category": 5,
+        "difficulty": 0,
+        "samples": 465,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 38,
+          "100": 81,
+          "150": 155
+        },
+        "peak_observed_speed": 166,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "5d0c2ce4c5d68dc5d976348f6798a8e36d4476d6a016ea7d6516ced6a9c885ae",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.007408326432052596
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 2
+      },
+      {
+        "model_cursor": 18,
+        "category": 6,
+        "difficulty": 0,
+        "samples": 471,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 34,
+          "100": 81,
+          "150": 161
+        },
+        "peak_observed_speed": 162,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "47a1acde0114a3e7578823d5eb41a44502eca639e5e0c3342cc0048f12993aee",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.010732181358496896
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      },
+      {
+        "model_cursor": 18,
+        "category": 6,
+        "difficulty": 0,
+        "samples": 469,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 34,
+          "100": 81,
+          "150": 161
+        },
+        "peak_observed_speed": 162,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "24121b7ef3a20e9cd2d01bb15c958741d20977b284358df5325dfa166e795bb1",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.010732181358496896
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 2
+      },
+      {
+        "model_cursor": 21,
+        "category": 7,
+        "difficulty": 0,
+        "samples": 470,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 44,
+          "100": 97,
+          "150": 185
+        },
+        "peak_observed_speed": 156,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "50189465adbcfc0a59abea85e52e2d001159edb90c27ce9c96ef4a0102c4b03a",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.10483627418725369
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      },
+      {
+        "model_cursor": 21,
+        "category": 7,
+        "difficulty": 0,
+        "samples": 468,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 44,
+          "100": 97,
+          "150": 185
+        },
+        "peak_observed_speed": 156,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "f1ef5c6c3b5117ae70add32bab658baf91f7ecfb80bf11d560522ee0290854d7",
+        "launch_steering_slew": 0,
+        "launch_window": {
+          "minimum_speed_step_to_100": 0,
+          "max_lateral_deviation_to_100": 0.10483627418725369
+        },
+        "automatic_gearbox_verified": true,
+        "rep": 2
+      }
+    ]
+  },
+  "excluded_failed_attempts": [],
+  "steering": {
+    "configuration": {
+      "headless": true,
+      "warp": "1:2:<model_cursor>:1",
+      "difficulty": 0,
+      "mode": 0,
+      "input": "8000:-80:0",
+      "max_vis": 650
+    },
+    "runs": [
+      {
+        "model_cursor": 0,
+        "category": 0,
+        "difficulty": 0,
+        "samples": 295,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 47,
+          "100": null,
+          "150": null
+        },
+        "peak_observed_speed": 87,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "7b28319ee12d3c708e5db2d7d2fee885c4fe67876f7e4ae4c5f037e29f6b0f23",
+        "launch_steering_slew": 4,
+        "launch_window": {},
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      },
+      {
+        "model_cursor": 3,
+        "category": 4,
+        "difficulty": 0,
+        "samples": 296,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 42,
+          "100": null,
+          "150": null
+        },
+        "peak_observed_speed": 73,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "8606bc2bc7c73cef5b0a6f873561f8cc64829d868dea13893637fadaee479734",
+        "launch_steering_slew": 4,
+        "launch_window": {},
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      },
+      {
+        "model_cursor": 6,
+        "category": 1,
+        "difficulty": 0,
+        "samples": 297,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 38,
+          "100": null,
+          "150": null
+        },
+        "peak_observed_speed": 69,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "4d20a651f3247c9343c51c59a6a8419f9e4ba3caa1824e824579aa484f1a4b75",
+        "launch_steering_slew": 4,
+        "launch_window": {},
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      },
+      {
+        "model_cursor": 9,
+        "category": 2,
+        "difficulty": 0,
+        "samples": 296,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 43,
+          "100": null,
+          "150": null
+        },
+        "peak_observed_speed": 82,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "8cc9075e1e3de5e9e404c4a23681cec34f497ce92059aaa25697a5b6dd43e667",
+        "launch_steering_slew": 4,
+        "launch_window": {},
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      },
+      {
+        "model_cursor": 12,
+        "category": 3,
+        "difficulty": 0,
+        "samples": 298,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 122,
+          "100": null,
+          "150": null
+        },
+        "peak_observed_speed": 94,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "2ea62829892d1dd755c7904c9a1fc23e41801c760580b14f0715b8c76f0824fd",
+        "launch_steering_slew": 4,
+        "launch_window": {},
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      },
+      {
+        "model_cursor": 15,
+        "category": 5,
+        "difficulty": 0,
+        "samples": 296,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 37,
+          "100": null,
+          "150": null
+        },
+        "peak_observed_speed": 75,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "9a8e349a0f9b9f547a86ffac6292c2b022b0459fd840ed2b9f201da8bcfb6e8f",
+        "launch_steering_slew": 4,
+        "launch_window": {},
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      },
+      {
+        "model_cursor": 18,
+        "category": 6,
+        "difficulty": 0,
+        "samples": 297,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 34,
+          "100": null,
+          "150": null
+        },
+        "peak_observed_speed": 76,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "a0449d1f429e062b662410f709aa27e6a61f4986df69066f4356f108470ca0db",
+        "launch_steering_slew": 4,
+        "launch_window": {},
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      },
+      {
+        "model_cursor": 21,
+        "category": 7,
+        "difficulty": 0,
+        "samples": 296,
+        "launch_frame": 127,
+        "updates_to_speed": {
+          "50": 35,
+          "100": null,
+          "150": null
+        },
+        "peak_observed_speed": 74,
+        "scratch_at_launch": [
+          0.5400000214576721,
+          0.5400000214576721,
+          0.8999999761581421,
+          0.8999999761581421
+        ],
+        "trace_sha256": "e7e69657e7e3b06e27cd80ddbf1e21bd1e2c3105e06bd57943b0adc60f3dd612",
+        "launch_steering_slew": 4,
+        "launch_window": {},
+        "automatic_gearbox_verified": true,
+        "rep": 1
+      }
+    ]
+  }
+}

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -559,10 +559,13 @@ func = "func_800028D0"
 before_vram = 0x80001CD4
 text = "extern void lambo_savestate_tick(uint8_t*, recomp_context*); lambo_savestate_tick(rdram, ctx);"
 
+# Car-differences measurement campaign: per-frame vehicle-record trace (one
+# instruction past the savestate hook). Gated behind LAMBO_CAR_TRACE; native in
+# src/lambo_car_trace.c. It shares the frame-boundary hook with replay setup.
 [[patches.hook]]
 func = "func_800028D0"
 before_vram = 0x80001CD8
-text = "extern void lambo_replay_dispatch_begin(uint8_t*); lambo_replay_dispatch_begin(rdram);"
+text = "extern void lambo_replay_dispatch_begin(uint8_t*); extern void lambo_car_trace_tick(uint8_t*, recomp_context*); lambo_replay_dispatch_begin(rdram); lambo_car_trace_tick(rdram, ctx);"
 
 [[patches.hook]]
 func = "func_800028D0"

--- a/scripts/gen_syms_toml.py
+++ b/scripts/gen_syms_toml.py
@@ -924,10 +924,13 @@ func = "func_800028D0"
 before_vram = 0x80001CD4
 text = "extern void lambo_savestate_tick(uint8_t*, recomp_context*); lambo_savestate_tick(rdram, ctx);"
 
+# Car-differences measurement campaign: per-frame vehicle-record trace (one
+# instruction past the savestate hook). Gated behind LAMBO_CAR_TRACE; native in
+# src/lambo_car_trace.c. It shares the frame-boundary hook with replay setup.
 [[patches.hook]]
 func = "func_800028D0"
 before_vram = 0x80001CD8
-text = "extern void lambo_replay_dispatch_begin(uint8_t*); lambo_replay_dispatch_begin(rdram);"
+text = "extern void lambo_replay_dispatch_begin(uint8_t*); extern void lambo_car_trace_tick(uint8_t*, recomp_context*); lambo_replay_dispatch_begin(rdram); lambo_car_trace_tick(rdram, ctx);"
 
 [[patches.hook]]
 func = "func_800028D0"

--- a/src/lambo_analog_brake.cpp
+++ b/src/lambo_analog_brake.cpp
@@ -8,6 +8,7 @@
 #include "recomp.h"
 #include "lambo_log.h"
 #include "lambo_input_quantize.h"
+#include "lambo_vehicle.h"
 
 // Guest seam (measured live, see docs/analog-brake.md):
 // - Brake demand is the float at vehicle offset 0xA0. Stock digital play ramps
@@ -24,14 +25,13 @@ namespace {
 
 constexpr uint32_t kAnalogEnabled = 0x80000000u;
 constexpr uint32_t kValueMask = 0x0000FFFFu;
-constexpr gpr kCurrentVehicleAddr = (gpr)(int32_t)0x80098398u;
 constexpr gpr kCurrentChannelAddr = (gpr)(int32_t)0x800CE6AAu;
 constexpr gpr kSelectedPadPtrAddr = (gpr)(int32_t)0x800A39DCu;
-constexpr uint32_t kVehicleBase = 0x800B69A8u;
-constexpr uint32_t kVehicleStride = 0x10Cu;
-constexpr uint32_t kSpeedOffset = 0x90u;
-constexpr uint32_t kBrakeOffset = 0xA0u;
-constexpr uint32_t kBrakeLatchOffset = 0xACu;
+constexpr uint32_t kVehicleBase = LAMBO_VEHICLE_BASE;
+constexpr uint32_t kVehicleStride = sizeof(LamboVehicleRecord);
+constexpr uint32_t kSpeedOffset = offsetof(LamboVehicleRecord, speed);
+constexpr uint32_t kBrakeOffset = offsetof(LamboVehicleRecord, brake_demand);
+constexpr uint32_t kBrakeLatchOffset = offsetof(LamboVehicleRecord, brake_latch);
 constexpr uint16_t kBrakeLatchBit = 0x0001u;
 constexpr float kBrakeMax = 16.0f;
 constexpr float kBrakeStep = 1.0f;
@@ -98,7 +98,8 @@ extern "C" void lambo_analog_brake_apply(uint8_t* rdram) {
     const bool probing = g_probe_enabled.load(std::memory_order_acquire);
     if (!analog_mode && !probing) return;
 
-    const int vehicle = static_cast<int16_t>(MEM_H(0, kCurrentVehicleAddr));
+    const int vehicle = static_cast<int16_t>(MEM_H(0,
+        (gpr)(int32_t)LAMBO_GUEST_CURRENT_VEHICLE_ADDR));
     // -1 is the ROM's inactive-vehicle sentinel (same meaning as the throttle hook).
     if (vehicle < 0) return;
 

--- a/src/lambo_analog_throttle.cpp
+++ b/src/lambo_analog_throttle.cpp
@@ -8,18 +8,18 @@
 #include "recomp.h"
 #include "lambo_log.h"
 #include "lambo_input_quantize.h"
+#include "lambo_vehicle.h"
 
 namespace {
 
 constexpr uint32_t kAnalogEnabled = 0x80000000u;
 constexpr uint32_t kValueMask = 0x0000FFFFu;
-constexpr gpr kCurrentVehicleAddr = (gpr)(int32_t)0x80098398u;
 constexpr gpr kCurrentChannelAddr = (gpr)(int32_t)0x800CE6AAu;
 constexpr gpr kSelectedPadPtrAddr = (gpr)(int32_t)0x800A39DCu;
-constexpr uint32_t kVehicleBase = 0x800B69A8u;
-constexpr uint32_t kVehicleStride = 0x10Cu;
-constexpr uint32_t kSpeedOffset = 0x90u;
-constexpr uint32_t kThrottleOffset = 0xAAu;
+constexpr uint32_t kVehicleBase = LAMBO_VEHICLE_BASE;
+constexpr uint32_t kVehicleStride = sizeof(LamboVehicleRecord);
+constexpr uint32_t kSpeedOffset = offsetof(LamboVehicleRecord, speed);
+constexpr uint32_t kThrottleOffset = offsetof(LamboVehicleRecord, throttle_demand);
 constexpr uint32_t kLimitBase = 0x800A5F2Cu;
 constexpr uint32_t kLimitStride = 0x84u;
 
@@ -82,7 +82,8 @@ extern "C" void lambo_analog_throttle_begin(uint8_t* rdram) {
         g_previous_valid[port] = false;
         return;
     }
-    const int vehicle = static_cast<int16_t>(MEM_H(0, kCurrentVehicleAddr));
+    const int vehicle = static_cast<int16_t>(MEM_H(0,
+        (gpr)(int32_t)LAMBO_GUEST_CURRENT_VEHICLE_ADDR));
     if (vehicle < 0) {
         g_previous_valid[port] = false;
         return;
@@ -103,7 +104,8 @@ extern "C" void lambo_analog_throttle_apply(uint8_t* rdram) {
     const bool probing = g_probe_enabled.load(std::memory_order_acquire);
     if (!analog_mode && !probing) return;
 
-    const int vehicle = static_cast<int16_t>(MEM_H(0, kCurrentVehicleAddr));
+    const int vehicle = static_cast<int16_t>(MEM_H(0,
+        (gpr)(int32_t)LAMBO_GUEST_CURRENT_VEHICLE_ADDR));
     // -1 is the ROM's inactive-vehicle sentinel. Other indices follow the
     // updater's own signed stride calculation immediately before this hook.
     if (vehicle < 0) return;

--- a/src/lambo_car_trace.c
+++ b/src/lambo_car_trace.c
@@ -1,0 +1,128 @@
+// Optional per-frame trace for validating the car-model evidence. It runs on the
+// game thread but stays disabled unless LAMBO_CAR_TRACE is set; when enabled,
+// buffered line writes keep instrumentation from changing frame timing. The
+// record format and guest addresses are documented in CAR_DIFFERENCES.md.
+
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "recomp.h"
+#include "lambo_vehicle.h"
+
+#define TRACE_VBASE   LAMBO_VEHICLE_BASE
+#define TRACE_VSTRIDE ((unsigned)sizeof(LamboVehicleRecord))
+#define TRACE_VEHICLES 6
+#define TRACE_E290    0x8013E290u
+#define TRACE_E2D0    0x8013E2D0u
+#define TRACE_TABLE_BYTES 64
+#define TRACE_LINE_CAP 2048
+#define TRACE_FLUSH_INTERVAL 64
+
+static FILE* g_trace;
+static unsigned g_frame;
+static int g_state = -1;  // -1 = not yet initialised
+static int g_trace_write_failed;
+
+static size_t trace_hex(char* out, size_t used, size_t cap,
+                        const uint32_t* words, unsigned count) {
+    static const char digits[] = "0123456789ABCDEF";
+    for (unsigned i = 0; i < count; ++i) {
+        if (used + 8 > cap) break;
+        const uint32_t word = words[i];
+        for (int shift = 28; shift >= 0; shift -= 4)
+            out[used++] = digits[(word >> shift) & 0xFu];
+    }
+    return used;
+}
+
+static void trace_close(void) {
+    if (g_trace == NULL) return;
+    fflush(g_trace);
+    fclose(g_trace);
+    g_trace = NULL;
+}
+
+void lambo_car_trace_tick(uint8_t* rdram, recomp_context* ctx) {
+    (void)ctx;
+    if (g_state < 0) {
+        g_state = getenv("LAMBO_CAR_TRACE") != NULL;
+        if (g_state) {
+            const char* path = getenv("LAMBO_CAR_TRACE_PATH");
+            g_trace = fopen(path != NULL ? path : "lambo_car_trace.txt", "w");
+            if (g_trace == NULL) {
+                fprintf(stderr, "[car-trace] cannot open %s: %s\n",
+                        path != NULL ? path : "lambo_car_trace.txt", strerror(errno));
+                g_state = 0;
+            } else {
+                atexit(trace_close);
+            }
+        }
+    }
+    if (!g_state) return;
+
+    g_frame++;
+    const int st = (int16_t)MEM_H(0, (gpr)(int32_t)LAMBO_GUEST_GAME_STATE_ADDR);
+    const int sel = (int16_t)MEM_H(0, (gpr)(int32_t)LAMBO_GUEST_RACE_DIFFICULTY_ADDR);
+    const int cur = (int16_t)MEM_H(0, (gpr)(int32_t)LAMBO_GUEST_MENU_DIFFICULTY_ADDR);
+    const int slot = (int16_t)MEM_H(0, (gpr)(int32_t)LAMBO_GUEST_CURRENT_VEHICLE_ADDR);
+    char line[TRACE_LINE_CAP];
+    int line_len = snprintf(line, sizeof(line), "F %u st %d sel %d cur %d slot %d\n",
+                            g_frame, st, sel, cur, slot);
+    if (line_len > 0 && (size_t)line_len < sizeof(line))
+        fwrite(line, 1, (size_t)line_len, g_trace);
+    if (st != 8) {
+        return;
+    }
+
+    uint32_t e290_words[TRACE_TABLE_BYTES / sizeof(uint32_t)];
+    uint32_t e2d0_words[TRACE_TABLE_BYTES / sizeof(uint32_t)];
+    // MEM_W captures this hook's local RDRAM pointer; keep the read loop here
+    // instead of passing a redundant pointer through a helper.
+#define TRACE_READ_WORDS(words, count, addr) \
+    do { \
+        for (unsigned i = 0; i < (count); ++i) \
+            (words)[i] = (uint32_t)MEM_W(0, (gpr)(int32_t)((addr) + i * 4)); \
+    } while (0)
+    TRACE_READ_WORDS(e290_words, sizeof(e290_words) / sizeof(e290_words[0]), TRACE_E290);
+    TRACE_READ_WORDS(e2d0_words, sizeof(e2d0_words) / sizeof(e2d0_words[0]), TRACE_E2D0);
+    for (int v = 0; v < TRACE_VEHICLES; v++) {
+        const uint32_t base = TRACE_VBASE + (uint32_t)v * TRACE_VSTRIDE;
+        const int ch = (int16_t)MEM_H(0, (gpr)(int32_t)(base + offsetof(LamboVehicleRecord, channel)));
+        if (ch <= 0) continue;  // unpopulated slot: channel is 1-based
+        const int cat = (int)MEM_HU(0, (gpr)(int32_t)(base + offsetof(LamboVehicleRecord, category)));
+        const int speed = (int)MEM_W(0, (gpr)(int32_t)(base + offsetof(LamboVehicleRecord, speed)));
+        const int thr = (int16_t)MEM_H(0, (gpr)(int32_t)(base + offsetof(LamboVehicleRecord, throttle_demand)));
+        const unsigned brk = (unsigned)MEM_W(0, (gpr)(int32_t)(base + offsetof(LamboVehicleRecord, brake_demand)));
+        const int lat = (int16_t)MEM_H(0, (gpr)(int32_t)(base + offsetof(LamboVehicleRecord, brake_latch)));
+        line_len = snprintf(line, sizeof(line),
+                            "R %d ch %d cat %d sp %d thr %d brk %08X lat %d rec ",
+                            v, ch, cat, speed, thr, brk, lat);
+        if (line_len <= 0 || (size_t)line_len >= sizeof(line)) continue;
+        uint32_t record_words[TRACE_VSTRIDE / sizeof(uint32_t)];
+        TRACE_READ_WORDS(record_words, sizeof(record_words) / sizeof(record_words[0]), base);
+        size_t used = (size_t)line_len;
+        used = trace_hex(line, used, sizeof(line) - 1, record_words,
+                         sizeof(record_words) / sizeof(record_words[0]));
+        const char e2[] = " e2 ";
+        if (used + sizeof(e2) - 1 >= sizeof(line)) continue;
+        memcpy(line + used, e2, sizeof(e2) - 1); used += sizeof(e2) - 1;
+        used = trace_hex(line, used, sizeof(line) - 1, e290_words,
+                         sizeof(e290_words) / sizeof(e290_words[0]));
+        const char ed[] = " ed ";
+        if (used + sizeof(ed) - 1 >= sizeof(line)) continue;
+        memcpy(line + used, ed, sizeof(ed) - 1); used += sizeof(ed) - 1;
+        used = trace_hex(line, used, sizeof(line) - 1, e2d0_words,
+                         sizeof(e2d0_words) / sizeof(e2d0_words[0]));
+        if (used + 1 >= sizeof(line)) continue;
+        line[used++] = '\n';
+        fwrite(line, 1, used, g_trace);
+    }
+    if ((g_frame % TRACE_FLUSH_INTERVAL) == 0 && fflush(g_trace) != 0 && !g_trace_write_failed) {
+        fprintf(stderr, "[car-trace] write failed after frame %u: %s\n",
+                g_frame, strerror(errno));
+        g_trace_write_failed = 1;
+    }
+#undef TRACE_READ_WORDS
+}

--- a/src/lambo_vehicle.h
+++ b/src/lambo_vehicle.h
@@ -1,0 +1,58 @@
+#ifndef LAMBO_VEHICLE_H
+#define LAMBO_VEHICLE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+// Guest layout schema, NOT a host view of RDRAM. Use offsetof with MEM_H/MEM_W:
+// librecomp's word-swizzled RDRAM does not have native C struct byte order.
+// Unknown fields deliberately remain unnamed. Evidence: ROM constructor at
+// runtime 0x80011370; control/physics consumers listed in CAR_DIFFERENCES.md.
+#pragma pack(push, 1)
+typedef struct LamboVehicleRecord {
+    uint8_t unknown_00[0x0E];
+    int16_t channel;
+    uint8_t unknown_10[2];
+    uint16_t category;
+    float position[3];
+    uint8_t unknown_20[0x70];
+    int32_t speed;
+    uint8_t unknown_94[0x0C];
+    float brake_demand;
+    uint8_t unknown_a4[4];
+    int16_t gear_state;
+    int16_t throttle_demand;
+    int16_t brake_latch;
+    uint8_t unknown_ae[6];
+    int16_t steering_accumulator;
+    uint8_t unknown_b6[0x1A];
+    float physics_scratch[4];
+    uint8_t unknown_e0[0x2C];
+} LamboVehicleRecord;
+#pragma pack(pop)
+
+#define LAMBO_VEHICLE_BASE UINT32_C(0x800B69A8)
+#define LAMBO_GUEST_CURRENT_VEHICLE_ADDR UINT32_C(0x80098398)
+#define LAMBO_GUEST_GAME_STATE_ADDR UINT32_C(0x800CE6AC)
+#define LAMBO_GUEST_RACE_DIFFICULTY_ADDR UINT32_C(0x800CE79C)
+#define LAMBO_GUEST_MENU_DIFFICULTY_ADDR UINT32_C(0x800CE7A4)
+#define LAMBO_GUEST_PLAYER_MODEL_CURSOR_ADDR UINT32_C(0x800CE7E8)
+#define LAMBO_GUEST_PLAYER_MODEL_CURSOR_STRIDE UINT32_C(2)
+#ifdef __cplusplus
+#define LAMBO_LAYOUT_ASSERT static_assert
+#else
+#define LAMBO_LAYOUT_ASSERT _Static_assert
+#endif
+LAMBO_LAYOUT_ASSERT(sizeof(LamboVehicleRecord) == 0x10C, "vehicle stride");
+LAMBO_LAYOUT_ASSERT(offsetof(LamboVehicleRecord, channel) == 0x0E, "channel offset");
+LAMBO_LAYOUT_ASSERT(offsetof(LamboVehicleRecord, category) == 0x12, "category offset");
+LAMBO_LAYOUT_ASSERT(offsetof(LamboVehicleRecord, position) == 0x14, "position offset");
+LAMBO_LAYOUT_ASSERT(offsetof(LamboVehicleRecord, speed) == 0x90, "speed offset");
+LAMBO_LAYOUT_ASSERT(offsetof(LamboVehicleRecord, brake_demand) == 0xA0, "brake offset");
+LAMBO_LAYOUT_ASSERT(offsetof(LamboVehicleRecord, gear_state) == 0xA8, "gear offset");
+LAMBO_LAYOUT_ASSERT(offsetof(LamboVehicleRecord, throttle_demand) == 0xAA, "throttle offset");
+LAMBO_LAYOUT_ASSERT(offsetof(LamboVehicleRecord, brake_latch) == 0xAC, "latch offset");
+LAMBO_LAYOUT_ASSERT(offsetof(LamboVehicleRecord, steering_accumulator) == 0xB4, "steering offset");
+LAMBO_LAYOUT_ASSERT(offsetof(LamboVehicleRecord, physics_scratch) == 0xD0, "scratch offset");
+#undef LAMBO_LAYOUT_ASSERT
+#endif

--- a/src/lambo_warp.c
+++ b/src/lambo_warp.c
@@ -19,7 +19,8 @@
 // Cluster map (all halfwords; MEM_H handles guest byte order):
 //   0x800CE6A4 players (1-4)          0x800CE6C0 track cursor (0-5; 0-2 if 3+ players)
 //   0x800CE6A6 track-select-entered   0x800CE6E0 laps cursor (menu range 3-30)
-//   0x800CE6B4 mode (2 = SINGLE RACE) 0x800CE7A4 car cursor
+//   0x800CE6B4 mode (2 = SINGLE RACE) 0x800CE7E8 player model cursors (0-23, +2 per player)
+//   0x800CE7A4 difficulty (0 = NOVICE, 1 = EXPERT), NOT a car selector
 //   0x800CE6BA race counter (0)       0x800CE6AC game state (7 = load race)
 
 #include <stdatomic.h>
@@ -29,6 +30,7 @@
 
 #include "lambo_log.h"
 #include "recomp.h"
+#include "lambo_vehicle.h"
 
 // Audio quiesce pair the ROM runs before every state->7 write (menu RACE action,
 // pause-restart, championship next-race). Recompiled bodies; safe to call from a
@@ -37,15 +39,12 @@
 void func_800676B4(uint8_t* rdram, recomp_context* ctx);
 void func_80008ECC(uint8_t* rdram, recomp_context* ctx);
 
-#define WARP_STATE      0x800CE6ACu
 #define WARP_PLAYERS    0x800CE6A4u
 #define WARP_TRACK_FLAG 0x800CE6A6u
 #define WARP_MODE       0x800CE6B4u
 #define WARP_COUNTER    0x800CE6BAu
 #define WARP_TRACK_CUR  0x800CE6C0u
 #define WARP_LAPS_CUR   0x800CE6E0u
-#define WARP_CAR_CUR    0x800CE7A4u
-
 #define MODE_SINGLE_RACE 2
 
 // The game's circuits are unnamed (menu shows "CIRCUIT" + a numbered map preview;
@@ -89,6 +88,10 @@ int lambo_warp_env_players(void) {
 int lambo_warp_env_mode(void) {
     return atomic_load_explicit(&g_warp_mode, memory_order_relaxed);
 }
+static int g_warp_options_parsed;
+static int g_warp_options_valid = 1;
+static int g_warp_mode_option = MODE_SINGLE_RACE;
+static int g_warp_difficulty = -1;
 
 static uint32_t pack_request(int circuit0, int laps, int car, int players) {
     return 0x80000000u | (uint32_t)(circuit0 & 0xFF) | ((uint32_t)(laps & 0xFF) << 8)
@@ -120,8 +123,40 @@ static void parse_env_request(void) {
         LAMBO_LOG("warp", "LAMBO_WARP=%s invalid: circuit must be 1-6\n", env);
         return;
     }
+    if (v[2] < 0 || v[2] >= 24) {
+        LAMBO_LOG("warp", "LAMBO_WARP=%s invalid: model must be 0-23\n", env);
+        return;
+    }
     atomic_store_explicit(&g_warp_request, pack_request(v[0] - 1, v[1], v[2], v[3]),
                           memory_order_relaxed);
+}
+
+// Environment options are process configuration, not per-frame state. Parse them
+// once before looking at the atomic request so a bad difficulty cannot consume a
+// valid request and leave the menu half-transitioned.
+static void parse_env_options(void) {
+    const char* mode = getenv("LAMBO_WARP_MODE");
+    if (mode != NULL && mode[0] != '\0') {
+        char* end = NULL;
+        long value = strtol(mode, &end, 10);
+        if (end == mode || *end != '\0' || value < -32768 || value > 32767) {
+            LAMBO_LOG("warp", "LAMBO_WARP_MODE=%s invalid: expected an integer\n", mode);
+            g_warp_options_valid = 0;
+        } else {
+            g_warp_mode_option = (int)value;
+        }
+    }
+
+    const char* difficulty = getenv("LAMBO_WARP_DIFFICULTY");
+    if (difficulty != NULL) {
+        if (strcmp(difficulty, "0") != 0 && strcmp(difficulty, "1") != 0) {
+            LAMBO_LOG("warp", "LAMBO_WARP_DIFFICULTY must be 0 or 1\n");
+            g_warp_options_valid = 0;
+            atomic_store_explicit(&g_warp_failed, 1, memory_order_release);
+        } else {
+            g_warp_difficulty = difficulty[0] - '0';
+        }
+    }
 }
 
 // States a warp is allowed to fire from, mirroring where the ROM itself issues the
@@ -136,15 +171,16 @@ static int warpable(int state) {
 // Per-frame tick, injected at the entry of func_800030F8 (see the [[patches.hook]]
 // block carried by scripts/gen_syms_toml.py). Runs on the game thread.
 void lambo_warp_tick(uint8_t* rdram, recomp_context* ctx) {
-    static int env_parsed;
-    if (!env_parsed) {
-        env_parsed = 1;
+    if (!g_warp_options_parsed) {
+        g_warp_options_parsed = 1;
+        parse_env_options();
         parse_env_request();
     }
+    if (!g_warp_options_valid) return;
     uint32_t req = atomic_load_explicit(&g_warp_request, memory_order_relaxed);
     if (!(req & 0x80000000u)) return;
 
-    int state = (int16_t)MEM_H(0, (gpr)(int32_t)WARP_STATE);
+    int state = (int16_t)MEM_H(0, (gpr)(int32_t)LAMBO_GUEST_GAME_STATE_ADDR);
     if (!warpable(state)) return;
     if (!atomic_compare_exchange_strong_explicit(&g_warp_request, &req, 0,
                                                  memory_order_relaxed,
@@ -165,22 +201,29 @@ void lambo_warp_tick(uint8_t* rdram, recomp_context* ctx) {
     // 0x800CE6B4 selects the race mode the state-7 finalizer builds: 2 = single race
     // (LAP/RANK HUD), 0 = time trial (PREVIOUS/RECORD/BEST-LAP HUD, no rank). Overridable
     // for testing the non-arcade HUD variants (issue #42); defaults to single race.
-    int mode = MODE_SINGLE_RACE;
-    { const char* m = getenv("LAMBO_WARP_MODE"); if (m != NULL) mode = atoi(m); }
-    // Report the exact signed halfword written to guest RAM, even for direct
-    // environment use outside the stricter scenario runner.
-    mode = (int)(int16_t)mode;
+    const int mode = g_warp_mode_option;
+    // The retail difficulty callback XORs this halfword with 1. Keep the
+    // existing setting unless explicitly overridden for a controlled run.
+    if (g_warp_difficulty >= 0)
+        MEM_H(0, (gpr)(int32_t)LAMBO_GUEST_MENU_DIFFICULTY_ADDR) = (int16_t)g_warp_difficulty;
     MEM_H(0, (gpr)(int32_t)WARP_PLAYERS)    = (int16_t)players;
     MEM_H(0, (gpr)(int32_t)WARP_TRACK_FLAG) = 1;
     MEM_H(0, (gpr)(int32_t)WARP_MODE)       = (int16_t)mode;
     MEM_H(0, (gpr)(int32_t)WARP_COUNTER)    = 0;
     MEM_H(0, (gpr)(int32_t)WARP_TRACK_CUR)  = (int16_t)circuit0;
     MEM_H(0, (gpr)(int32_t)WARP_LAPS_CUR)   = (int16_t)laps;
-    MEM_H(0, (gpr)(int32_t)WARP_CAR_CUR)    = (int16_t)car;
-
     func_800676B4(rdram, ctx);
     func_80008ECC(rdram, ctx);
-    MEM_H(0, (gpr)(int32_t)WARP_STATE) = 7;
+    // The menu maintains one model cursor per player.  A warp request carries a
+    // single model selector, so mirror it to every requested player rather than
+    // silently leaving players 2-4 on stale menu selections.
+    for (int player = 0; player < players; ++player) {
+        MEM_H(0, (gpr)(int32_t)(LAMBO_GUEST_PLAYER_MODEL_CURSOR_ADDR +
+                                (uint32_t)player * LAMBO_GUEST_PLAYER_MODEL_CURSOR_STRIDE)) =
+            (int16_t)car;
+    }
+
+    MEM_H(0, (gpr)(int32_t)LAMBO_GUEST_GAME_STATE_ADDR) = 7;
 
     atomic_store_explicit(&g_warp_circuit, circuit0 + 1, memory_order_relaxed);
     atomic_store_explicit(&g_warp_laps, laps, memory_order_relaxed);
@@ -189,6 +232,8 @@ void lambo_warp_tick(uint8_t* rdram, recomp_context* ctx) {
     atomic_store_explicit(&g_warp_mode, mode, memory_order_relaxed);
     atomic_store_explicit(&g_warp_applied, 1, memory_order_release);
 
-    LAMBO_LOG("warp", "%s: single race, %d lap(s), car %d, %d player(s) (from state %d)\n",
-            lambo_scene_table[circuit0], laps, car, players, state);
+    const char* mode_name = mode == 0 ? "time trial" :
+                            mode == MODE_SINGLE_RACE ? "single race" : "custom mode";
+    LAMBO_LOG("warp", "%s: %s (mode %d), %d lap(s), car %d, %d player(s) (from state %d)\n",
+            lambo_scene_table[circuit0], mode_name, mode, laps, car, players, state);
 }

--- a/tests/test_analog_brake.cpp
+++ b/tests/test_analog_brake.cpp
@@ -7,17 +7,13 @@
 #include <vector>
 
 #include "lambo_analog_brake.h"
+#include "lambo_vehicle.h"
 
 namespace {
 
-constexpr uint32_t kCurrentVehicleAddr = 0x80098398u;
 constexpr uint32_t kCurrentChannelAddr = 0x800CE6AAu;
 constexpr uint32_t kSelectedPadPtrAddr = 0x800A39DCu;
 constexpr uint32_t kPadBase = 0x800A39E0u;
-constexpr uint32_t kVehicleBase = 0x800B69A8u;
-constexpr uint32_t kVehicleStride = 0x10Cu;
-constexpr uint32_t kBrakeOffset = 0xA0u;
-constexpr uint32_t kLatchOffset = 0xACu;
 
 int failures = 0;
 
@@ -37,12 +33,14 @@ int32_t& word(std::vector<uint8_t>& rdram, uint32_t address) {
 }
 
 uint32_t latch_address(int vehicle) {
-    return kVehicleBase + static_cast<uint32_t>(vehicle) * kVehicleStride + kLatchOffset;
+    return LAMBO_VEHICLE_BASE + static_cast<uint32_t>(vehicle) * sizeof(LamboVehicleRecord) +
+           offsetof(LamboVehicleRecord, brake_latch);
 }
 
 float read_brake(const std::vector<uint8_t>& rdram, int vehicle) {
     const uint32_t address =
-        kVehicleBase + static_cast<uint32_t>(vehicle) * kVehicleStride + kBrakeOffset;
+        LAMBO_VEHICLE_BASE + static_cast<uint32_t>(vehicle) * sizeof(LamboVehicleRecord) +
+        offsetof(LamboVehicleRecord, brake_demand);
     uint32_t bits = static_cast<uint32_t>(
         word(const_cast<std::vector<uint8_t>&>(rdram), address));
     float out;
@@ -52,14 +50,15 @@ float read_brake(const std::vector<uint8_t>& rdram, int vehicle) {
 
 void write_brake(std::vector<uint8_t>& rdram, int vehicle, float value) {
     const uint32_t address =
-        kVehicleBase + static_cast<uint32_t>(vehicle) * kVehicleStride + kBrakeOffset;
+        LAMBO_VEHICLE_BASE + static_cast<uint32_t>(vehicle) * sizeof(LamboVehicleRecord) +
+        offsetof(LamboVehicleRecord, brake_demand);
     uint32_t bits;
     std::memcpy(&bits, &value, sizeof(bits));
     word(rdram, address) = static_cast<int32_t>(bits);
 }
 
 void set_context(std::vector<uint8_t>& rdram, int vehicle, int channel) {
-    halfword(rdram, kCurrentVehicleAddr) = static_cast<int16_t>(vehicle);
+    halfword(rdram, LAMBO_GUEST_CURRENT_VEHICLE_ADDR) = static_cast<int16_t>(vehicle);
     halfword(rdram, kCurrentChannelAddr) = static_cast<int16_t>(channel);
     word(rdram, kSelectedPadPtrAddr) = static_cast<int32_t>(kPadBase +
         static_cast<uint32_t>(channel - 1) * 6u);
@@ -114,12 +113,12 @@ int main() {
     expect((halfword(rdram, latch_address(1)) & 0x0001) != 0,
            "analog braking latches the physics gate like held digital B");
 
-    halfword(rdram, kCurrentVehicleAddr) = -1;
+    halfword(rdram, LAMBO_GUEST_CURRENT_VEHICLE_ADDR) = -1;
     write_brake(rdram, 1, 3.0f);
     lambo_analog_brake_apply(rdram.data());
     expect(read_brake(rdram, 1) == 3.0f,
            "inactive ROM vehicle sentinel leaves guest memory untouched");
-    halfword(rdram, kCurrentVehicleAddr) = 1;
+    halfword(rdram, LAMBO_GUEST_CURRENT_VEHICLE_ADDR) = 1;
 
     halfword(rdram, kPadBase) = static_cast<int16_t>(0x4000u);
     for (int frame = 0; frame < 20; ++frame) race_step(rdram, 1, true);

--- a/tests/test_analog_throttle.cpp
+++ b/tests/test_analog_throttle.cpp
@@ -6,16 +6,13 @@
 #include <vector>
 
 #include "lambo_analog_throttle.h"
+#include "lambo_vehicle.h"
 
 namespace {
 
-constexpr uint32_t kCurrentVehicleAddr = 0x80098398u;
 constexpr uint32_t kCurrentChannelAddr = 0x800CE6AAu;
 constexpr uint32_t kSelectedPadPtrAddr = 0x800A39DCu;
 constexpr uint32_t kPadBase = 0x800A39E0u;
-constexpr uint32_t kVehicleBase = 0x800B69A8u;
-constexpr uint32_t kVehicleStride = 0x10Cu;
-constexpr uint32_t kThrottleOffset = 0xAAu;
 constexpr uint32_t kLimitBase = 0x800A5F2Cu;
 constexpr uint32_t kLimitStride = 0x84u;
 
@@ -37,11 +34,12 @@ int32_t& word(std::vector<uint8_t>& rdram, uint32_t address) {
 }
 
 uint32_t demand_address(int vehicle) {
-    return kVehicleBase + static_cast<uint32_t>(vehicle) * kVehicleStride + kThrottleOffset;
+    return LAMBO_VEHICLE_BASE + static_cast<uint32_t>(vehicle) * sizeof(LamboVehicleRecord) +
+           offsetof(LamboVehicleRecord, throttle_demand);
 }
 
 void set_context(std::vector<uint8_t>& rdram, int vehicle, int channel, int limit) {
-    halfword(rdram, kCurrentVehicleAddr) = static_cast<int16_t>(vehicle);
+    halfword(rdram, LAMBO_GUEST_CURRENT_VEHICLE_ADDR) = static_cast<int16_t>(vehicle);
     halfword(rdram, kCurrentChannelAddr) = static_cast<int16_t>(channel);
     word(rdram, kSelectedPadPtrAddr) = static_cast<int32_t>(kPadBase +
         static_cast<uint32_t>(channel - 1) * 6u);
@@ -89,13 +87,13 @@ int main() {
     expect(halfword(rdram, demand_address(1)) == 25,
            "analog mode settles at the normalized demand");
 
-    halfword(rdram, kCurrentVehicleAddr) = -1;
+    halfword(rdram, LAMBO_GUEST_CURRENT_VEHICLE_ADDR) = -1;
     halfword(rdram, demand_address(1)) = 26;
     lambo_analog_throttle_begin(rdram.data());
     lambo_analog_throttle_apply(rdram.data());
     expect(halfword(rdram, demand_address(1)) == 26,
            "inactive ROM vehicle sentinel leaves guest memory untouched");
-    halfword(rdram, kCurrentVehicleAddr) = 1;
+    halfword(rdram, LAMBO_GUEST_CURRENT_VEHICLE_ADDR) = 1;
 
     halfword(rdram, kPadBase) = static_cast<int16_t>(0x8000u);
     for (int frame = 0; frame < 8; ++frame) race_step(rdram, 1, 100, true);

--- a/tools/emu_instrumentation/audit_car_data.py
+++ b/tools/emu_instrumentation/audit_car_data.py
@@ -1,0 +1,124 @@
+"""Verify USA car-selection evidence and decode parameters from a supplied ROM.
+
+No disassembler dependency. Instruction checks pin the relevant decoded MIPS
+operations to this ROM; output contains small numeric tables, not ROM assets.
+"""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import struct
+import tomllib
+
+ROOT = Path(__file__).resolve().parents[2]
+SHA256 = "cab2467684a58bc19c787423d704a961aa497629763367d9fe691172de58591c"
+MENU_DIFFICULTY_RECORD_OFFSET = 0x14A184
+MENU_DIFFICULTY_TEXT_RECORD_OFFSET = 0x14A1B8
+TEXT_POINTER_TABLE_OFFSET = 0x149710
+TEXT_BANK_RUNTIME_BASE = 0x801F9490
+TEXT_BANK_ROM_OFFSET = 0x158BF0
+DIFFICULTY_XORI_RUNTIME = 0x8003DAB8
+MODEL_RANGE_CHECK_RUNTIME = 0x8003E9A8
+MODEL_CURSOR_LOAD_RUNTIME = 0x8000722C
+SLEW_TABLE_OFFSET = 0x89D70
+THRESHOLD_TABLE_OFFSET = 0x89F0C
+MODEL_DESCRIPTOR_TABLE_OFFSET = 0xAEE80
+ENGINE_TABLE_OFFSET = 0xAFAE0
+ENGINE_ROW_STRIDE = 52
+ENGINE_MAX_GEAR_OFFSET = 8
+ENGINE_MAX_GEARS = (5, 6, 6, 6, 5, 6, 5, 5)
+ENGINE_CURVE_RUNTIME_BASE = 0x8013D6F0
+ENGINE_CURVE_ROM_BASE = 0xAF0E0
+DIFFICULTY_E290_OFFSET = 0xAFC80
+DIFFICULTY_E2D0_OFFSET = 0xAFCC0
+
+
+def audit(rom, root=ROOT):
+    if hashlib.sha256(rom).hexdigest() != SHA256:
+        raise ValueError("Expected the audited big-endian USA ROM (SHA-256 mismatch)")
+
+    def check(offset, fmt, expected):
+        actual = struct.unpack_from(fmt, rom, offset)
+        if actual != expected:
+            raise ValueError(f"ROM {offset:#x}: expected {expected}, got {actual}")
+
+    # Menu record: callback, target; next record displays text IDs 20 / 21.
+    check(MENU_DIFFICULTY_RECORD_OFFSET, ">II", (0x8003DA98, 0x800CE7A4))
+    check(MENU_DIFFICULTY_TEXT_RECORD_OFFSET, ">IHH", (20, 21, 0))
+    # Text pointer table is loaded separately from the string bank.
+    def text_at(index):
+        address, = struct.unpack_from(">I", rom, TEXT_POINTER_TABLE_OFFSET + index * 4)
+        offset = address - TEXT_BANK_RUNTIME_BASE + TEXT_BANK_ROM_OFFSET
+        return rom[offset:rom.index(b"\0", offset)].decode("ascii")
+
+    if [text_at(i) for i in (19, 20, 21)] != ["DIFFICULTY", "NOVICE", "EXPERT"]:
+        raise ValueError("Difficulty menu text mapping changed")
+    # Runtime code maps to ROM at runtime - 0x80000000 + 0xC00.
+    check(DIFFICULTY_XORI_RUNTIME - 0x80000000 + 0xC00, ">I", (0x392A0001,))  # xori t2,t1,1
+    check(MODEL_RANGE_CHECK_RUNTIME - 0x80000000 + 0xC00, ">I", (0x29810018,))  # slti at,t4,24
+    check(MODEL_CURSOR_LOAD_RUNTIME - 0x80000000 + 0xC00, ">I", (0x85EFE7E8,))  # lh t7,model cursor
+    check(SLEW_TABLE_OFFSET, ">8h", (4, 7, 1, 1, 1, 1, 1, 2))
+    check(THRESHOLD_TABLE_OFFSET, ">8I", (0x3F400000, 0x3EE66666, 0x3727C5AC, 0x358637BD,
+                            0x38A7C5AC, 0x370637BD, 0x3727C5AC, 0x358637BD))
+    categories = [struct.unpack_from(">H", rom, MODEL_DESCRIPTOR_TABLE_OFFSET + i * 24)[0]
+                  for i in range(24)]
+    if categories != [c for c in (0, 4, 1, 2, 3, 5, 6, 7) for _ in range(3)]:
+        raise ValueError("Model descriptor categories changed")
+    parameters = []
+    for category in range(8):
+        offset = ENGINE_TABLE_OFFSET + category * ENGINE_ROW_STRIDE
+        halfwords = struct.unpack_from(">5H", rom, offset)
+        max_gear = struct.unpack_from(">H", rom, offset + ENGINE_MAX_GEAR_OFFSET)[0]
+        if max_gear != ENGINE_MAX_GEARS[category]:
+            raise ValueError(f"ROM engine category {category}: expected max gear "
+                             f"{ENGINE_MAX_GEARS[category]}, got {max_gear}")
+        curve_address, = struct.unpack_from(">I", rom, offset + 48)
+        curve_offset = curve_address - ENGINE_CURVE_RUNTIME_BASE + ENGINE_CURVE_ROM_BASE
+        curve = struct.unpack_from(">160h", rom, curve_offset)
+        parameters.append({
+            "category": category, "rom_offset": f"0x{offset:X}",
+            "engine_halfwords": list(halfwords),
+            "ratio_multiplier": struct.unpack_from(">f", rom, offset + 12)[0],
+            "gear_ratios_including_neutral": list(struct.unpack_from(">7f", rom, offset + 16)),
+            "coefficient_2c": struct.unpack_from(">f", rom, offset + 44)[0],
+            "engine_curve_address": f"0x{curve_address:X}",
+            "engine_curve_peak_raw": max(curve),
+        })
+    symbols = tomllib.loads((root / "lamborghini.syms.toml").read_text(encoding="utf-8"))
+    functions = {f["name"]: f for s in symbols["section"] for f in s.get("functions", [])}
+    head, tail = (functions[n] for n in ("func_80019D20", "func_8001E01C"))
+    covered = head["vram"] <= tail["vram"] and head["vram"] + head["size"] >= tail["vram"] + tail["size"]
+    if not covered:
+        raise ValueError("Updater no longer includes the force-stubbed tail range")
+    return {
+        "rom_sha256": SHA256,
+        "difficulty": {"cursor": "0x800CE7A4", "race_value": "0x800CE79C",
+                       "labels": [text_at(20), text_at(21)]},
+        "model_cursor_base": "0x800CE7E8", "model_categories": categories,
+        "availability": {"flags": "0x800985C0", "progress": "0x800A4170",
+                         "unconditional_categories": [0, 4],
+                         "progress_masks_by_category": {"1": 4, "2": 8, "3": 2,
+                                                        "5": 1, "6": 32, "7": 16}},
+        "slew_region_halfwords_not_eight_cars": list(struct.unpack_from(">8h", rom, SLEW_TABLE_OFFSET)),
+        "threshold_region_floats_not_eight_cars": list(struct.unpack_from(">8f", rom, THRESHOLD_TABLE_OFFSET)),
+        "engine_parameters": parameters,
+        "category_difficulty_e290": [list(struct.unpack_from(">2f", rom, DIFFICULTY_E290_OFFSET + i * 8)) for i in range(8)],
+        "category_difficulty_e2d0": [list(struct.unpack_from(">2f", rom, DIFFICULTY_E2D0_OFFSET + i * 8)) for i in range(8)],
+        "stub_tail_covered_by_updater": covered,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("rom", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    result = json.dumps(audit(args.rom.read_bytes()), indent=2) + "\n"
+    if args.output:
+        args.output.write_text(result, encoding="utf-8", newline="\n")
+    else:
+        print(result, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/emu_instrumentation/probe_car_models.py
+++ b/tools/emu_instrumentation/probe_car_models.py
@@ -1,0 +1,215 @@
+"""Measure model cursors with difficulty held fixed.
+
+Each invocation writes a schema shared with the retained evidence: campaign
+metadata lives at the top level and the selected scenario contains a
+configuration plus successful ``runs``. Failed attempts are retained in a
+separate list and make the process exit non-zero; they are never converted
+into measurements.
+"""
+import argparse
+import datetime
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import re
+import struct
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ROM = ROOT / "Automobili Lamborghini (USA).z64"
+CATEGORIES = (0, 4, 1, 2, 3, 5, 6, 7)
+# Maximum gear values from the engine rows' +8 halfword at ROM 0xAFAE0.
+# The neutral gear is zero, so these are maxima rather than counts.
+MAX_GEAR_BY_CATEGORY = (5, 6, 6, 6, 5, 6, 5, 5)
+FRAME = re.compile(r"F (\d+) st (\d+) sel (\d+) cur (\d+) slot (-?\d+)")
+RECORD = re.compile(r"R (\d+) ch (\d+) cat (\d+) sp (-?\d+).* rec ([0-9A-F]+) ")
+GEAR_STATE_OFFSET = 0xA8
+STEERING_ACCUM_OFFSET = 0xB4
+POSITION_OFFSET = 0x14
+SCRATCH_OFFSET = 0xD0
+
+
+def read_text(path):
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def summarize(path, model, difficulty):
+    samples = []
+    frame = None
+    for line in read_text(path).splitlines():
+        if match := FRAME.fullmatch(line):
+            frame, state, actual_difficulty, _, _ = map(int, match.groups())
+            continue
+        match = RECORD.match(line)
+        if not match or frame is None or state != 8:
+            continue
+        slot, channel, category, speed = map(int, match.groups()[:4])
+        data = bytes.fromhex(match[5])
+        if channel != 1 or category != CATEGORIES[model // 3]:
+            continue
+        if actual_difficulty != difficulty:
+            raise ValueError(f"{path}: difficulty changed to {actual_difficulty}")
+        samples.append((frame, speed, slot, data))
+    if not samples or max(s[1] for s in samples) <= 0:
+        raise ValueError(f"{path}: no moving player with expected category")
+    if len({s[2] for s in samples}) != 1:
+        raise ValueError(f"{path}: ambiguous player body")
+
+    gear_states = [struct.unpack_from(">h", s[3], GEAR_STATE_OFFSET)[0] for s in samples]
+    max_gear = MAX_GEAR_BY_CATEGORY[CATEGORIES[model // 3]]
+    if gear_states[0] != 0 or any(gear < 0 or gear > max_gear for gear in gear_states):
+        raise ValueError(f"{path}: invalid automatic gear sequence: {sorted(set(gear_states))}")
+    if max(s[1] for s in samples) >= 50 and max(gear_states) == 0:
+        raise ValueError(f"{path}: automatic gearbox never left neutral")
+
+    launch = next(s[0] for s in samples if s[1] > 0)
+    thresholds = {str(t): next((s[0] - launch for s in samples if s[1] >= t), None)
+                  for t in (50, 100, 150)}
+    commands = [struct.unpack_from(">h", s[3], STEERING_ACCUM_OFFSET)[0]
+                for s in samples if s[0] <= launch + 80]
+    end100 = next((i for i, s in enumerate(samples) if s[1] >= 100), None)
+    launch_window = {}
+    if end100 is not None:
+        prefix = [s for s in samples[:end100 + 1] if s[0] >= launch]
+        positions = [struct.unpack_from(">3f", s[3], POSITION_OFFSET) for s in prefix]
+        dx, dz = positions[-1][0] - positions[0][0], positions[-1][2] - positions[0][2]
+        distance = math.hypot(dx, dz)
+        deviation = max(abs((p[0] - positions[0][0]) * dz - (p[2] - positions[0][2]) * dx)
+                        / distance for p in positions) if distance else None
+        launch_window = {
+            "minimum_speed_step_to_100": min((b[1] - a[1] for a, b in zip(prefix, prefix[1:])), default=0),
+            "max_lateral_deviation_to_100": deviation,
+        }
+    return {
+        "model_cursor": model, "category": CATEGORIES[model // 3],
+        "difficulty": difficulty, "samples": len(samples), "launch_frame": launch,
+        "updates_to_speed": thresholds, "peak_observed_speed": max(s[1] for s in samples),
+        "scratch_at_launch": list(struct.unpack_from(">4f", next(s[3] for s in samples if s[1] > 0), SCRATCH_OFFSET)),
+        "trace_sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        "launch_steering_slew": max((abs(b - a) for a, b in zip(commands, commands[1:])), default=0),
+        "launch_window": launch_window,
+        "automatic_gearbox_verified": True,
+    }
+
+
+def git_metadata():
+    revision = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True,
+        encoding="utf-8", errors="replace").strip()
+    dirty = bool(subprocess.check_output(
+        ["git", "status", "--porcelain", "--untracked-files=all"], cwd=ROOT,
+        text=True, encoding="utf-8", errors="replace"))
+    return revision, dirty
+
+
+def failure_record(model, rep, difficulty, vis, error, trace, log, exit_code):
+    record = {
+        "model_cursor": model, "difficulty": difficulty, "rep": rep,
+        "requested_vis": vis, "status": "failed", "error": str(error),
+        "exit_code": exit_code,
+    }
+    if trace.exists():
+        record["trace_sha256"] = hashlib.sha256(trace.read_bytes()).hexdigest()
+        frames = re.findall(r"^F (\d+) ", read_text(trace), re.MULTILINE)
+        if frames:
+            record["last_trace_frame"] = int(frames[-1])
+    if log.exists():
+        log_text = read_text(log)
+        record["controlled_exit_observed"] = f"reached {vis} VIs; quitting" in log_text
+        record["native_crash_banner"] = "NATIVE CRASH" in log_text
+    return record
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--exe", type=Path, default=ROOT / "build/lamborghini_modern.exe")
+    parser.add_argument("--rom", type=Path, default=DEFAULT_ROM)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--models", default="0,3,6,9,12,15,18,21")
+    parser.add_argument("--difficulty", type=int, choices=(0, 1), default=0)
+    parser.add_argument("--vis", type=int, default=1000)
+    parser.add_argument("--reps", type=int, default=2)
+    parser.add_argument("--scenario", choices=("launch", "steering"), default="launch")
+    args = parser.parse_args()
+    models = [int(v) for v in args.models.split(",")]
+    if any(v < 0 or v >= 24 for v in models) or args.reps < 1 or args.vis < 1:
+        parser.error("models must be 0-23; reps and vis must be positive")
+    args.out = args.out.resolve()
+    args.out.mkdir(parents=True, exist_ok=True)
+    executable = args.exe.resolve()
+    if not executable.is_file():
+        parser.error(f"missing executable: {executable}")
+    source_revision, source_dirty = git_metadata()
+    executable_sha256 = hashlib.sha256(executable.read_bytes()).hexdigest()
+    rom_sha256 = hashlib.sha256(args.rom.resolve().read_bytes()).hexdigest() if args.rom.is_file() else None
+
+    input_value = "8000" if args.scenario == "launch" else "8000:-80:0"
+    scenario_config = {
+        "headless": True, "warp": "1:2:<model_cursor>:1", "difficulty": args.difficulty,
+        "mode": 0, "input": input_value, "max_vis": args.vis,
+    }
+    summary_path = args.out / "summary.json"
+    if summary_path.exists():
+        loaded_summary = json.loads(read_text(summary_path))
+        summary = loaded_summary if isinstance(loaded_summary, dict) else {}
+    else:
+        summary = {}
+    metadata = {"rom_sha256": rom_sha256, "executable_sha256": executable_sha256,
+                "source_base_revision": source_revision, "source_dirty": source_dirty}
+    if summary:
+        mismatches = [key for key, value in metadata.items()
+                      if key in summary and summary[key] != value]
+        if mismatches:
+            raise SystemExit("existing summary provenance differs for "
+                             + ", ".join(mismatches) + "; choose a new --out directory")
+        existing_scenario = summary.get(args.scenario)
+        if isinstance(existing_scenario, dict):
+            old_config = existing_scenario.get("configuration")
+            if old_config is not None and old_config != scenario_config:
+                raise SystemExit("existing summary configuration differs for "
+                                 + args.scenario + "; choose a new --out directory")
+    summary.update({"date": datetime.date.today().isoformat(), **metadata})
+    summary[args.scenario] = {"configuration": scenario_config, "runs": []}
+    summary.setdefault("excluded_failed_attempts", [])
+    failures = 0
+    for model in models:
+        for rep in range(1, args.reps + 1):
+            stem = f"{args.scenario}_model{model}_difficulty{args.difficulty}_rep{rep}"
+            trace = args.out / (stem + ".txt")
+            log = args.out / (stem + ".log")
+            env = {k: v for k, v in os.environ.items() if not k.startswith("LAMBO_")}
+            env.update(LAMBO_HEADLESS="1", LAMBO_WARP=f"1:2:{model}:1",
+                       LAMBO_WARP_DIFFICULTY=str(args.difficulty), LAMBO_WARP_MODE="0",
+                       LAMBO_CAR_TRACE="1", LAMBO_CAR_TRACE_PATH=str(trace),
+                       LAMBO_MODERN_INPUT=input_value, LAMBO_MODERN_MAX_VIS=str(args.vis))
+            print(stem, flush=True)
+            result = None
+            try:
+                trace.unlink(missing_ok=True)
+                with log.open("wb") as log_file:
+                    subprocess.run([str(executable), "--lambo-debug"], cwd=ROOT, env=env,
+                                   stdout=log_file, stderr=subprocess.STDOUT,
+                                   timeout=180, check=True)
+                log_text = read_text(log)
+                if f"reached {args.vis} VIs; quitting" not in log_text:
+                    raise RuntimeError("process exited without the controlled VI-cap message")
+                result = summarize(trace, model, args.difficulty)
+                result["rep"] = rep
+                summary[args.scenario]["runs"].append(result)
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError,
+                    ValueError, RuntimeError) as error:
+                failures += 1
+                exit_code = getattr(error, "returncode", None)
+                summary["excluded_failed_attempts"].append(
+                    failure_record(model, rep, args.difficulty, args.vis, error,
+                                   trace, log, exit_code))
+            summary_path.write_text(json.dumps(summary, indent=2) + "\n",
+                                   encoding="utf-8", newline="\n")
+            print(json.dumps(result if result is not None else summary["excluded_failed_attempts"][-1]), flush=True)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The original developer warp was writing its `car` argument into the Novice/Expert difficulty cursor, so the old selector campaign did not compare cars. This follow-up selects the real 24 model cursors, hardens the shared vehicle layout and warp/trace code, and retains clean, repeatable launch and steering evidence for the eight physics categories.

Related issue: #150 covers vehicle-performance distinctions and future stats UI work.

## Why?

This is the implementation follow-up for the requested review corrections.

- ROM menu records and the XOR-1 callback prove that `0x800CE7A4` / `0x800CE79C` are difficulty. The real per-player model cursor starts at `0x800CE7E8`.
- Eight categories have separate engine curves and gear ratios. The adjacent eight-entry regions are difficulty lookups, not an eight-car steering table.
- The `func_8001E01C` symbol remains force-stubbed; its range is covered by the live enlarged `func_80019D20` updater, so the runtime status is documented explicitly.
- `lambo_vehicle.h` is a packed layout schema with compile-time assertions and shared guest addresses. Trace, throttle, brake, and their tests use the same offsets.
- The trace writer buffers records, flushes periodically, reports open/write errors, and closes the file. Warp options are parsed once before a request is consumed, and one model cursor is written for every requested player.
- The probe snapshots provenance once, detects untracked source files, rejects incompatible reused output directories, and prefixes raw artifacts with their scenario.

## How was it verified?

- [x] `cmake --build build --target lamborghini_modern -j 4` passed.
- [x] Boot smoke: model 3 and model 9 each completed at the 1000-VI cap after the buffered trace change, with no native crash banner; a clean output directory retained both launch and steering scenarios without overwriting traces.
- [x] All 17 `lambo_` CTest tests passed, including rebuilt throttle/brake bridge tests.
- [x] ROM SHA-256, menu instructions/text, numeric tables, model descriptors, and symbol-range containment passed `audit_car_data.py`.
- [x] Clean evidence from revision `984a91a` contains 16 launch runs and eight steering runs across all eight categories; every run reached the controlled VI cap, verified automatic gear, and left `excluded_failed_attempts` empty.
- [x] The model probe emits the committed top-level scenario/configuration/runs schema and performs explicit UTF-8 file I/O.
- [x] Python syntax checks, generator spacing checks, and the branch-wide `git diff --check` passed.

## Screenshots / video

No car-selection UI change is included. The model/category mapping and comparative measurements are the groundwork for that UI work.

## Risk / rollback

The development warp's `car` argument now means model cursor `0-23`; callers that need difficulty must use `LAMBO_WARP_DIFFICULTY=0|1`. Disable the optional trace with `LAMBO_CAR_TRACE` unset to return to the normal path.

Peak observed speed remains an observation, not a terminal-speed rating. Matched-speed handling, collision-free terminal speed, retail names, and reference-emulator convergence remain future work.