### PR TITLE
feat(saves): import common Controller Pak formats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,9 @@ if(BUILD_TESTING)
     target_include_directories(lambo_controller_pak_storage_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
     )
+    target_compile_definitions(lambo_controller_pak_storage_tests PRIVATE
+        LAMBO_PAK_STORAGE_TESTING=1
+    )
     target_link_libraries(lambo_controller_pak_storage_tests PRIVATE Threads::Threads)
     add_test(NAME lambo_controller_pak_batched_storage COMMAND lambo_controller_pak_storage_tests)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,11 +85,13 @@ if(BUILD_TESTING)
         tests/test_controller_pak.c
         src/libultra_stubs.c
         src/lambo_pak_io.c
+        src/lambo_pak_storage.cpp
     )
     target_include_directories(lambo_controller_pak_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${N64MR}/N64Recomp/include
     )
+    target_link_libraries(lambo_controller_pak_tests PRIVATE Threads::Threads)
     add_test(NAME lambo_controller_pak_identity COMMAND lambo_controller_pak_tests)
 
     add_executable(lambo_controller_pak_io_tests
@@ -100,6 +102,17 @@ if(BUILD_TESTING)
         ${CMAKE_CURRENT_SOURCE_DIR}/src
     )
     add_test(NAME lambo_controller_pak_emulator_formats COMMAND lambo_controller_pak_io_tests)
+
+    add_executable(lambo_controller_pak_storage_tests
+        tests/test_pak_storage.cpp
+        src/lambo_pak_storage.cpp
+        src/lambo_pak_io.c
+    )
+    target_include_directories(lambo_controller_pak_storage_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    target_link_libraries(lambo_controller_pak_storage_tests PRIVATE Threads::Threads)
+    add_test(NAME lambo_controller_pak_batched_storage COMMAND lambo_controller_pak_storage_tests)
 
     add_executable(lambo_startup_tests
         tests/test_startup.cpp
@@ -432,6 +445,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
                                # libc backtrace(3) (POSIX).
         src/libultra_stubs.c   # no-op symbols for ignored libultra CP0 helpers (e.g. __osSetSR)
         src/lambo_pak_io.c
+        src/lambo_pak_storage.cpp
         src/lambo_hud_widescreen.c  # issue #2: gEXSetRectAlign brackets around the race-HUD dials
         src/lambo_flare_widescreen.c  # issue #40: gEXSetRectAspect(STRETCH) bracket around the sun lens-flare ghosts
         src/lambo_fog_widescreen.cpp  # issue #83: widen dense 3P/4P fog to the 1P window/colour (DL rewrite, players>=3)
@@ -590,7 +604,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         # dbghelp.dll. MinGW64 ships the import lib (libdbghelp.a) so an explicit
         # target_link_libraries entry is enough; we don't ship the DLL — the
         # system one is fine.
-        target_link_libraries(lamborghini_modern PRIVATE dbghelp)
+        target_link_libraries(lamborghini_modern PRIVATE dbghelp shell32)
         # Self-contained exe dir: RT64 dlopen()s dxcompiler/dxil at runtime and SDL2 is
         # a dynamic dep; MinGW's own runtime is linked statically so the exe runs
         # outside an MSYS/MinGW shell.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,11 +84,22 @@ if(BUILD_TESTING)
     add_executable(lambo_controller_pak_tests
         tests/test_controller_pak.c
         src/libultra_stubs.c
+        src/lambo_pak_io.c
     )
     target_include_directories(lambo_controller_pak_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${N64MR}/N64Recomp/include
     )
     add_test(NAME lambo_controller_pak_identity COMMAND lambo_controller_pak_tests)
+
+    add_executable(lambo_controller_pak_io_tests
+        tests/test_pak_io.c
+        src/lambo_pak_io.c
+    )
+    target_include_directories(lambo_controller_pak_io_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    add_test(NAME lambo_controller_pak_emulator_formats COMMAND lambo_controller_pak_io_tests)
 
     add_executable(lambo_startup_tests
         tests/test_startup.cpp
@@ -420,6 +431,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
                                # function-lookup trace ring. No deps beyond libc + DbgHelp (Win) /
                                # libc backtrace(3) (POSIX).
         src/libultra_stubs.c   # no-op symbols for ignored libultra CP0 helpers (e.g. __osSetSR)
+        src/lambo_pak_io.c
         src/lambo_hud_widescreen.c  # issue #2: gEXSetRectAlign brackets around the race-HUD dials
         src/lambo_flare_widescreen.c  # issue #40: gEXSetRectAspect(STRETCH) bracket around the sun lens-flare ghosts
         src/lambo_fog_widescreen.cpp  # issue #83: widen dense 3P/4P fog to the 1P window/colour (DL rewrite, players>=3)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,32 @@ Only the **North American (USA) release** is currently supported. The build read
 
 This is an in-progress port. It boots, presents the attract/title sequence and menus, and goes in-race. Input, audio, and rendering are wired through RT64. Expect rough edges — see the issue tracker.
 
+## Controller Pak save compatibility
+
+Automobili Lamborghini stores its records and progress on a Controller Pak, not in
+cartridge EEPROM. The port's normal save is `lambo_controller_pak.mpk` in its config
+directory. It is a standard raw 32 KiB Controller Pak image and can be opened by
+Controller Pak tools or used by emulators that accept `.mpk` files.
+
+The port recognises these common containers and uses controller port 1:
+
+| Format | Size | Compatibility |
+| --- | ---: | --- |
+| Raw `.mpk` / `.pak` | 32 KiB | Emulators, flash carts, and tools that accept raw Controller Pak images |
+| Four-port `.mpk` | 128 KiB | Wii64/not64 and multi-controller dumps |
+| Mupen64Plus-Next `.srm` | exactly 290 KiB | RetroArch combined save; Pak 1 begins at offset `0x800` |
+| DexDrive `.n64` | 36,928 bytes | DexDrive Controller Pak backup |
+
+To import a save, drag one of those files onto the game executable, or run
+`lamborghini_modern --import-save "path/to/save.srm"`. The source is left untouched;
+an existing port save is backed up before the imported Pak replaces it. A 2 KiB `.eep`
+file is cartridge EEPROM and does not contain this game's Controller Pak progress.
+
+For a save that remains shared with an emulator, launch with
+`--controller-pak "path/to/save.srm"` (or set `LAMBO_CONTROLLER_PAK_FILE`). Writes update
+only Pak 1 inside an existing Mupen64Plus-Next, four-port, or DexDrive container and preserve
+all unrelated bytes. Do not have both programs open on the shared file at once.
+
 ## Graphics options
 
 Graphics settings persist in `graphics.json` (in `%LOCALAPPDATA%\LamborghiniRecomp` on

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ file is cartridge EEPROM and does not contain this game's Controller Pak progres
 For a save that remains shared with an emulator, launch with
 `--controller-pak "path/to/save.srm"` (or set `LAMBO_CONTROLLER_PAK_FILE`). Writes update
 only Pak 1 inside an existing Mupen64Plus-Next, four-port, or DexDrive container and preserve
-all unrelated bytes. Do not have both programs open on the shared file at once.
+all unrelated bytes. Joybus write bursts are coalesced and atomically published by a background
+writer instead of blocking the emulation thread. Do not have both programs open on the shared
+file at once.
 
 ## Graphics options
 

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -379,7 +379,7 @@ std::filesystem::path app_config_dir() {
         return std::filesystem::current_path();
     }
 #if defined(_WIN32)
-    if (const char* localappdata = std::getenv("LOCALAPPDATA")) {
+    if (const wchar_t* localappdata = _wgetenv(L"LOCALAPPDATA")) {
         return std::filesystem::path{localappdata} / kAppFolderName;
     }
 #else

--- a/src/lambo_pak_io.c
+++ b/src/lambo_pak_io.c
@@ -1,0 +1,257 @@
+#include "lambo_pak_io.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+enum {
+    FOUR_PORT_SIZE = 4 * LAMBO_PAK_SIZE,
+    RETROARCH_SIZE = 296960,
+    RETROARCH_PAK_OFFSET = 0x800,
+    DEXDRIVE_SIZE = 36928,
+    DEXDRIVE_PAK_OFFSET = 0x1040
+};
+
+static const unsigned char dexdrive_magic[12] = {
+    '1', '2', '3', '-', '4', '5', '6', '-', 'S', 'T', 'D', 0
+};
+
+/* Layout ground truth:
+ * - Mupen64Plus-Next's libretro_memory.h stores EEPROM[0x800], then four
+ *   MEMPAK_SIZE (0x8000) images, SRAM[0x8000], and FlashRAM[0x20000].
+ * - MPKEdit's parser strips 0x800 from that SRM and 0x1040 from a DexDrive
+ *   file after checking the "123-456-STD" signature.
+ * These are container seams only; Controller Pak bytes themselves are never
+ * byte-swapped by the referenced emulator/converter implementations. */
+
+typedef struct PakContainer {
+    uint8_t* data;
+    size_t size;
+    size_t pak_offset;
+    LamboPakFormat format;
+} PakContainer;
+
+typedef struct PakFormatDescriptor {
+    LamboPakFormat format;
+    size_t size;
+    size_t pak_offset;
+    const char* name;
+    int requires_dexdrive_magic;
+} PakFormatDescriptor;
+
+static const PakFormatDescriptor formats[] = {
+    { LAMBO_PAK_FORMAT_RAW, LAMBO_PAK_SIZE, 0, "raw MPK", 0 },
+    { LAMBO_PAK_FORMAT_FOUR_PORT, FOUR_PORT_SIZE, 0, "four-port MPK", 0 },
+    { LAMBO_PAK_FORMAT_RETROARCH, RETROARCH_SIZE, RETROARCH_PAK_OFFSET, "Mupen64Plus-Next SRM", 0 },
+    { LAMBO_PAK_FORMAT_DEXDRIVE, DEXDRIVE_SIZE, DEXDRIVE_PAK_OFFSET, "DexDrive N64", 1 }
+};
+
+static LamboPakIoResult result_error(const char* message, const char* path) {
+    LamboPakIoResult result;
+    memset(&result, 0, sizeof(result));
+    if (path != NULL) snprintf(result.error, sizeof(result.error), "%s: %s", message, path);
+    else snprintf(result.error, sizeof(result.error), "%s", message);
+    return result;
+}
+
+static LamboPakIoResult result_ok(const PakContainer* container) {
+    LamboPakIoResult result;
+    memset(&result, 0, sizeof(result));
+    result.ok = 1;
+    result.format = container->format;
+    result.container_size = container->size;
+    result.pak_offset = container->pak_offset;
+    return result;
+}
+
+static int identify_container(PakContainer* container) {
+    size_t index;
+    for (index = 0; index < sizeof(formats) / sizeof(formats[0]); ++index) {
+        const PakFormatDescriptor* descriptor = &formats[index];
+        if (container->size != descriptor->size) continue;
+        if (descriptor->requires_dexdrive_magic &&
+            memcmp(container->data, dexdrive_magic, sizeof(dexdrive_magic)) != 0) return 0;
+        container->format = descriptor->format;
+        container->pak_offset = descriptor->pak_offset;
+        return 1;
+    }
+    return 0;
+}
+
+static int pak_image_is_plausible(const uint8_t image[LAMBO_PAK_SIZE]) {
+    static const size_t id_offsets[] = { 0x20, 0x60, 0x80, 0xc0 };
+    size_t area;
+    for (area = 0; area < sizeof(id_offsets) / sizeof(id_offsets[0]); ++area) {
+        const size_t offset = id_offsets[area];
+        uint16_t sum = 0;
+        uint16_t inverted;
+        uint16_t stored_sum;
+        uint16_t stored_inverted;
+        size_t word;
+        for (word = 0; word < 14; ++word) {
+            const size_t pos = offset + word * 2;
+            sum = (uint16_t)(sum + (uint16_t)((image[pos] << 8) | image[pos + 1]));
+        }
+        inverted = (uint16_t)(0xfff2u - sum);
+        stored_sum = (uint16_t)((image[offset + 0x1c] << 8) | image[offset + 0x1d]);
+        stored_inverted = (uint16_t)((image[offset + 0x1e] << 8) | image[offset + 0x1f]);
+        /* DexDrive software is known to toggle bit 0x000c in the inverted checksum. */
+        if (stored_sum == sum &&
+            (stored_inverted == inverted || (uint16_t)(stored_inverted ^ 0x000cu) == inverted))
+            return 1;
+    }
+    return 0;
+}
+
+static LamboPakIoResult load_container(const char* path, PakContainer* container) {
+    FILE* file;
+    long length;
+    size_t read_count;
+
+    memset(container, 0, sizeof(*container));
+    file = fopen(path, "rb");
+    if (file == NULL) return result_error("cannot open Controller Pak file", path);
+    if (fseek(file, 0, SEEK_END) != 0 || (length = ftell(file)) < 0 ||
+        fseek(file, 0, SEEK_SET) != 0) {
+        fclose(file);
+        return result_error("cannot determine Controller Pak file size", path);
+    }
+    container->size = (size_t)length;
+    if (container->size == 0 || container->size > RETROARCH_SIZE) {
+        fclose(file);
+        return result_error("unsupported Controller Pak file size", path);
+    }
+    container->data = (uint8_t*)malloc(container->size);
+    if (container->data == NULL) {
+        fclose(file);
+        return result_error("out of memory while reading Controller Pak", path);
+    }
+    read_count = fread(container->data, 1, container->size, file);
+    if (fclose(file) != 0 || read_count != container->size) {
+        free(container->data);
+        container->data = NULL;
+        return result_error("cannot read complete Controller Pak file", path);
+    }
+    if (!identify_container(container)) {
+        free(container->data);
+        container->data = NULL;
+        return result_error("unsupported Controller Pak format (expected 32/128 KiB MPK, 290 KiB SRM, or DexDrive N64)", path);
+    }
+    if (!pak_image_is_plausible(container->data + container->pak_offset)) {
+        free(container->data);
+        container->data = NULL;
+        return result_error("Controller Pak has no checksum-valid ID block", path);
+    }
+    return result_ok(container);
+}
+
+static LamboPakIoResult publish_container(const char* path, const PakContainer* container) {
+    char temporary[1024];
+    FILE* file;
+    size_t written;
+    LamboPakIoResult result;
+
+    if ((int)snprintf(temporary, sizeof(temporary), "%s.tmp", path) >= (int)sizeof(temporary))
+        return result_error("Controller Pak path is too long", path);
+    file = fopen(temporary, "wb");
+    if (file == NULL) return result_error("cannot create temporary Controller Pak file", temporary);
+    written = fwrite(container->data, 1, container->size, file);
+    if (fclose(file) != 0 || written != container->size) {
+        remove(temporary);
+        return result_error("cannot write complete Controller Pak file", temporary);
+    }
+#if defined(_WIN32)
+    /* Unlike MSVCRT rename(), MoveFileEx replaces without first deleting the live
+     * save. A failed publish therefore leaves the prior emulator container intact. */
+    if (!MoveFileExA(temporary, path, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        remove(temporary);
+        return result_error("cannot replace Controller Pak file", path);
+    }
+#else
+    if (rename(temporary, path) != 0) {
+        remove(temporary);
+        return result_error("cannot replace Controller Pak file", path);
+    }
+#endif
+    result = result_ok(container);
+    return result;
+}
+
+LamboPakIoResult lambo_pak_read_file(const char* path, uint8_t image[LAMBO_PAK_SIZE]) {
+    PakContainer container;
+    LamboPakIoResult result = load_container(path, &container);
+    if (!result.ok) return result;
+    memcpy(image, container.data + container.pak_offset, LAMBO_PAK_SIZE);
+    free(container.data);
+    return result;
+}
+
+LamboPakIoResult lambo_pak_probe_file(const char* path) {
+    PakContainer container;
+    LamboPakIoResult result = load_container(path, &container);
+    free(container.data);
+    return result;
+}
+
+LamboPakIoResult lambo_pak_write_file(const char* path, const uint8_t image[LAMBO_PAK_SIZE]) {
+    PakContainer container;
+    LamboPakIoResult loaded = load_container(path, &container);
+
+    if (!loaded.ok) {
+        FILE* probe = fopen(path, "rb");
+        if (probe != NULL) {
+            fclose(probe);
+            return loaded; /* Never replace an existing unrecognised file. */
+        }
+        memset(&container, 0, sizeof(container));
+        container.size = LAMBO_PAK_SIZE;
+        container.format = LAMBO_PAK_FORMAT_RAW;
+        container.data = (uint8_t*)malloc(container.size);
+        if (container.data == NULL) return result_error("out of memory while saving Controller Pak", path);
+    }
+
+    memcpy(container.data + container.pak_offset, image, LAMBO_PAK_SIZE);
+    loaded = publish_container(path, &container);
+    free(container.data);
+    return loaded;
+}
+
+LamboPakIoResult lambo_pak_import_file(const char* source_path, const char* destination_path) {
+    uint8_t image[LAMBO_PAK_SIZE];
+    LamboPakIoResult source;
+    LamboPakIoResult written;
+    if (strcmp(source_path, destination_path) == 0)
+        return result_error("import source and destination must be different", source_path);
+    source = lambo_pak_read_file(source_path, image);
+    if (!source.ok) return source;
+
+    /* Imports intentionally produce raw MPK. Do not let an existing destination's
+     * container format affect the result, and never modify the source file. */
+    {
+        PakContainer container;
+        memset(&container, 0, sizeof(container));
+        container.data = image;
+        container.size = LAMBO_PAK_SIZE;
+        container.format = LAMBO_PAK_FORMAT_RAW;
+        written = publish_container(destination_path, &container);
+    }
+    if (written.ok) {
+        written.format = source.format;
+        written.container_size = source.container_size;
+        written.pak_offset = source.pak_offset;
+    }
+    return written;
+}
+
+const char* lambo_pak_format_name(LamboPakFormat format) {
+    size_t index;
+    for (index = 0; index < sizeof(formats) / sizeof(formats[0]); ++index) {
+        if (formats[index].format == format) return formats[index].name;
+    }
+    return "unknown";
+}

--- a/src/lambo_pak_io.c
+++ b/src/lambo_pak_io.c
@@ -1,8 +1,13 @@
 #include "lambo_pak_io.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#if !defined(_WIN32)
+#include <sys/stat.h>
+#endif
 
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
@@ -30,6 +35,7 @@ static const unsigned char dexdrive_magic[12] = {
  * byte-swapped by the referenced emulator/converter implementations. */
 
 typedef struct PakContainer {
+    /* load_container owns this allocation; callers free it exactly once. */
     uint8_t* data;
     size_t size;
     size_t pak_offset;
@@ -58,6 +64,75 @@ static LamboPakIoResult result_error(const char* message, const char* path) {
     else snprintf(result.error, sizeof(result.error), "%s", message);
     return result;
 }
+
+static LamboPakIoResult result_errno(const char* message, const char* path, int code) {
+    LamboPakIoResult result;
+    memset(&result, 0, sizeof(result));
+    snprintf(result.error, sizeof(result.error), "%s (errno=%d: %s): %s",
+             message, code, strerror(code), path != NULL ? path : "");
+    return result;
+}
+
+#if defined(_WIN32)
+static LamboPakIoResult result_win32(const char* message, const char* path, DWORD code) {
+    LamboPakIoResult result;
+    memset(&result, 0, sizeof(result));
+    snprintf(result.error, sizeof(result.error), "%s (Win32 error=%lu): %s",
+             message, (unsigned long)code, path != NULL ? path : "");
+    return result;
+}
+
+static wchar_t* path_to_wide(const char* path) {
+    int count;
+    wchar_t* wide;
+    if (path == NULL) {
+        errno = EINVAL;
+        return NULL;
+    }
+    count = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, NULL, 0);
+    if (count == 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    wide = (wchar_t*)malloc((size_t)count * sizeof(*wide));
+    if (wide == NULL) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, wide, count) == 0) {
+        free(wide);
+        errno = EINVAL;
+        return NULL;
+    }
+    return wide;
+}
+
+static FILE* path_open(const char* path, const wchar_t* mode) {
+    wchar_t* wide = path_to_wide(path);
+    FILE* file;
+    if (wide == NULL) return NULL;
+    file = _wfopen(wide, mode);
+    free(wide);
+    return file;
+}
+
+static int path_remove(const char* path) {
+    wchar_t* wide = path_to_wide(path);
+    int removed;
+    if (wide == NULL) return -1;
+    removed = _wremove(wide);
+    free(wide);
+    return removed;
+}
+#else
+static FILE* path_open(const char* path, const char* mode) {
+    return fopen(path, mode);
+}
+
+static int path_remove(const char* path) {
+    return remove(path);
+}
+#endif
 
 static LamboPakIoResult result_ok(const PakContainer* container) {
     LamboPakIoResult result;
@@ -114,12 +189,19 @@ static LamboPakIoResult load_container(const char* path, PakContainer* container
     size_t read_count;
 
     memset(container, 0, sizeof(*container));
-    file = fopen(path, "rb");
-    if (file == NULL) return result_error("cannot open Controller Pak file", path);
+    file = path_open(path,
+#if defined(_WIN32)
+                     L"rb"
+#else
+                     "rb"
+#endif
+    );
+    if (file == NULL) return result_errno("cannot open Controller Pak file", path, errno);
     if (fseek(file, 0, SEEK_END) != 0 || (length = ftell(file)) < 0 ||
         fseek(file, 0, SEEK_SET) != 0) {
+        const int code = errno != 0 ? errno : EIO;
         fclose(file);
-        return result_error("cannot determine Controller Pak file size", path);
+        return result_errno("cannot determine Controller Pak file size", path, code);
     }
     container->size = (size_t)length;
     if (container->size == 0 || container->size > RETROARCH_SIZE) {
@@ -133,9 +215,10 @@ static LamboPakIoResult load_container(const char* path, PakContainer* container
     }
     read_count = fread(container->data, 1, container->size, file);
     if (fclose(file) != 0 || read_count != container->size) {
+        const int code = errno != 0 ? errno : EIO;
         free(container->data);
         container->data = NULL;
-        return result_error("cannot read complete Controller Pak file", path);
+        return result_errno("cannot read complete Controller Pak file", path, code);
     }
     if (!identify_container(container)) {
         free(container->data);
@@ -150,35 +233,86 @@ static LamboPakIoResult load_container(const char* path, PakContainer* container
     return result_ok(container);
 }
 
-static LamboPakIoResult publish_container(const char* path, const PakContainer* container) {
-    char temporary[1024];
+static LamboPakIoResult publish_bytes(const char* path, const uint8_t* data, size_t size,
+                                      LamboPakFormat format, size_t pak_offset) {
+    char* temporary;
     FILE* file;
     size_t written;
     LamboPakIoResult result;
+    PakContainer view;
+    const size_t path_length = strlen(path);
 
-    if ((int)snprintf(temporary, sizeof(temporary), "%s.tmp", path) >= (int)sizeof(temporary))
-        return result_error("Controller Pak path is too long", path);
-    file = fopen(temporary, "wb");
-    if (file == NULL) return result_error("cannot create temporary Controller Pak file", temporary);
-    written = fwrite(container->data, 1, container->size, file);
-    if (fclose(file) != 0 || written != container->size) {
-        remove(temporary);
-        return result_error("cannot write complete Controller Pak file", temporary);
+    temporary = (char*)malloc(path_length + 5);
+    if (temporary == NULL) return result_error("out of memory while saving Controller Pak", path);
+    memcpy(temporary, path, path_length);
+    memcpy(temporary + path_length, ".tmp", 5);
+    file = path_open(temporary,
+#if defined(_WIN32)
+                     L"wb"
+#else
+                     "wb"
+#endif
+    );
+    if (file == NULL) {
+        result = result_errno("cannot create temporary Controller Pak file", temporary, errno);
+        free(temporary);
+        return result;
+    }
+    written = fwrite(data, 1, size, file);
+    if (fclose(file) != 0 || written != size) {
+        const int code = errno != 0 ? errno : EIO;
+        path_remove(temporary);
+        result = result_errno("cannot write complete Controller Pak file", temporary, code);
+        free(temporary);
+        return result;
     }
 #if defined(_WIN32)
+    {
+        wchar_t* wide_temporary = path_to_wide(temporary);
+        wchar_t* wide_path = path_to_wide(path);
+        DWORD code = ERROR_SUCCESS;
+        int attempt;
+        int moved = 0;
     /* Unlike MSVCRT rename(), MoveFileEx replaces without first deleting the live
      * save. A failed publish therefore leaves the prior emulator container intact. */
-    if (!MoveFileExA(temporary, path, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
-        remove(temporary);
-        return result_error("cannot replace Controller Pak file", path);
+        if (wide_temporary != NULL && wide_path != NULL) {
+            for (attempt = 0; attempt < 5; ++attempt) {
+                if (MoveFileExW(wide_temporary, wide_path,
+                                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+                    moved = 1;
+                    break;
+                }
+                code = GetLastError();
+                if (code != ERROR_ACCESS_DENIED && code != ERROR_SHARING_VIOLATION) break;
+                Sleep((DWORD)(10 * (attempt + 1)));
+            }
+        } else {
+            code = ERROR_NO_UNICODE_TRANSLATION;
+        }
+        if (!moved) {
+            free(wide_temporary);
+            free(wide_path);
+            path_remove(temporary);
+            free(temporary);
+            return result_win32("cannot replace Controller Pak file", path, code);
+        }
+        free(wide_temporary);
+        free(wide_path);
     }
 #else
     if (rename(temporary, path) != 0) {
-        remove(temporary);
-        return result_error("cannot replace Controller Pak file", path);
+        const int code = errno;
+        path_remove(temporary);
+        free(temporary);
+        return result_errno("cannot replace Controller Pak file", path, code);
     }
 #endif
-    result = result_ok(container);
+    free(temporary);
+    memset(&view, 0, sizeof(view));
+    view.size = size;
+    view.format = format;
+    view.pak_offset = pak_offset;
+    result = result_ok(&view);
     return result;
 }
 
@@ -198,16 +332,55 @@ LamboPakIoResult lambo_pak_probe_file(const char* path) {
     return result;
 }
 
+typedef enum TargetState {
+    TARGET_MISSING,
+    TARGET_BLANK_RAW,
+    TARGET_OTHER
+} TargetState;
+
+static TargetState inspect_unrecognised_target(const char* path) {
+    FILE* file = path_open(path,
+#if defined(_WIN32)
+                           L"rb"
+#else
+                           "rb"
+#endif
+    );
+    long length;
+    size_t index;
+    int byte;
+    if (file == NULL) return errno == ENOENT ? TARGET_MISSING : TARGET_OTHER;
+    if (fseek(file, 0, SEEK_END) != 0 || (length = ftell(file)) < 0 ||
+        fseek(file, 0, SEEK_SET) != 0) {
+        fclose(file);
+        return TARGET_OTHER;
+    }
+    if (length == 0) {
+        fclose(file);
+        return TARGET_BLANK_RAW;
+    }
+    if ((size_t)length != LAMBO_PAK_SIZE) {
+        fclose(file);
+        return TARGET_OTHER;
+    }
+    for (index = 0; index < LAMBO_PAK_SIZE; ++index) {
+        byte = fgetc(file);
+        if (byte != 0) {
+            fclose(file);
+            return TARGET_OTHER;
+        }
+    }
+    fclose(file);
+    return TARGET_BLANK_RAW;
+}
+
 LamboPakIoResult lambo_pak_write_file(const char* path, const uint8_t image[LAMBO_PAK_SIZE]) {
     PakContainer container;
     LamboPakIoResult loaded = load_container(path, &container);
 
     if (!loaded.ok) {
-        FILE* probe = fopen(path, "rb");
-        if (probe != NULL) {
-            fclose(probe);
-            return loaded; /* Never replace an existing unrecognised file. */
-        }
+        const TargetState state = inspect_unrecognised_target(path);
+        if (state == TARGET_OTHER) return loaded;
         memset(&container, 0, sizeof(container));
         container.size = LAMBO_PAK_SIZE;
         container.format = LAMBO_PAK_FORMAT_RAW;
@@ -216,30 +389,63 @@ LamboPakIoResult lambo_pak_write_file(const char* path, const uint8_t image[LAMB
     }
 
     memcpy(container.data + container.pak_offset, image, LAMBO_PAK_SIZE);
-    loaded = publish_container(path, &container);
+    loaded = publish_bytes(path, container.data, container.size,
+                           container.format, container.pak_offset);
     free(container.data);
     return loaded;
+}
+
+static int paths_refer_to_same_file(const char* first, const char* second) {
+#if defined(_WIN32)
+    wchar_t* wide_first = path_to_wide(first);
+    wchar_t* wide_second = path_to_wide(second);
+    HANDLE first_handle;
+    HANDLE second_handle;
+    BY_HANDLE_FILE_INFORMATION first_info;
+    BY_HANDLE_FILE_INFORMATION second_info;
+    int same = 0;
+    if (wide_first == NULL || wide_second == NULL) {
+        free(wide_first);
+        free(wide_second);
+        return 0;
+    }
+    first_handle = CreateFileW(wide_first, 0, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                               NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    second_handle = CreateFileW(wide_second, 0, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (first_handle != INVALID_HANDLE_VALUE && second_handle != INVALID_HANDLE_VALUE &&
+        GetFileInformationByHandle(first_handle, &first_info) &&
+        GetFileInformationByHandle(second_handle, &second_info)) {
+        same = first_info.dwVolumeSerialNumber == second_info.dwVolumeSerialNumber &&
+               first_info.nFileIndexHigh == second_info.nFileIndexHigh &&
+               first_info.nFileIndexLow == second_info.nFileIndexLow;
+    }
+    if (first_handle != INVALID_HANDLE_VALUE) CloseHandle(first_handle);
+    if (second_handle != INVALID_HANDLE_VALUE) CloseHandle(second_handle);
+    free(wide_first);
+    free(wide_second);
+    return same;
+#else
+    struct stat first_info;
+    struct stat second_info;
+    return stat(first, &first_info) == 0 && stat(second, &second_info) == 0 &&
+           first_info.st_dev == second_info.st_dev && first_info.st_ino == second_info.st_ino;
+#endif
 }
 
 LamboPakIoResult lambo_pak_import_file(const char* source_path, const char* destination_path) {
     uint8_t image[LAMBO_PAK_SIZE];
     LamboPakIoResult source;
     LamboPakIoResult written;
-    if (strcmp(source_path, destination_path) == 0)
+    if (paths_refer_to_same_file(source_path, destination_path))
         return result_error("import source and destination must be different", source_path);
     source = lambo_pak_read_file(source_path, image);
     if (!source.ok) return source;
 
     /* Imports intentionally produce raw MPK. Do not let an existing destination's
      * container format affect the result, and never modify the source file. */
-    {
-        PakContainer container;
-        memset(&container, 0, sizeof(container));
-        container.data = image;
-        container.size = LAMBO_PAK_SIZE;
-        container.format = LAMBO_PAK_FORMAT_RAW;
-        written = publish_container(destination_path, &container);
-    }
+    written = publish_bytes(destination_path, image, LAMBO_PAK_SIZE,
+                            LAMBO_PAK_FORMAT_RAW, 0);
     if (written.ok) {
         written.format = source.format;
         written.container_size = source.container_size;

--- a/src/lambo_pak_io.c
+++ b/src/lambo_pak_io.c
@@ -347,8 +347,8 @@ static TargetState inspect_unrecognised_target(const char* path) {
 #endif
     );
     long length;
-    size_t index;
-    int byte;
+    uint8_t block[4096];
+    size_t offset;
     if (file == NULL) return errno == ENOENT ? TARGET_MISSING : TARGET_OTHER;
     if (fseek(file, 0, SEEK_END) != 0 || (length = ftell(file)) < 0 ||
         fseek(file, 0, SEEK_SET) != 0) {
@@ -363,11 +363,17 @@ static TargetState inspect_unrecognised_target(const char* path) {
         fclose(file);
         return TARGET_OTHER;
     }
-    for (index = 0; index < LAMBO_PAK_SIZE; ++index) {
-        byte = fgetc(file);
-        if (byte != 0) {
+    for (offset = 0; offset < LAMBO_PAK_SIZE; offset += sizeof(block)) {
+        size_t index;
+        if (fread(block, 1, sizeof(block), file) != sizeof(block)) {
             fclose(file);
             return TARGET_OTHER;
+        }
+        for (index = 0; index < sizeof(block); ++index) {
+            if (block[index] != 0) {
+                fclose(file);
+                return TARGET_OTHER;
+            }
         }
     }
     fclose(file);

--- a/src/lambo_pak_io.h
+++ b/src/lambo_pak_io.h
@@ -40,11 +40,6 @@ LamboPakIoResult lambo_pak_import_file(const char* source_path, const char* dest
 
 const char* lambo_pak_format_name(LamboPakFormat format);
 
-void lambo_pak_set_default_path(const char* path);
-
-/* Explicit CLI selection takes precedence over LAMBO_CONTROLLER_PAK_FILE. */
-void lambo_pak_override_path(const char* path);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/lambo_pak_io.h
+++ b/src/lambo_pak_io.h
@@ -1,0 +1,52 @@
+#ifndef LAMBO_PAK_IO_H
+#define LAMBO_PAK_IO_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LAMBO_PAK_SIZE 0x8000u
+
+typedef enum LamboPakFormat {
+    LAMBO_PAK_FORMAT_RAW,
+    LAMBO_PAK_FORMAT_FOUR_PORT,
+    LAMBO_PAK_FORMAT_RETROARCH,
+    LAMBO_PAK_FORMAT_DEXDRIVE
+} LamboPakFormat;
+
+typedef struct LamboPakIoResult {
+    int ok;
+    LamboPakFormat format;
+    size_t container_size;
+    size_t pak_offset;
+    char error[192];
+} LamboPakIoResult;
+
+LamboPakIoResult lambo_pak_probe_file(const char* path);
+
+LamboPakIoResult lambo_pak_read_file(const char* path, uint8_t image[LAMBO_PAK_SIZE]);
+
+/*
+ * Atomically update controller 1's Pak. If path already contains a recognised
+ * container, bytes outside the Pak are retained; a new path is created as raw MPK.
+ */
+LamboPakIoResult lambo_pak_write_file(const char* path, const uint8_t image[LAMBO_PAK_SIZE]);
+
+/* The source is never modified; source and destination must be different files. */
+LamboPakIoResult lambo_pak_import_file(const char* source_path, const char* destination_path);
+
+const char* lambo_pak_format_name(LamboPakFormat format);
+
+void lambo_pak_set_default_path(const char* path);
+
+/* Explicit CLI selection takes precedence over LAMBO_CONTROLLER_PAK_FILE. */
+void lambo_pak_override_path(const char* path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/lambo_pak_storage.cpp
+++ b/src/lambo_pak_storage.cpp
@@ -24,9 +24,13 @@ struct StorageState {
     uint64_t generation = 0;
     bool dirty = false;
     bool writing = false;
+    bool flush_requested = false;
     bool stopping = false;
     bool exit_handler_registered = false;
     LamboPakIoResult last_result{};
+#if defined(LAMBO_PAK_STORAGE_TESTING)
+    LamboPakStorageWriteHook write = lambo_pak_write_file;
+#endif
 };
 
 StorageState& state() {
@@ -48,7 +52,12 @@ void publish_snapshot(StorageState& storage, std::unique_lock<std::mutex>& lock)
     storage.dirty = false;
     storage.writing = true;
     lock.unlock();
-    const LamboPakIoResult result = lambo_pak_write_file(path.c_str(), image.data());
+    const LamboPakIoResult result =
+#if defined(LAMBO_PAK_STORAGE_TESTING)
+        storage.write(path.c_str(), image.data());
+#else
+        lambo_pak_write_file(path.c_str(), image.data());
+#endif
     if (!result.ok) std::fprintf(stderr, "[pak] save failed: %s\n", result.error);
     lock.lock();
     storage.last_result = result;
@@ -63,16 +72,23 @@ void storage_worker() {
         storage.changed.wait(lock, [&storage] { return storage.dirty || storage.stopping; });
         if (!storage.dirty && storage.stopping) return;
 
-        if (!storage.stopping) {
+        if (!storage.stopping && !storage.flush_requested) {
             const uint64_t generation = storage.generation;
             const auto deadline = storage.deadline;
             storage.changed.wait_until(lock, deadline, [&storage, generation] {
-                return storage.stopping || storage.generation != generation;
+                return storage.stopping || storage.flush_requested ||
+                       storage.generation != generation;
             });
-            if (!storage.stopping && storage.generation != generation) continue;
+            if (!storage.stopping && !storage.flush_requested &&
+                storage.generation != generation) {
+                continue;
+            }
         }
 
+        if (!storage.dirty) continue;
         publish_snapshot(storage, lock);
+        if (!storage.dirty) storage.flush_requested = false;
+        storage.changed.notify_all();
         if (storage.stopping && !storage.dirty) return;
     }
 }
@@ -122,10 +138,13 @@ extern "C" void lambo_pak_storage_schedule_save(const uint8_t image[LAMBO_PAK_SI
 extern "C" LamboPakIoResult lambo_pak_storage_flush(void) {
     StorageState& storage = state();
     std::unique_lock lock(storage.mutex);
-    while (storage.writing) storage.changed.wait(lock);
-    while (storage.dirty) {
-        publish_snapshot(storage, lock);
-        while (storage.writing) storage.changed.wait(lock);
+    if (storage.dirty || storage.writing) {
+        start_worker(storage);
+        storage.flush_requested = true;
+        storage.changed.notify_all();
+        storage.changed.wait(lock, [&storage] {
+            return !storage.dirty && !storage.writing;
+        });
     }
     return storage.last_result.ok ? storage.last_result :
            (storage.last_result.error[0] != '\0' ? storage.last_result : idle_result());
@@ -143,5 +162,14 @@ extern "C" void lambo_pak_storage_shutdown(void) {
     {
         std::lock_guard lock(storage.mutex);
         storage.stopping = false;
+        storage.flush_requested = false;
     }
 }
+
+#if defined(LAMBO_PAK_STORAGE_TESTING)
+extern "C" void lambo_pak_storage_set_write_hook(LamboPakStorageWriteHook hook) {
+    StorageState& storage = state();
+    std::lock_guard lock(storage.mutex);
+    storage.write = hook != nullptr ? hook : lambo_pak_write_file;
+}
+#endif

--- a/src/lambo_pak_storage.cpp
+++ b/src/lambo_pak_storage.cpp
@@ -1,0 +1,147 @@
+#include "lambo_pak_storage.h"
+
+#include <array>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace {
+
+constexpr auto kSaveDebounce = std::chrono::milliseconds(250);
+
+struct StorageState {
+    std::mutex mutex;
+    std::condition_variable changed;
+    std::thread worker;
+    std::string path{"lambo_controller_pak.mpk"};
+    std::array<uint8_t, LAMBO_PAK_SIZE> pending{};
+    std::chrono::steady_clock::time_point deadline{};
+    uint64_t generation = 0;
+    bool dirty = false;
+    bool writing = false;
+    bool stopping = false;
+    bool exit_handler_registered = false;
+    LamboPakIoResult last_result{};
+};
+
+StorageState& state() {
+    static StorageState value;
+    return value;
+}
+
+LamboPakIoResult idle_result() {
+    LamboPakIoResult result{};
+    result.ok = 1;
+    result.format = LAMBO_PAK_FORMAT_RAW;
+    result.container_size = LAMBO_PAK_SIZE;
+    return result;
+}
+
+void publish_snapshot(StorageState& storage, std::unique_lock<std::mutex>& lock) {
+    const auto image = storage.pending;
+    const std::string path = storage.path;
+    storage.dirty = false;
+    storage.writing = true;
+    lock.unlock();
+    const LamboPakIoResult result = lambo_pak_write_file(path.c_str(), image.data());
+    if (!result.ok) std::fprintf(stderr, "[pak] save failed: %s\n", result.error);
+    lock.lock();
+    storage.last_result = result;
+    storage.writing = false;
+    storage.changed.notify_all();
+}
+
+void storage_worker() {
+    StorageState& storage = state();
+    std::unique_lock lock(storage.mutex);
+    for (;;) {
+        storage.changed.wait(lock, [&storage] { return storage.dirty || storage.stopping; });
+        if (!storage.dirty && storage.stopping) return;
+
+        if (!storage.stopping) {
+            const uint64_t generation = storage.generation;
+            const auto deadline = storage.deadline;
+            storage.changed.wait_until(lock, deadline, [&storage, generation] {
+                return storage.stopping || storage.generation != generation;
+            });
+            if (!storage.stopping && storage.generation != generation) continue;
+        }
+
+        publish_snapshot(storage, lock);
+        if (storage.stopping && !storage.dirty) return;
+    }
+}
+
+void start_worker(StorageState& storage) {
+    if (storage.worker.joinable()) return;
+    storage.stopping = false;
+    storage.worker = std::thread(storage_worker);
+    if (!storage.exit_handler_registered) {
+        std::atexit(lambo_pak_storage_shutdown);
+        storage.exit_handler_registered = true;
+    }
+}
+
+} // namespace
+
+extern "C" void lambo_pak_storage_configure(const char* path) {
+    if (path == nullptr || path[0] == '\0') return;
+    lambo_pak_storage_shutdown();
+    StorageState& storage = state();
+    std::lock_guard lock(storage.mutex);
+    storage.path = path;
+    storage.last_result = idle_result();
+}
+
+extern "C" const char* lambo_pak_storage_path(void) {
+    return state().path.c_str();
+}
+
+extern "C" LamboPakIoResult lambo_pak_storage_load(uint8_t image[LAMBO_PAK_SIZE]) {
+    StorageState& storage = state();
+    std::lock_guard lock(storage.mutex);
+    return lambo_pak_read_file(storage.path.c_str(), image);
+}
+
+extern "C" void lambo_pak_storage_schedule_save(const uint8_t image[LAMBO_PAK_SIZE]) {
+    StorageState& storage = state();
+    std::lock_guard lock(storage.mutex);
+    start_worker(storage);
+    std::memcpy(storage.pending.data(), image, storage.pending.size());
+    storage.dirty = true;
+    storage.generation++;
+    storage.deadline = std::chrono::steady_clock::now() + kSaveDebounce;
+    storage.changed.notify_all();
+}
+
+extern "C" LamboPakIoResult lambo_pak_storage_flush(void) {
+    StorageState& storage = state();
+    std::unique_lock lock(storage.mutex);
+    while (storage.writing) storage.changed.wait(lock);
+    while (storage.dirty) {
+        publish_snapshot(storage, lock);
+        while (storage.writing) storage.changed.wait(lock);
+    }
+    return storage.last_result.ok ? storage.last_result :
+           (storage.last_result.error[0] != '\0' ? storage.last_result : idle_result());
+}
+
+extern "C" void lambo_pak_storage_shutdown(void) {
+    StorageState& storage = state();
+    (void)lambo_pak_storage_flush();
+    {
+        std::lock_guard lock(storage.mutex);
+        storage.stopping = true;
+        storage.changed.notify_all();
+    }
+    if (storage.worker.joinable()) storage.worker.join();
+    {
+        std::lock_guard lock(storage.mutex);
+        storage.stopping = false;
+    }
+}

--- a/src/lambo_pak_storage.h
+++ b/src/lambo_pak_storage.h
@@ -1,0 +1,26 @@
+#ifndef LAMBO_PAK_STORAGE_H
+#define LAMBO_PAK_STORAGE_H
+
+#include "lambo_pak_io.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Paths use UTF-8. Reconfiguration flushes and stops any previous writer. */
+void lambo_pak_storage_configure(const char* path);
+const char* lambo_pak_storage_path(void);
+LamboPakIoResult lambo_pak_storage_load(uint8_t image[LAMBO_PAK_SIZE]);
+
+/* Copies the image and returns without filesystem I/O. Bursts are coalesced. */
+void lambo_pak_storage_schedule_save(const uint8_t image[LAMBO_PAK_SIZE]);
+
+/* Synchronously publish pending data; application exit paths must call this. */
+LamboPakIoResult lambo_pak_storage_flush(void);
+void lambo_pak_storage_shutdown(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/lambo_pak_storage.h
+++ b/src/lambo_pak_storage.h
@@ -19,6 +19,12 @@ void lambo_pak_storage_schedule_save(const uint8_t image[LAMBO_PAK_SIZE]);
 LamboPakIoResult lambo_pak_storage_flush(void);
 void lambo_pak_storage_shutdown(void);
 
+#if defined(LAMBO_PAK_STORAGE_TESTING)
+typedef LamboPakIoResult (*LamboPakStorageWriteHook)(
+    const char* path, const uint8_t image[LAMBO_PAK_SIZE]);
+void lambo_pak_storage_set_write_hook(LamboPakStorageWriteHook hook);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libultra_stubs.c
+++ b/src/libultra_stubs.c
@@ -16,6 +16,7 @@
 
 #include "recomp.h"
 #include "lambo_pak_io.h"
+#include "lambo_pak_storage.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -149,37 +150,6 @@ static void lambo_pak_format(void) {
     }
 }
 
-// Both the path and the enable flag are read from the environment ONCE and cached: env vars can't
-// change after startup, and lambo_joybus_answer is on the per-frame input-poll hot path, so a
-// getenv() per call is wasted work. Caching the path into our own buffer also avoids holding a
-// pointer into getenv's storage.
-static char g_lambo_pak_default_path[1024] = "lambo_controller_pak.mpk";
-static char g_lambo_pak_override_path[1024];
-
-void lambo_pak_set_default_path(const char* path) {
-    if (path != NULL && path[0] != '\0')
-        snprintf(g_lambo_pak_default_path, sizeof(g_lambo_pak_default_path), "%s", path);
-}
-
-void lambo_pak_override_path(const char* path) {
-    if (path != NULL && path[0] != '\0')
-        snprintf(g_lambo_pak_override_path, sizeof(g_lambo_pak_override_path), "%s", path);
-}
-
-static const char* lambo_pak_path(void) {
-    static char cached[1024];
-    static int init = 0;
-    if (!init) {
-        const char* p = g_lambo_pak_override_path[0] != '\0'
-            ? g_lambo_pak_override_path
-            : getenv("LAMBO_CONTROLLER_PAK_FILE");
-        if (!p || !*p) p = g_lambo_pak_default_path;
-        snprintf(cached, sizeof(cached), "%s", p);
-        init = 1;
-    }
-    return cached;
-}
-
 // Controller-pak feature is ON by default (this is the #69 deliverable). LAMBO_CONTROLLER_PAK=0
 // is a deliberate A/B opt-out (the old W121 "no pak" behaviour) for boot-stability debugging.
 static int lambo_pak_enabled(void) {
@@ -200,34 +170,21 @@ static void lambo_pak_ensure_loaded(void) {
     LamboPakIoResult result;
     if (loaded) return;
     loaded = 1;
-    result = lambo_pak_read_file(lambo_pak_path(), g_lambo_pak_image);
+    result = lambo_pak_storage_load(g_lambo_pak_image);
     if (result.ok) {
         fprintf(stderr, "[pak] loaded %s from %s\n",
-                lambo_pak_format_name(result.format), lambo_pak_path());
+                lambo_pak_format_name(result.format), lambo_pak_storage_path());
         return;
     }
-    /* A missing file is the normal first-run case. Malformed/external formats are
-     * reported before falling back, so a failed import is not silent. */
-    {
-        FILE* existing = fopen(lambo_pak_path(), "rb");
-        if (existing != NULL) {
-            fclose(existing);
-            fprintf(stderr, "[pak] %s; using a fresh in-memory Pak without overwriting it\n", result.error);
-        }
-    }
+    fprintf(stderr, "[pak] %s; using a fresh formatted Pak in memory\n", result.error);
     lambo_pak_format();                                         /* fresh formatted pak (memory only) */
 }
 
-// Persist the whole 32 KB image after a block write. ATOMIC: write a temp file, then rename it
-// over the target -- a crash/kill/power-loss mid-write must never truncate the live .mpk (a short
-// read on next boot would silently reformat and lose ALL saved games). The storage module uses
-// rename() on POSIX and MoveFileEx(REPLACE_EXISTING) on Windows, leaving the old file in place if
-// publication fails. We flush per block (each write persisted immediately) rather than batching --
-// this trades a small hitch at save time for crash-safety, which for a save file is the right call
-// (saves are rare: records/best-times, a handful of blocks).
+// Copy the current image into the host storage module. Its worker coalesces a burst of 32-byte
+// Joybus writes and atomically publishes the final image after the burst, keeping filesystem I/O
+// off this emulation thread. Explicit application-exit paths flush any pending image.
 static void lambo_pak_save(void) {
-    LamboPakIoResult result = lambo_pak_write_file(lambo_pak_path(), g_lambo_pak_image);
-    if (!result.ok) fprintf(stderr, "[pak] save failed: %s\n", result.error);
+    lambo_pak_storage_schedule_save(g_lambo_pak_image);
 }
 
 // LAMBO_PAK_TRACE=1: per-frame joybus log (issue #35 diagnosis) -- shows exactly what the save

--- a/src/libultra_stubs.c
+++ b/src/libultra_stubs.c
@@ -15,6 +15,7 @@
 // drmario64/Zelda64Recomp leave __osSetSR in ignored_funcs.
 
 #include "recomp.h"
+#include "lambo_pak_io.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -107,7 +108,7 @@ static unsigned char lambo_joybus_data_crc(uint8_t* rdram, gpr addr) {
 // a dead pak. Port of the proven legacy HLE (src/recomp/recomp_support.c lambo_pak_image_format,
 // W16): ID areas at pages 1/3/4/6 (device id bit0, 1 bank = 32 KB, id16 + inverted checksums),
 // inode table page 1 + backup page 2 with slots 5..127 = 0x03 (empty).
-uint8_t g_lambo_pak_image[0x8000];
+uint8_t g_lambo_pak_image[LAMBO_PAK_SIZE];
 
 static void lambo_pak_format(void) {
     uint8_t* img = g_lambo_pak_image;
@@ -152,12 +153,27 @@ static void lambo_pak_format(void) {
 // change after startup, and lambo_joybus_answer is on the per-frame input-poll hot path, so a
 // getenv() per call is wasted work. Caching the path into our own buffer also avoids holding a
 // pointer into getenv's storage.
+static char g_lambo_pak_default_path[1024] = "lambo_controller_pak.mpk";
+static char g_lambo_pak_override_path[1024];
+
+void lambo_pak_set_default_path(const char* path) {
+    if (path != NULL && path[0] != '\0')
+        snprintf(g_lambo_pak_default_path, sizeof(g_lambo_pak_default_path), "%s", path);
+}
+
+void lambo_pak_override_path(const char* path) {
+    if (path != NULL && path[0] != '\0')
+        snprintf(g_lambo_pak_override_path, sizeof(g_lambo_pak_override_path), "%s", path);
+}
+
 static const char* lambo_pak_path(void) {
     static char cached[1024];
     static int init = 0;
     if (!init) {
-        const char* p = getenv("LAMBO_CONTROLLER_PAK_FILE");
-        if (!p || !*p) p = "lambo_controller_pak.mpk";
+        const char* p = g_lambo_pak_override_path[0] != '\0'
+            ? g_lambo_pak_override_path
+            : getenv("LAMBO_CONTROLLER_PAK_FILE");
+        if (!p || !*p) p = g_lambo_pak_default_path;
         snprintf(cached, sizeof(cached), "%s", p);
         init = 1;
     }
@@ -181,39 +197,37 @@ static int lambo_pak_enabled(void) {
 // the game thread during boot. The file is created on the first real save (lambo_pak_save).
 static void lambo_pak_ensure_loaded(void) {
     static int loaded = 0;
-    FILE* f;
+    LamboPakIoResult result;
     if (loaded) return;
     loaded = 1;
-    f = fopen(lambo_pak_path(), "rb");
-    if (f) {
-        size_t n = fread(g_lambo_pak_image, 1, sizeof(g_lambo_pak_image), f);
-        fclose(f);
-        if (n == sizeof(g_lambo_pak_image)) return;             /* good image on disk */
+    result = lambo_pak_read_file(lambo_pak_path(), g_lambo_pak_image);
+    if (result.ok) {
+        fprintf(stderr, "[pak] loaded %s from %s\n",
+                lambo_pak_format_name(result.format), lambo_pak_path());
+        return;
+    }
+    /* A missing file is the normal first-run case. Malformed/external formats are
+     * reported before falling back, so a failed import is not silent. */
+    {
+        FILE* existing = fopen(lambo_pak_path(), "rb");
+        if (existing != NULL) {
+            fclose(existing);
+            fprintf(stderr, "[pak] %s; using a fresh in-memory Pak without overwriting it\n", result.error);
+        }
     }
     lambo_pak_format();                                         /* fresh formatted pak (memory only) */
 }
 
 // Persist the whole 32 KB image after a block write. ATOMIC: write a temp file, then rename it
 // over the target -- a crash/kill/power-loss mid-write must never truncate the live .mpk (a short
-// read on next boot would silently reformat and lose ALL saved games). rename() is atomic on POSIX
-// and replaces; on Windows (MinGW/MSVCRT) it fails if the target exists, so fall back to
-// remove()+rename(). We flush per block (each write persisted immediately) rather than batching --
+// read on next boot would silently reformat and lose ALL saved games). The storage module uses
+// rename() on POSIX and MoveFileEx(REPLACE_EXISTING) on Windows, leaving the old file in place if
+// publication fails. We flush per block (each write persisted immediately) rather than batching --
 // this trades a small hitch at save time for crash-safety, which for a save file is the right call
 // (saves are rare: records/best-times, a handful of blocks).
 static void lambo_pak_save(void) {
-    const char* path = lambo_pak_path();
-    char tmp[1024];
-    FILE* f;
-    size_t n;
-    if ((int)snprintf(tmp, sizeof(tmp), "%s.tmp", path) >= (int)sizeof(tmp)) return; /* path too long */
-    f = fopen(tmp, "wb");
-    if (!f) return;
-    n = fwrite(g_lambo_pak_image, 1, sizeof(g_lambo_pak_image), f);
-    if (fclose(f) != 0 || n != sizeof(g_lambo_pak_image)) { remove(tmp); return; }
-    if (rename(tmp, path) != 0) {          /* Windows: target exists -> replace explicitly */
-        remove(path);
-        if (rename(tmp, path) != 0) remove(tmp);
-    }
+    LamboPakIoResult result = lambo_pak_write_file(lambo_pak_path(), g_lambo_pak_image);
+    if (!result.ok) fprintf(stderr, "[pak] save failed: %s\n", result.error);
 }
 
 // LAMBO_PAK_TRACE=1: per-frame joybus log (issue #35 diagnosis) -- shows exactly what the save

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "librecomp/game.hpp"
 #include "librecomp/rsp.hpp"
@@ -36,6 +37,9 @@
 #include <SDL.h>          // RT64 default presenter (#58): real window + event pump under WSLg
 #if defined(_WIN32)
 #include <SDL_syswm.h>    // native Windows (#68): unwrap the HWND for ultramodern/RT64-D3D12
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <shellapi.h>
 #endif
 #include "lambo_rt64.h"
 #include "lambo_audio.h"
@@ -44,6 +48,7 @@
 #include "lambo_gpu_advisory.h"  // issue #109: outdated-driver popup handoff
 #include "lambo_log.h"   
 #include "lambo_pak_io.h"
+#include "lambo_pak_storage.h"
 #include "lambo_menu.h"
 #include "lambo_input_gate.h"
 #include "lambo_analog_throttle.h"
@@ -119,6 +124,7 @@ static void thread_create_cb(uint8_t*, recomp_context*) {
     LAMBO_LOG("probe", "boot summary; threads=%d vis=%d first_vi=%d max_state=%d swaps=%d\n",
                  g_threads.load(), g_vis.load(), (int)g_first_vi.load(), g_max_state.load(),
                  g_swaps.load());
+    (void)lambo_pak_storage_flush();
     std::fflush(nullptr);
     std::_Exit(g_first_vi.load() ? 0 : 2);
 }
@@ -131,6 +137,7 @@ static void thread_create_cb(uint8_t*, recomp_context*) {
     // down RmlUi while a draw hook can still be using it. This path deliberately
     // terminates the process below, so there is no cleanup benefit that can
     // justify touching either subsystem first.
+    (void)lambo_pak_storage_flush();
     std::fflush(nullptr);
     std::_Exit(0);
 }
@@ -689,10 +696,18 @@ static ultramodern::input::connected_device_info_t input_device_info(int control
 }
 
 static bool is_controller_pak_container(const char* path) {
-    const LamboPakIoResult result = lambo_pak_probe_file(path);
-    std::string extension = std::filesystem::path(path).extension().string();
+    const char* extension_start = std::strrchr(path, '.');
+    const char* forward_slash = std::strrchr(path, '/');
+    const char* back_slash = std::strrchr(path, '\\');
+    const char* slash = forward_slash == nullptr ? back_slash :
+        (back_slash == nullptr || forward_slash > back_slash ? forward_slash : back_slash);
+    if (extension_start == nullptr || (slash != nullptr && extension_start < slash)) return false;
+    std::string extension = extension_start;
     std::transform(extension.begin(), extension.end(), extension.begin(),
                    [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    if (extension != ".mpk" && extension != ".pak" &&
+        extension != ".srm" && extension != ".n64") return false;
+    const LamboPakIoResult result = lambo_pak_probe_file(path);
     if (!result.ok) return false;
     switch (result.format) {
     case LAMBO_PAK_FORMAT_RAW:
@@ -707,14 +722,27 @@ static bool is_controller_pak_container(const char* path) {
     }
 }
 
+static std::string path_to_utf8(const std::filesystem::path& path) {
+    const std::u8string value = path.u8string();
+    return {reinterpret_cast<const char*>(value.data()), value.size()};
+}
+
+static std::filesystem::path path_from_utf8(const char* path) {
+    const auto* begin = reinterpret_cast<const char8_t*>(path);
+    return std::filesystem::path(std::u8string(begin, begin + std::strlen(path)));
+}
+
 static std::filesystem::path unused_backup_path(const std::filesystem::path& path) {
-    std::filesystem::path candidate = path.string() + ".bak";
-    for (unsigned index = 1; std::filesystem::exists(candidate); ++index)
-        candidate = path.string() + ".bak." + std::to_string(index);
+    std::filesystem::path candidate = path;
+    candidate += ".bak";
+    for (unsigned index = 1; std::filesystem::exists(candidate); ++index) {
+        candidate = path;
+        candidate += ".bak." + std::to_string(index);
+    }
     return candidate;
 }
 
-int main(int argc, char** argv) {
+static int application_main(int argc, char** argv) {
     // Deterministic lighting self-test: no ROM, no runtime -- exercises the swrender
     // light-decode + lambert path on a synthetic DL and exits (tests/pivot/test_lighting.py).
     if (std::getenv("LAMBO_LIGHTING_SELFTEST")) {
@@ -781,12 +809,23 @@ int main(int argc, char** argv) {
     recomp::register_config_path(config_dir);
 
     const std::filesystem::path pak_path = config_dir / "lambo_controller_pak.mpk";
-    const std::string pak_path_string = pak_path.string();
-    const std::string active_pak_path = controller_pak_path != nullptr
-        ? std::filesystem::path(controller_pak_path).string()
-        : pak_path_string;
-    if (controller_pak_path != nullptr) lambo_pak_override_path(active_pak_path.c_str());
-    else lambo_pak_set_default_path(active_pak_path.c_str());
+    const std::string pak_path_string = path_to_utf8(pak_path);
+    std::filesystem::path active_pak_path = pak_path;
+    if (controller_pak_path != nullptr) {
+        active_pak_path = path_from_utf8(controller_pak_path);
+    } else {
+#if defined(_WIN32)
+        if (const wchar_t* environment_path = _wgetenv(L"LAMBO_CONTROLLER_PAK_FILE");
+            environment_path != nullptr && environment_path[0] != L'\0')
+            active_pak_path = environment_path;
+#else
+        if (const char* environment_path = std::getenv("LAMBO_CONTROLLER_PAK_FILE");
+            environment_path != nullptr && environment_path[0] != '\0')
+            active_pak_path = path_from_utf8(environment_path);
+#endif
+    }
+    const std::string active_pak_path_string = path_to_utf8(active_pak_path);
+    lambo_pak_storage_configure(active_pak_path_string.c_str());
 
     if (import_path != nullptr && controller_pak_path != nullptr) {
         std::fprintf(stderr, "--import-save and --controller-pak cannot be used together\n");
@@ -798,7 +837,8 @@ int main(int argc, char** argv) {
             std::fprintf(stderr, "[pak] import failed: %s\n", source.error);
             return 2;
         }
-        const bool source_is_destination = std::filesystem::equivalent(import_path, pak_path, error);
+        const bool source_is_destination =
+            std::filesystem::equivalent(path_from_utf8(import_path), pak_path, error);
         if (source_is_destination && !error) {
             std::fprintf(stderr, "[pak] selected save is already the active Controller Pak: %s\n",
                          pak_path_string.c_str());
@@ -808,11 +848,13 @@ int main(int argc, char** argv) {
                 const auto backup = unused_backup_path(pak_path);
                 std::filesystem::copy_file(pak_path, backup, error);
                 if (error) {
+                    const std::string backup_string = path_to_utf8(backup);
                     std::fprintf(stderr, "[pak] cannot back up existing save to %s: %s\n",
-                                 backup.string().c_str(), error.message().c_str());
+                                 backup_string.c_str(), error.message().c_str());
                     return 2;
                 }
-                std::fprintf(stderr, "[pak] backed up existing save to %s\n", backup.string().c_str());
+                const std::string backup_string = path_to_utf8(backup);
+                std::fprintf(stderr, "[pak] backed up existing save to %s\n", backup_string.c_str());
             }
             const LamboPakIoResult imported = lambo_pak_import_file(import_path, pak_path_string.c_str());
             if (!imported.ok) {
@@ -826,11 +868,10 @@ int main(int argc, char** argv) {
         // One-time migration for builds before #176, which accidentally stored the
         // default Controller Pak beside the executable/current working directory.
         const std::filesystem::path legacy = "lambo_controller_pak.mpk";
-        std::error_code same_error;
-        const bool same_path = std::filesystem::equivalent(legacy, pak_path, same_error);
-        if (std::filesystem::exists(legacy) && (!same_path || same_error)) {
+        if (std::filesystem::exists(legacy)) {
+            const std::string legacy_string = path_to_utf8(legacy);
             const LamboPakIoResult migrated =
-                lambo_pak_import_file(legacy.string().c_str(), pak_path_string.c_str());
+                lambo_pak_import_file(legacy_string.c_str(), pak_path_string.c_str());
             if (migrated.ok)
                 std::fprintf(stderr, "[pak] migrated legacy %s save to %s\n",
                              lambo_pak_format_name(migrated.format), pak_path_string.c_str());
@@ -983,3 +1024,35 @@ int main(int argc, char** argv) {
     // path exits from vi_cb via boot_summary_and_exit() and never returns here.
     boot_summary_and_exit();
 }
+
+#if defined(_WIN32)
+int main(int, char**) {
+    int argument_count = 0;
+    wchar_t** wide_arguments = CommandLineToArgvW(GetCommandLineW(), &argument_count);
+    if (wide_arguments == nullptr) return 2;
+    std::vector<std::string> arguments;
+    std::vector<char*> argument_pointers;
+    arguments.reserve(static_cast<size_t>(argument_count));
+    argument_pointers.reserve(static_cast<size_t>(argument_count));
+    for (int index = 0; index < argument_count; ++index) {
+        const int size = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wide_arguments[index],
+                                             -1, nullptr, 0, nullptr, nullptr);
+        if (size == 0) {
+            LocalFree(wide_arguments);
+            return 2;
+        }
+        std::string converted(static_cast<size_t>(size), '\0');
+        WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wide_arguments[index], -1,
+                            converted.data(), size, nullptr, nullptr);
+        converted.pop_back();
+        arguments.push_back(std::move(converted));
+    }
+    LocalFree(wide_arguments);
+    for (std::string& argument : arguments) argument_pointers.push_back(argument.data());
+    return application_main(argument_count, argument_pointers.data());
+}
+#else
+int main(int argc, char** argv) {
+    return application_main(argc, argv);
+}
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cctype>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
@@ -42,6 +43,7 @@
 #include "lambo_crash.h"   // issue #13 / A14
 #include "lambo_gpu_advisory.h"  // issue #109: outdated-driver popup handoff
 #include "lambo_log.h"   
+#include "lambo_pak_io.h"
 #include "lambo_menu.h"
 #include "lambo_input_gate.h"
 #include "lambo_analog_throttle.h"
@@ -686,6 +688,32 @@ static ultramodern::input::connected_device_info_t input_device_info(int control
     return { Device::None, Pak::None };
 }
 
+static bool is_controller_pak_container(const char* path) {
+    const LamboPakIoResult result = lambo_pak_probe_file(path);
+    std::string extension = std::filesystem::path(path).extension().string();
+    std::transform(extension.begin(), extension.end(), extension.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    if (!result.ok) return false;
+    switch (result.format) {
+    case LAMBO_PAK_FORMAT_RAW:
+    case LAMBO_PAK_FORMAT_FOUR_PORT:
+        return extension == ".mpk" || extension == ".pak";
+    case LAMBO_PAK_FORMAT_RETROARCH:
+        return extension == ".srm";
+    case LAMBO_PAK_FORMAT_DEXDRIVE:
+        return extension == ".n64";
+    default:
+        return false;
+    }
+}
+
+static std::filesystem::path unused_backup_path(const std::filesystem::path& path) {
+    std::filesystem::path candidate = path.string() + ".bak";
+    for (unsigned index = 1; std::filesystem::exists(candidate); ++index)
+        candidate = path.string() + ".bak." + std::to_string(index);
+    return candidate;
+}
+
 int main(int argc, char** argv) {
     // Deterministic lighting self-test: no ROM, no runtime -- exercises the swrender
     // light-decode + lambert path on a synthetic DL and exits (tests/pivot/test_lighting.py).
@@ -695,14 +723,29 @@ int main(int argc, char** argv) {
     // Parse --lambo-debug BEFORE anything else that might print a [probe] line.
     // The flag is read by every LAMBO_LOG() site via the lambo_log_enabled bool.
     lambo_log_parse_flag(argc, argv);
-    // The ROM path is the first non-flag positional arg; skip argv entries that
-    // start with "--" so e.g. `lamborghini_modern --lambo-debug` still finds the
-    // bundled ROM at argv[2] (or falls back to the default when no path given).
     const char* rom_path = "Automobili Lamborghini (USA).z64";
+    const char* import_path = nullptr;
+    const char* controller_pak_path = nullptr;
+    bool rom_was_selected = false;
     for (int i = 1; i < argc; ++i) {
-        if (argv[i] && argv[i][0] != '-' && argv[i][0] != '\0') {
+        if (argv[i] && std::strcmp(argv[i], "--import-save") == 0) {
+            if (i + 1 >= argc || argv[i + 1] == nullptr || argv[i + 1][0] == '\0') {
+                std::fprintf(stderr, "--import-save requires an MPK, SRM, or DexDrive N64 file\n");
+                return 2;
+            }
+            import_path = argv[++i];
+        } else if (argv[i] && std::strcmp(argv[i], "--controller-pak") == 0) {
+            if (i + 1 >= argc || argv[i + 1] == nullptr || argv[i + 1][0] == '\0') {
+                std::fprintf(stderr, "--controller-pak requires an MPK, SRM, or DexDrive N64 file\n");
+                return 2;
+            }
+            controller_pak_path = argv[++i];
+        } else if (argv[i] && argv[i][0] != '-' && argv[i][0] != '\0' &&
+                   is_controller_pak_container(argv[i])) {
+            import_path = argv[i];
+        } else if (!rom_was_selected && argv[i] && argv[i][0] != '-' && argv[i][0] != '\0') {
             rom_path = argv[i];
-            break;
+            rom_was_selected = true;
         }
     }
     LAMBO_LOG("probe", "ROM: %s\n", rom_path);
@@ -736,6 +779,65 @@ int main(int argc, char** argv) {
     std::filesystem::path config_dir = lambo::config::app_config_dir();
     std::filesystem::create_directories(config_dir);
     recomp::register_config_path(config_dir);
+
+    const std::filesystem::path pak_path = config_dir / "lambo_controller_pak.mpk";
+    const std::string pak_path_string = pak_path.string();
+    const std::string active_pak_path = controller_pak_path != nullptr
+        ? std::filesystem::path(controller_pak_path).string()
+        : pak_path_string;
+    if (controller_pak_path != nullptr) lambo_pak_override_path(active_pak_path.c_str());
+    else lambo_pak_set_default_path(active_pak_path.c_str());
+
+    if (import_path != nullptr && controller_pak_path != nullptr) {
+        std::fprintf(stderr, "--import-save and --controller-pak cannot be used together\n");
+        return 2;
+    } else if (import_path != nullptr) {
+        std::error_code error;
+        const LamboPakIoResult source = lambo_pak_probe_file(import_path);
+        if (!source.ok) {
+            std::fprintf(stderr, "[pak] import failed: %s\n", source.error);
+            return 2;
+        }
+        const bool source_is_destination = std::filesystem::equivalent(import_path, pak_path, error);
+        if (source_is_destination && !error) {
+            std::fprintf(stderr, "[pak] selected save is already the active Controller Pak: %s\n",
+                         pak_path_string.c_str());
+        } else {
+            error.clear();
+            if (std::filesystem::exists(pak_path)) {
+                const auto backup = unused_backup_path(pak_path);
+                std::filesystem::copy_file(pak_path, backup, error);
+                if (error) {
+                    std::fprintf(stderr, "[pak] cannot back up existing save to %s: %s\n",
+                                 backup.string().c_str(), error.message().c_str());
+                    return 2;
+                }
+                std::fprintf(stderr, "[pak] backed up existing save to %s\n", backup.string().c_str());
+            }
+            const LamboPakIoResult imported = lambo_pak_import_file(import_path, pak_path_string.c_str());
+            if (!imported.ok) {
+                std::fprintf(stderr, "[pak] import failed: %s\n", imported.error);
+                return 2;
+            }
+            std::fprintf(stderr, "[pak] imported %s to %s\n",
+                         lambo_pak_format_name(imported.format), pak_path_string.c_str());
+        }
+    } else if (controller_pak_path == nullptr && !std::filesystem::exists(pak_path)) {
+        // One-time migration for builds before #176, which accidentally stored the
+        // default Controller Pak beside the executable/current working directory.
+        const std::filesystem::path legacy = "lambo_controller_pak.mpk";
+        std::error_code same_error;
+        const bool same_path = std::filesystem::equivalent(legacy, pak_path, same_error);
+        if (std::filesystem::exists(legacy) && (!same_path || same_error)) {
+            const LamboPakIoResult migrated =
+                lambo_pak_import_file(legacy.string().c_str(), pak_path_string.c_str());
+            if (migrated.ok)
+                std::fprintf(stderr, "[pak] migrated legacy %s save to %s\n",
+                             lambo_pak_format_name(migrated.format), pak_path_string.c_str());
+            else
+                std::fprintf(stderr, "[pak] legacy save migration failed: %s\n", migrated.error);
+        }
+    }
     g_controls = std::make_unique<lambo::controls::SdlAdapter>();
 
     recomp::GameEntry game{};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1033,7 +1033,7 @@ int main(int, char**) {
     std::vector<std::string> arguments;
     std::vector<char*> argument_pointers;
     arguments.reserve(static_cast<size_t>(argument_count));
-    argument_pointers.reserve(static_cast<size_t>(argument_count));
+    argument_pointers.reserve(static_cast<size_t>(argument_count) + 1);
     for (int index = 0; index < argument_count; ++index) {
         const int size = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wide_arguments[index],
                                              -1, nullptr, 0, nullptr, nullptr);
@@ -1049,6 +1049,7 @@ int main(int, char**) {
     }
     LocalFree(wide_arguments);
     for (std::string& argument : arguments) argument_pointers.push_back(argument.data());
+    argument_pointers.push_back(nullptr);
     return application_main(argument_count, argument_pointers.data());
 }
 #else

--- a/tests/test_controller_pak.c
+++ b/tests/test_controller_pak.c
@@ -1,7 +1,9 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
+#include "lambo_pak_storage.h"
 #include "recomp.h"
 
 void func_8007F780(uint8_t* rdram, recomp_context* ctx);
@@ -44,6 +46,7 @@ void func_8007AF60(uint8_t* rdram, recomp_context* ctx) {
 }
 
 int main(void) {
+    static const char* pak_path = "controller_pak_joybus_test.mpk";
     uint8_t* rdram = calloc(1, 0x800000);
     recomp_context ctx = { 0 };
     gpr pak_status = (gpr)(int32_t)0x8011C6D0u;
@@ -56,6 +59,9 @@ int main(void) {
         return 1;
     }
 
+    remove(pak_path);
+    lambo_pak_storage_configure(pak_path);
+
     ctx.r5 = pak_status;
     MEM_B(0, pak_status) = (signed char)0xFE;
     MEM_W(0, rumble_present) = 1;
@@ -64,6 +70,36 @@ int main(void) {
 
     if (MEM_W(0, rumble_present) != 0) {
         fprintf(stderr, "Controller Pak poll left the Rumble Pak present flag set\n");
+        free(rdram);
+        return 1;
+    }
+
+    for (unsigned block = 0; block < 20; ++block) {
+        const unsigned address = 0x500u + block * 0x20u;
+        memset(rdram + 0x11C6D0u, 0, 0x40);
+        MEM_B(0, pak_status) = (signed char)0xFF;
+        MEM_B(1, pak_status) = 0x23;
+        MEM_B(2, pak_status) = 0x01;
+        MEM_B(3, pak_status) = 0x03;
+        MEM_B(4, pak_status) = (signed char)(address >> 8);
+        MEM_B(5, pak_status) = (signed char)address;
+        for (unsigned byte = 0; byte < 32; ++byte)
+            MEM_B(6 + byte, pak_status) = (signed char)(block + byte);
+        MEM_B(39, pak_status) = (signed char)0xFE;
+        ctx.r5 = pak_status;
+        func_8007F780(rdram, &ctx);
+    }
+    {
+        FILE* synchronous_write = fopen(pak_path, "rb");
+        if (synchronous_write != NULL) {
+            fprintf(stderr, "Joybus block write synchronously published the Pak\n");
+            fclose(synchronous_write);
+            free(rdram);
+            return 1;
+        }
+    }
+    if (!lambo_pak_storage_flush().ok) {
+        fprintf(stderr, "batched Joybus Pak writes did not flush\n");
         free(rdram);
         return 1;
     }
@@ -109,6 +145,8 @@ int main(void) {
         return 1;
     }
 
+    lambo_pak_storage_shutdown();
+    remove(pak_path);
     free(rdram);
     return 0;
 }

--- a/tests/test_pak_io.c
+++ b/tests/test_pak_io.c
@@ -4,6 +4,13 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
+#include <sys/stat.h>
+#endif
+
 enum {
     FOUR_PORT_SIZE = 4 * LAMBO_PAK_SIZE,
     RETROARCH_SIZE = 296960,
@@ -75,6 +82,9 @@ int main(void) {
     static const char* dex_path = "pak_io_test_dexdrive.n64";
     static const char* bad_path = "pak_io_test_eeprom.eep";
     static const char* import_path = "pak_io_test_imported.mpk";
+    static const char* empty_path = "pak_io_test_empty.mpk";
+    static const char* zero_path = "pak_io_test_zero.mpk";
+    static const char* missing_path = "pak_io_missing_dir/save.mpk";
     unsigned char expected[LAMBO_PAK_SIZE];
     unsigned char actual[LAMBO_PAK_SIZE];
     unsigned char* container;
@@ -83,6 +93,7 @@ int main(void) {
 
     remove(raw_path); remove(four_path); remove(srm_path);
     remove(dex_path); remove(bad_path); remove(import_path);
+    remove(empty_path); remove(zero_path);
     fill_pattern(expected);
     make_valid_pak(expected);
 
@@ -154,8 +165,46 @@ int main(void) {
     free(container);
     result = lambo_pak_import_file(import_path, import_path);
     expect(!result.ok, "import refuses to overwrite its own source");
+    result = lambo_pak_import_file(import_path, "./pak_io_test_imported.mpk");
+    expect(!result.ok, "import refuses a lexical alias of its own source");
+
+    expect(write_bytes(empty_path, expected, 0), "empty target fixture writes");
+    result = lambo_pak_write_file(empty_path, expected);
+    expect(result.ok, "an explicitly selected empty target becomes a formatted raw MPK");
+    memset(actual, 0, sizeof(actual));
+    result = lambo_pak_read_file(empty_path, actual);
+    expect(result.ok && memcmp(actual, expected, sizeof(actual)) == 0,
+           "formatted empty target round-trips");
+
+    container = (unsigned char*)calloc(1, LAMBO_PAK_SIZE);
+    expect(write_bytes(zero_path, container, LAMBO_PAK_SIZE), "zero-filled target fixture writes");
+    free(container);
+    result = lambo_pak_write_file(zero_path, expected);
+    expect(result.ok, "an explicitly selected zero-filled raw target becomes formatted");
+
+    result = lambo_pak_write_file(missing_path, expected);
+    expect(!result.ok && (strstr(result.error, "errno=") != NULL ||
+                          strstr(result.error, "Win32 error=") != NULL),
+           "I/O failures include the operating-system error code");
+
+#if defined(_WIN32)
+    {
+        static const wchar_t unicode_dir[] = L"pak_io_t\u00e9st";
+        static const char unicode_path[] = "pak_io_t\xC3\xA9st/save.mpk";
+        CreateDirectoryW(unicode_dir, NULL);
+        result = lambo_pak_write_file(unicode_path, expected);
+        expect(result.ok, "UTF-8 Controller Pak paths work on Windows");
+        memset(actual, 0, sizeof(actual));
+        result = lambo_pak_read_file(unicode_path, actual);
+        expect(result.ok && memcmp(actual, expected, sizeof(actual)) == 0,
+               "UTF-8 Controller Pak path round-trips on Windows");
+        DeleteFileW(L"pak_io_t\u00e9st\\save.mpk");
+        RemoveDirectoryW(unicode_dir);
+    }
+#endif
 
     remove(raw_path); remove(four_path); remove(srm_path);
     remove(dex_path); remove(bad_path); remove(import_path);
+    remove(empty_path); remove(zero_path);
     return failures == 0 ? 0 : 1;
 }

--- a/tests/test_pak_io.c
+++ b/tests/test_pak_io.c
@@ -1,0 +1,161 @@
+#include "lambo_pak_io.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum {
+    FOUR_PORT_SIZE = 4 * LAMBO_PAK_SIZE,
+    RETROARCH_SIZE = 296960,
+    RETROARCH_PAK_OFFSET = 0x800,
+    DEXDRIVE_SIZE = 36928,
+    DEXDRIVE_PAK_OFFSET = 0x1040
+};
+
+static int failures;
+
+static void expect(int condition, const char* message) {
+    if (!condition) {
+        fprintf(stderr, "FAIL: %s\n", message);
+        failures++;
+    }
+}
+
+static int write_bytes(const char* path, const unsigned char* data, size_t size) {
+    FILE* file = fopen(path, "wb");
+    size_t count;
+    if (file == NULL) return 0;
+    count = fwrite(data, 1, size, file);
+    return fclose(file) == 0 && count == size;
+}
+
+static unsigned char* read_bytes(const char* path, size_t expected_size) {
+    unsigned char* data = (unsigned char*)malloc(expected_size);
+    FILE* file = fopen(path, "rb");
+    if (data == NULL || file == NULL) {
+        free(data);
+        if (file != NULL) fclose(file);
+        return NULL;
+    }
+    if (fread(data, 1, expected_size, file) != expected_size || fgetc(file) != EOF || fclose(file) != 0) {
+        free(data);
+        return NULL;
+    }
+    return data;
+}
+
+static void fill_pattern(unsigned char* data) {
+    size_t index;
+    for (index = 0; index < LAMBO_PAK_SIZE; ++index)
+        data[index] = (unsigned char)((index * 37u + 11u) & 0xffu);
+}
+
+static void make_valid_pak(unsigned char* data) {
+    /* Keep fixture construction independent of production code so tests fail
+     * if either side drifts from the SDK-compatible ID checksum contract. */
+    const size_t offset = 0x20;
+    unsigned short sum = 0;
+    unsigned short inverted;
+    size_t word;
+    for (word = 0; word < 14; ++word) {
+        const size_t pos = offset + word * 2;
+        sum = (unsigned short)(sum + (unsigned short)((data[pos] << 8) | data[pos + 1]));
+    }
+    inverted = (unsigned short)(0xfff2u - sum);
+    data[offset + 0x1c] = (unsigned char)(sum >> 8);
+    data[offset + 0x1d] = (unsigned char)sum;
+    data[offset + 0x1e] = (unsigned char)(inverted >> 8);
+    data[offset + 0x1f] = (unsigned char)inverted;
+}
+
+int main(void) {
+    static const char* raw_path = "pak_io_test_raw.mpk";
+    static const char* four_path = "pak_io_test_four.mpk";
+    static const char* srm_path = "pak_io_test_retroarch.srm";
+    static const char* dex_path = "pak_io_test_dexdrive.n64";
+    static const char* bad_path = "pak_io_test_eeprom.eep";
+    static const char* import_path = "pak_io_test_imported.mpk";
+    unsigned char expected[LAMBO_PAK_SIZE];
+    unsigned char actual[LAMBO_PAK_SIZE];
+    unsigned char* container;
+    LamboPakIoResult result;
+    size_t index;
+
+    remove(raw_path); remove(four_path); remove(srm_path);
+    remove(dex_path); remove(bad_path); remove(import_path);
+    fill_pattern(expected);
+    make_valid_pak(expected);
+
+    result = lambo_pak_write_file(raw_path, expected);
+    expect(result.ok && result.format == LAMBO_PAK_FORMAT_RAW, "new saves are portable raw MPK files");
+    memset(actual, 0, sizeof(actual));
+    result = lambo_pak_read_file(raw_path, actual);
+    expect(result.ok && memcmp(actual, expected, sizeof(actual)) == 0, "raw MPK round-trips");
+
+    container = (unsigned char*)malloc(FOUR_PORT_SIZE);
+    memset(container, 0xa5, FOUR_PORT_SIZE);
+    memcpy(container, expected, LAMBO_PAK_SIZE);
+    expect(write_bytes(four_path, container, FOUR_PORT_SIZE), "four-port fixture writes");
+    result = lambo_pak_read_file(four_path, actual);
+    expect(result.ok && result.format == LAMBO_PAK_FORMAT_FOUR_PORT &&
+           memcmp(actual, expected, sizeof(actual)) == 0, "four-port MPK imports controller 1");
+    free(container);
+
+    container = (unsigned char*)malloc(RETROARCH_SIZE);
+    memset(container, 0x5a, RETROARCH_SIZE);
+    memcpy(container + RETROARCH_PAK_OFFSET, expected, LAMBO_PAK_SIZE);
+    expect(write_bytes(srm_path, container, RETROARCH_SIZE), "RetroArch fixture writes");
+    free(container);
+    result = lambo_pak_read_file(srm_path, actual);
+    expect(result.ok && result.format == LAMBO_PAK_FORMAT_RETROARCH &&
+           result.pak_offset == RETROARCH_PAK_OFFSET &&
+           memcmp(actual, expected, sizeof(actual)) == 0, "RetroArch SRM imports controller 1 at 0x800");
+    for (index = 0x500; index < LAMBO_PAK_SIZE; ++index) actual[index] ^= 0xffu;
+    result = lambo_pak_write_file(srm_path, actual);
+    expect(result.ok && result.format == LAMBO_PAK_FORMAT_RETROARCH, "RetroArch SRM updates in place");
+    container = read_bytes(srm_path, RETROARCH_SIZE);
+    expect(container != NULL && container[0] == 0x5a &&
+           container[RETROARCH_PAK_OFFSET - 1] == 0x5a &&
+           container[RETROARCH_PAK_OFFSET + LAMBO_PAK_SIZE] == 0x5a,
+           "RetroArch EEPROM, other paks, SRAM, and FlashRAM bytes are preserved");
+    expect(container != NULL && memcmp(container + RETROARCH_PAK_OFFSET, actual, LAMBO_PAK_SIZE) == 0,
+           "RetroArch controller 1 bytes are replaced");
+    free(container);
+
+    container = (unsigned char*)malloc(DEXDRIVE_SIZE);
+    memset(container, 0x33, DEXDRIVE_SIZE);
+    memcpy(container, "123-456-STD\0", 12);
+    memcpy(container + DEXDRIVE_PAK_OFFSET, expected, LAMBO_PAK_SIZE);
+    expect(write_bytes(dex_path, container, DEXDRIVE_SIZE), "DexDrive fixture writes");
+    free(container);
+    result = lambo_pak_read_file(dex_path, actual);
+    expect(result.ok && result.format == LAMBO_PAK_FORMAT_DEXDRIVE &&
+           result.pak_offset == DEXDRIVE_PAK_OFFSET &&
+           memcmp(actual, expected, sizeof(actual)) == 0, "DexDrive N64 wrapper imports at 0x1040");
+
+    container = (unsigned char*)calloc(1, LAMBO_PAK_SIZE);
+    expect(write_bytes(bad_path, container, LAMBO_PAK_SIZE), "invalid same-sized fixture writes");
+    result = lambo_pak_read_file(bad_path, actual);
+    expect(!result.ok, "same-sized data without a Controller Pak ID block is rejected");
+    free(container);
+
+    container = (unsigned char*)calloc(1, 2048);
+    expect(write_bytes(bad_path, container, 2048), "EEPROM fixture writes");
+    free(container);
+    result = lambo_pak_read_file(bad_path, actual);
+    expect(!result.ok, "2 KiB cartridge EEPROM is not mistaken for a Controller Pak");
+
+    result = lambo_pak_import_file(srm_path, import_path);
+    expect(result.ok && result.format == LAMBO_PAK_FORMAT_RETROARCH, "SRM import reports its source format");
+    container = read_bytes(import_path, LAMBO_PAK_SIZE);
+    for (index = 0x500; index < LAMBO_PAK_SIZE; ++index) expected[index] ^= 0xffu;
+    expect(container != NULL && memcmp(container, expected, LAMBO_PAK_SIZE) == 0,
+           "import creates a raw MPK containing only controller 1");
+    free(container);
+    result = lambo_pak_import_file(import_path, import_path);
+    expect(!result.ok, "import refuses to overwrite its own source");
+
+    remove(raw_path); remove(four_path); remove(srm_path);
+    remove(dex_path); remove(bad_path); remove(import_path);
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_pak_storage.cpp
+++ b/tests/test_pak_storage.cpp
@@ -5,11 +5,26 @@
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
+#include <mutex>
 #include <thread>
 
 namespace {
 
 int failures;
+std::mutex writer_observation_mutex;
+std::thread::id writer_thread;
+bool writer_thread_changed = false;
+
+LamboPakIoResult observed_write(const char* path, const uint8_t image[LAMBO_PAK_SIZE]) {
+    {
+        std::lock_guard lock(writer_observation_mutex);
+        if (writer_thread == std::thread::id{})
+            writer_thread = std::this_thread::get_id();
+        else if (writer_thread != std::this_thread::get_id())
+            writer_thread_changed = true;
+    }
+    return lambo_pak_write_file(path, image);
+}
 
 void expect(bool condition, const char* message) {
     if (!condition) {
@@ -46,6 +61,7 @@ int main() {
     make_valid_pak(image);
 
     lambo_pak_storage_configure(first.string().c_str());
+    lambo_pak_storage_set_write_hook(observed_write);
     expect(std::strcmp(lambo_pak_storage_path(), first.string().c_str()) == 0,
            "configured storage path is visible to the Joybus adapter");
     lambo_pak_storage_configure(second.string().c_str());
@@ -66,6 +82,11 @@ int main() {
     lambo_pak_storage_schedule_save(image.data());
     const LamboPakIoResult flushed = lambo_pak_storage_flush();
     expect(flushed.ok, "explicit flush publishes the pending save batch");
+    {
+        std::lock_guard lock(writer_observation_mutex);
+        expect(!writer_thread_changed,
+               "debounced and flushed saves use the same dedicated writer thread");
+    }
 
     std::array<uint8_t, LAMBO_PAK_SIZE> actual{};
     const LamboPakIoResult loaded = lambo_pak_read_file(second.string().c_str(), actual.data());

--- a/tests/test_pak_storage.cpp
+++ b/tests/test_pak_storage.cpp
@@ -1,0 +1,78 @@
+#include "lambo_pak_storage.h"
+
+#include <array>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <thread>
+
+namespace {
+
+int failures;
+
+void expect(bool condition, const char* message) {
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", message);
+        failures++;
+    }
+}
+
+void make_valid_pak(std::array<uint8_t, LAMBO_PAK_SIZE>& image) {
+    const size_t offset = 0x20;
+    uint16_t sum = 0;
+    for (size_t word = 0; word < 14; ++word) {
+        const size_t pos = offset + word * 2;
+        sum = static_cast<uint16_t>(sum + static_cast<uint16_t>((image[pos] << 8) | image[pos + 1]));
+    }
+    const uint16_t inverted = static_cast<uint16_t>(0xfff2u - sum);
+    image[offset + 0x1c] = static_cast<uint8_t>(sum >> 8);
+    image[offset + 0x1d] = static_cast<uint8_t>(sum);
+    image[offset + 0x1e] = static_cast<uint8_t>(inverted >> 8);
+    image[offset + 0x1f] = static_cast<uint8_t>(inverted);
+}
+
+} // namespace
+
+int main() {
+    const std::filesystem::path first = "pak_storage_first.mpk";
+    const std::filesystem::path second = "pak_storage_second.mpk";
+    std::filesystem::remove(first);
+    std::filesystem::remove(second);
+
+    std::array<uint8_t, LAMBO_PAK_SIZE> image{};
+    for (size_t index = 0; index < image.size(); ++index)
+        image[index] = static_cast<uint8_t>((index * 13u + 7u) & 0xffu);
+    make_valid_pak(image);
+
+    lambo_pak_storage_configure(first.string().c_str());
+    expect(std::strcmp(lambo_pak_storage_path(), first.string().c_str()) == 0,
+           "configured storage path is visible to the Joybus adapter");
+    lambo_pak_storage_configure(second.string().c_str());
+    expect(std::strcmp(lambo_pak_storage_path(), second.string().c_str()) == 0,
+           "reconfiguration is not hidden by one-shot path caching");
+
+    for (unsigned write = 0; write < 20; ++write) {
+        image[0x500 + write] ^= 0xffu;
+        lambo_pak_storage_schedule_save(image.data());
+    }
+    expect(!std::filesystem::exists(second),
+           "Joybus block writes do not synchronously publish the whole container");
+    for (unsigned attempt = 0; attempt < 200 && !std::filesystem::exists(second); ++attempt)
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    expect(std::filesystem::exists(second), "the debounced worker publishes a completed save burst");
+
+    image[0x600] ^= 0xffu;
+    lambo_pak_storage_schedule_save(image.data());
+    const LamboPakIoResult flushed = lambo_pak_storage_flush();
+    expect(flushed.ok, "explicit flush publishes the pending save batch");
+
+    std::array<uint8_t, LAMBO_PAK_SIZE> actual{};
+    const LamboPakIoResult loaded = lambo_pak_read_file(second.string().c_str(), actual.data());
+    expect(loaded.ok && actual == image, "a save burst publishes the final Pak image");
+
+    lambo_pak_storage_shutdown();
+    std::filesystem::remove(first);
+    std::filesystem::remove(second);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Adds format-aware Controller Pak import and shared-file support for raw MPK, Mupen64Plus-Next SRM, four-port MPK, and DexDrive N64 containers. Imports validate Pak identity data, back up existing saves, and preserve unrelated container regions during shared writes.

The Joybus adapter hands save snapshots to a dedicated host-storage module. A single worker thread now owns every disk publication: it coalesces 32-byte write bursts, responds immediately to explicit flush requests, and keeps publishing if newer data arrives during a write. File handling supports UTF-8 Windows paths, physical same-file detection, blank Pak initialization, transient replacement retries, and operating-system error details.

## Why?

Players commonly already have progress in emulator-generated Controller Pak files, but the recomp previously used only its own raw MPK in the working directory. This makes those saves portable without treating unrelated EEPROM, SRAM, or ROM files as Controller Paks.

Closes #176

## How was it verified?

- [x] Built clean with `build.ps1` (Windows) - no manual cmake incantation
- [x] Booted smoke-tested: attract -> title -> menu -> race
- [x] If visual: not applicable; no visual changes
- [x] If config/schema: not applicable; no graphics schema changes
- [x] If new dep patch: not applicable; no dependency patches added
- [x] If new hook into recompiled code: not applicable; no generated-code hooks added
- [x] No comments that explain *what* the code does (only *why* - see `CLAUDE.md`)
- [x] No "Generated with Claude Code" footer in commits or PR description

Additional verification:

- All three Controller Pak CTest targets passed: identity, emulator formats, and batched storage.
- The single-writer storage regression passed 20 consecutive runs and proves debounced and explicitly flushed saves use the same worker thread.
- Strict C17 and C++20 warning-as-error builds passed for the Pak I/O and storage changes.
- The Windows RDRAM allocation check run by `build.ps1` passed.
- A headless boot loaded the generated MPK and exited successfully after reaching the configured VI cap.
- The earlier visible automated menu/game smoke reached state 8, accepted 150 RAM-region Joybus Pak writes, produced a valid 32 KiB MPK, and reported zero save failures.
- A second boot loaded that generated MPK and left its SHA-256 unchanged.
- End-to-end Windows launch loaded an MPK from a directory and filename containing accented characters.

## Screenshots / video

Not applicable; this is save-file and command-line behavior.

## Risk / rollback

Risk is limited to Controller Pak path selection, import, and host persistence. Revert commits `e6876f7`, `fa4b25c`, and `4538b5b` to restore the previous raw-MPK-only behavior.
