### PR TITLE
feat(logging): make console opt-in with verbosity controls

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -82,7 +82,7 @@ A clear and concise description of what you expected to happen.
 **Session log.** On Windows, reproduce once with:
 
 ```
-LamborghiniRecomp.exe --console --verbose
+lamborghini_modern.exe --console --verbose
 ```
 
 Then attach the newest `logs/lamborghini-*.log` from

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -91,7 +91,7 @@ preferred `--verbose` flag is equivalent to `--log-level=debug`; use
 `--log-level=trace` only when a maintainer requests the noisier trace.
 
 **Crash output.** If the port hit a native crash, attach the newest
-`crashes/crash-report.txt` from the same directory. The crash report is written
+`crashes/crash-*.txt` from the same directory. The crash report is written
 even when no console was visible and contains a banner like:
 
 ```

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -79,18 +79,27 @@ A clear and concise description of what you expected to happen.
 
 ## Logs
 
-**Stderr.** Paste the **last ~30–50 lines of stderr** from `./build/lamborghini_modern`. The port logs warp lines (`[warp] CIRCUIT N: …`), audio warnings, and crash breadcrumbs to stderr — a single `[error]` line often names the function.
+**Session log.** On Windows, reproduce once with:
 
-> **On Windows**, stderr only appears in the launching terminal by default. Run the binary from a `cmd` / PowerShell window so you can copy the output. If you launched by double-click, re-launch from a terminal.
+```
+LamborghiniRecomp.exe --console --verbose
+```
 
-**Crash output.** If the port hit a native crash, the crash block is **text on stderr** delimited by a banner like:
+Then attach the newest `logs/lamborghini-*.log` from
+`%LOCALAPPDATA%\LamborghiniRecomp` (or the portable launch directory). The
+preferred `--verbose` flag is equivalent to `--log-level=debug`; use
+`--log-level=trace` only when a maintainer requests the noisier trace.
+
+**Crash output.** If the port hit a native crash, attach the newest
+`crashes/crash-report.txt` from the same directory. The crash report is written
+even when no console was visible and contains a banner like:
 
 ```
 ========================= NATIVE CRASH =========================
 Reason: ...
 ```
 
-Paste that whole block. *(The port does not produce a `.dmp` file — it prints a textual backtrace to stderr and `_Exit`s.)* Screenshot the OS crash dialog if one appeared.
+Attach that whole file. Screenshot the OS crash dialog if one appeared.
 
 ## Triage helpers
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,20 @@ else()
     set(NFD_PORTAL ON CACHE BOOL "" FORCE)
 endif()
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lib/rt64 ${CMAKE_BINARY_DIR}/rt64)
+# SDL2main owns the Windows entry point, but this project provides its own
+# WinMain wrapper so it can build as a GUI executable while still accepting
+# normal command-line arguments. RT64's bundled CMake adds SDL2main to its
+# direct link list; remove only that transitive entry-point library while
+# retaining SDL2 for the renderer and input backends.
+if(WIN32 AND TARGET rt64)
+    get_target_property(RT64_LINK_LIBRARIES rt64 LINK_LIBRARIES)
+    list(REMOVE_ITEM RT64_LINK_LIBRARIES SDL2main)
+    set_target_properties(rt64 PROPERTIES LINK_LIBRARIES "${RT64_LINK_LIBRARIES}")
+    get_target_property(RT64_INTERFACE_LINK_LIBRARIES rt64 INTERFACE_LINK_LIBRARIES)
+    list(REMOVE_ITEM RT64_INTERFACE_LINK_LIBRARIES SDL2main)
+    set_target_properties(rt64 PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${RT64_INTERFACE_LINK_LIBRARIES}")
+endif()
 # Generated shader headers land in the rt64 binary dir (Zelda64Recomp does the same).
 target_include_directories(rt64 PRIVATE ${CMAKE_BINARY_DIR}/rt64/src)
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ if(BUILD_TESTING)
         ${N64MR}/N64Recomp/include
         ${N64MR}/thirdparty
     )
+    target_link_libraries(lambo_config_tests PRIVATE Threads::Threads)
     add_test(NAME lambo_config_live_updates COMMAND lambo_config_tests)
 
     add_executable(lambo_log_tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,16 @@ if(BUILD_TESTING)
     )
     add_test(NAME lambo_config_live_updates COMMAND lambo_config_tests)
 
+    add_executable(lambo_log_tests
+        tests/test_lambo_log.cpp
+        src/lambo_log.cpp
+    )
+    target_include_directories(lambo_log_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    target_link_libraries(lambo_log_tests PRIVATE Threads::Threads)
+    add_test(NAME lambo_logging_policy COMMAND lambo_log_tests)
+
     add_executable(lambo_camera_projection_tests
         tests/test_camera_projection.cpp
     )
@@ -481,13 +491,20 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/lambo_gpu_advisory.cpp  # issue #109: outdated-Intel-driver detection + user-facing fix advisory
         src/lambo_warp.c       # issue #12: developer warp menu (F1-F6 / LAMBO_WARP race-track warp)
         src/lambo_savestate.c  # issue #22: developer save-state (F7/F8 / LAMBO_STATE_LOAD RDRAM snapshot)
-        src/lambo_log.cpp      # first-party debug-logging gate (--lambo-debug CLI flag)
+        src/lambo_log.cpp      # file-first levelled logging + --console/--verbose CLI policy
     )
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/aspMain.cpp)
         list(APPEND LAMBO_SOURCES src/aspMain.cpp)
     endif()
 
-    add_executable(lamborghini_modern ${LAMBO_SOURCES})
+    # The shipped Windows application is a GUI-subsystem executable.  Its
+    # WinMain wrapper still accepts normal command-line arguments; lambo_log
+    # allocates a console only when --console is requested.
+    if(WIN32)
+        add_executable(lamborghini_modern WIN32 ${LAMBO_SOURCES})
+    else()
+        add_executable(lamborghini_modern ${LAMBO_SOURCES})
+    endif()
     target_compile_definitions(lamborghini_modern PRIVATE
         HLSL_CPU
         LAMBO_VERSION="${PROJECT_VERSION}"
@@ -495,6 +512,9 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         LAMBO_VERSION_MINOR=${PROJECT_VERSION_MINOR}
         LAMBO_VERSION_PATCH=${PROJECT_VERSION_PATCH}
     )
+    if(WIN32)
+        target_compile_definitions(lamborghini_modern PRIVATE SDL_MAIN_HANDLED)
+    endif()
     if(NOT WIN32 AND NOT APPLE)
         target_compile_definitions(lamborghini_modern PRIVATE
             PLUME_SDL_VULKAN_ENABLED
@@ -593,8 +613,14 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         rt64
         RmlUi::Core
         RmlUi::Debugger
-        ${SDL2_LIBRARIES}
     )
+    if(WIN32)
+        # We own WinMain for the GUI-subsystem executable; SDL2main supplies
+        # its own entrypoint and would conflict with it.
+        target_link_libraries(lamborghini_modern PRIVATE SDL2)
+    else()
+        target_link_libraries(lamborghini_modern PRIVATE ${SDL2_LIBRARIES})
+    endif()
 
     add_custom_command(TARGET lamborghini_modern POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,9 @@ recompilation — please read this before opening an issue or PR.
 
 Use the **Bug report** issue template. The fields are not bureaucracy — each one
 maps to a layer the maintainer has to peel back to fix anything (ROM, build,
-config, runtime). A save state (F7) + `LAMBO_WARP` recipe + last 30 lines of
-stderr cut triage from hours to minutes. See the template for the full list.
+config, runtime). A save state (F7) + `LAMBO_WARP` recipe + the newest session
+log and crash report cut triage from hours to minutes. See the template for
+the full list.
 
 ## Proposing a change
 

--- a/README.md
+++ b/README.md
@@ -140,9 +140,11 @@ The warp performs the same stores the game's own menu makes when you confirm RAC
 (selection cursors + audio quiesce + game-state 7), so the race it starts is a normal
 single race. Warp and other diagnostic output is written to a per-session log
 file. By default only warnings and errors are retained; use `--log-level=debug`
-(or the shorter `--verbose`) for a bug report. Logs are stored under the same
-`LamborghiniRecomp` directory as `graphics.json`, in `logs/`. On Windows, launch
-with `--console --verbose` to mirror the verbose log live in a console as well.
+(or the shorter `--verbose`) for a bug report. On Windows logs are stored in
+`%LOCALAPPDATA%\LamborghiniRecomp\logs`; on Linux/macOS they use
+`$XDG_STATE_HOME/LamborghiniRecomp/logs` (or `~/.local/state/LamborghiniRecomp/logs`).
+With `portable.txt`, they are kept under the launch directory. On Windows,
+launch with `--console --verbose` to mirror the verbose log live in a console.
 
 The console, verbosity, and log file are independent: `--console` alone shows
 only the default warning/error output, while `--verbose` still records a file

--- a/README.md
+++ b/README.md
@@ -138,7 +138,16 @@ For development it is useful to jump straight into a race without driving the me
 
 The warp performs the same stores the game's own menu makes when you confirm RACE
 (selection cursors + audio quiesce + game-state 7), so the race it starts is a normal
-single race. Each warp is logged to stderr as `[warp] CIRCUIT N: ...`.
+single race. Warp and other diagnostic output is written to a per-session log
+file. By default only warnings and errors are retained; use `--log-level=debug`
+(or the shorter `--verbose`) for a bug report. Logs are stored under the same
+`LamborghiniRecomp` directory as `graphics.json`, in `logs/`. On Windows, launch
+with `--console --verbose` to mirror the verbose log live in a console as well.
+
+The console, verbosity, and log file are independent: `--console` alone shows
+only the default warning/error output, while `--verbose` still records a file
+when the game is launched by double-click. The older `--lambo-debug` flag remains
+accepted as an alias for `--verbose`.
 
 ## Building
 

--- a/src/lambo_analog_brake.cpp
+++ b/src/lambo_analog_brake.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 
 #include "recomp.h"
+#include "lambo_log.h"
 
 // Guest seam (measured live, see docs/analog-brake.md):
 // - Brake demand is the float at vehicle offset 0xA0. Stock digital play ramps
@@ -151,8 +152,8 @@ extern "C" void lambo_analog_brake_apply(uint8_t* rdram) {
         const int32_t speed = static_cast<int32_t>(MEM_W(0,
             (gpr)(int32_t)(kVehicleBase +
                 static_cast<uint32_t>(vehicle) * kVehicleStride + kSpeedOffset)));
-        std::fprintf(stderr,
-            "[probe] analog brake field: mode=%s port=%u channel=%d vehicle=%d frame=%u "
+        LAMBO_LOG_DEBUG("probe",
+            "analog brake field: mode=%s port=%u channel=%d vehicle=%d frame=%u "
             "normalized=%u demand=%.1f speed=%d\n",
             analog_mode ? "analog" : "digital", port, channel, vehicle, frame,
             static_cast<unsigned>(normalized), static_cast<double>(demand), speed);

--- a/src/lambo_analog_throttle.cpp
+++ b/src/lambo_analog_throttle.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 
 #include "recomp.h"
+#include "lambo_log.h"
 
 namespace {
 
@@ -150,8 +151,8 @@ extern "C" void lambo_analog_throttle_apply(uint8_t* rdram) {
         const int32_t speed = static_cast<int32_t>(MEM_W(0, speed_addr));
         const int previous = g_probe_last[port].exchange(demand, std::memory_order_relaxed);
         if (previous == demand && frame % 60u != 0) return;
-        std::fprintf(stderr,
-            "[probe] analog throttle field: mode=%s port=%u channel=%d vehicle=%d frame=%u "
+        LAMBO_LOG_DEBUG("probe",
+            "analog throttle field: mode=%s port=%u channel=%d vehicle=%d frame=%u "
             "normalized=%u limit=%d demand=%d speed=%d\n",
             analog_mode ? "analog" : "digital", port, channel, vehicle, frame,
             static_cast<unsigned>(normalized), static_cast<int>(limit),

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -16,12 +16,12 @@
 #include <thread>
 
 #include "lambo_log.h"
+#include "lambo_paths.h"
 
 #include "json/json.hpp"
 
 namespace {
 
-constexpr const char* kAppFolderName = "LamborghiniRecomp";
 constexpr const char* kGraphicsFile = "graphics.json";
 
 // Window-size keys live in the same graphics.json (extra keys alongside the
@@ -373,24 +373,7 @@ std::filesystem::path graphics_config_path() {
 }
 
 std::filesystem::path app_config_dir() {
-    // Portable mode: a portable.txt in the working directory keeps everything local.
-    std::error_code ec;
-    if (std::filesystem::exists("portable.txt", ec)) {
-        return std::filesystem::current_path();
-    }
-#if defined(_WIN32)
-    if (const wchar_t* localappdata = _wgetenv(L"LOCALAPPDATA")) {
-        return std::filesystem::path{localappdata} / kAppFolderName;
-    }
-#else
-    if (const char* xdg = std::getenv("XDG_CONFIG_HOME")) {
-        return std::filesystem::path{xdg} / kAppFolderName;
-    }
-    if (const char* home = std::getenv("HOME")) {
-        return std::filesystem::path{home} / ".config" / kAppFolderName;
-    }
-#endif
-    return std::filesystem::current_path();
+    return lambo::paths::app_config_dir();
 }
 
 ultramodern::renderer::GraphicsConfig default_graphics_config() {

--- a/src/lambo_config.cpp
+++ b/src/lambo_config.cpp
@@ -100,13 +100,13 @@ void from_or_default(const nlohmann::json& j, const char* key, T& out) {
     try {
         T parsed = it->get<T>();
         if (nlohmann::json(parsed) != *it) {
-            LAMBO_LOG("config", "%s: invalid value %s -- keeping default\n",
+            LAMBO_LOG_WARN("config", "%s: invalid value %s -- keeping default\n",
                          key, it->dump().c_str());
             return;
         }
         out = parsed;
     } catch (const nlohmann::json::exception&) {
-        LAMBO_LOG("config", "%s: wrong type -- keeping default\n", key);
+        LAMBO_LOG_WARN("config", "%s: wrong type -- keeping default\n", key);
     }
 }
 
@@ -212,7 +212,7 @@ void from_json(const nlohmann::json& j, ultramodern::renderer::GraphicsConfig& c
     // permanently headless, so reset to defaults instead.
     if (g_window_size.width < 320 || g_window_size.width > 7680 ||
         g_window_size.height < 240 || g_window_size.height > 4320) {
-        LAMBO_LOG("config", "window %dx%d out of range -- using %dx%d\n",
+        LAMBO_LOG_WARN("config", "window %dx%d out of range -- using %dx%d\n",
                      g_window_size.width, g_window_size.height,
                      kDefaultWindowWidth, kDefaultWindowHeight);
         g_window_size = {kDefaultWindowWidth, kDefaultWindowHeight};
@@ -232,7 +232,7 @@ ReadResult read_graphics_file(const std::filesystem::path& path,
         from_json(j, cfg);
         return ReadResult::Ok;
     } catch (const nlohmann::json::exception& e) {
-        LAMBO_LOG("config", "%s unparseable (%s); using defaults IN MEMORY"
+        LAMBO_LOG_WARN("config", "%s unparseable (%s); using defaults IN MEMORY"
                      " -- file left untouched, fix or delete it\n",
                      path.string().c_str(), e.what());
         return ReadResult::Unparseable;
@@ -252,13 +252,13 @@ bool write_graphics_json(const std::filesystem::path& path, const nlohmann::json
     std::filesystem::create_directories(path.parent_path(), ec);
     std::ofstream out{path};
     if (!out.good()) {
-        LAMBO_LOG("config", "cannot write %s\n", path.string().c_str());
+        LAMBO_LOG_ERROR("config", "cannot write %s\n", path.string().c_str());
         return false;
     }
     out << json.dump(4) << "\n";
     out.flush();
     if (!out.good()) {
-        LAMBO_LOG("config", "write to %s FAILED (disk full / permissions?)"
+        LAMBO_LOG_ERROR("config", "write to %s FAILED (disk full / permissions?)"
                             " -- settings may not persist\n", path.string().c_str());
         return false;
     }
@@ -283,12 +283,12 @@ void save_graphics_updates_sync(const nlohmann::json& updates) {
         try {
             in >> current;
             if (!current.is_object()) {
-                LAMBO_LOG("config", "%s is not a JSON object; leaving it untouched\n",
+                LAMBO_LOG_WARN("config", "%s is not a JSON object; leaving it untouched\n",
                           path.string().c_str());
                 return;
             }
         } catch (const nlohmann::json::exception& e) {
-            LAMBO_LOG("config", "%s unparseable (%s); leaving it untouched\n",
+            LAMBO_LOG_WARN("config", "%s unparseable (%s); leaving it untouched\n",
                       path.string().c_str(), e.what());
             return;
         }
@@ -436,7 +436,7 @@ ultramodern::renderer::GraphicsConfig load_and_apply_graphics() {
     if (r != ReadResult::Unparseable) {
         save_graphics(cfg);
     }
-    LAMBO_LOG("config", "graphics config: %s\n", path.string().c_str());
+    LAMBO_LOG_INFO("config", "graphics config: %s\n", path.string().c_str());
     return cfg;
 }
 

--- a/src/lambo_crash.cpp
+++ b/src/lambo_crash.cpp
@@ -26,6 +26,7 @@
 
 #include "librecomp/sections.h"
 #include "recomp.h"
+#include "lambo_log.h"
 
 #if defined(_WIN32)
     #define LAMBO_CRASH_WIN32 1
@@ -68,8 +69,8 @@ const SymbolInfo* lookup_in_pool(uint32_t vram, uint32_t* out_offset_bytes) {
 bool load_symbol_table(const std::filesystem::path& syms_path) {
     std::ifstream f(syms_path);
     if (!f.good()) {
-        std::fprintf(stderr, "[crash] syms file %s not found; raw N64 PCs only\n",
-                     syms_path.string().c_str());
+        LAMBO_LOG_WARN("crash", "syms file %s not found; raw N64 PCs only\n",
+                       syms_path.string().c_str());
         return false;
     }
 
@@ -163,8 +164,8 @@ bool load_symbol_table(const std::filesystem::path& syms_path) {
     // attributed name is identical run-to-run (matters for crash-digest CI).
     std::stable_sort(g_pool.table.begin(), g_pool.table.end(),
         [](const SymbolInfo& a, const SymbolInfo& b) { return a.vram < b.vram; });
-    std::fprintf(stderr, "[crash] loaded %zu symbols from %s\n",
-                 g_pool.table.size(), syms_path.string().c_str());
+    LAMBO_LOG_INFO("crash", "loaded %zu symbols from %s\n",
+                   g_pool.table.size(), syms_path.string().c_str());
     return !g_pool.table.empty();
 }
 
@@ -202,6 +203,7 @@ const SymbolInfo* lookup(uint32_t vram, uint32_t* out_offset_bytes) {
 // ----- Native-PC -> N64-vram map (populated by register_overlays) -----
 namespace {
 std::unordered_map<const void*, uint32_t> g_native_to_vram;
+FILE* g_crash_file = nullptr;
 } // namespace
 
 extern "C" void lambo_crash_register_code_ptrs(
@@ -365,8 +367,7 @@ void print_native_backtrace(FILE* fp, const void* const* pcs, int n, const char*
     }
 }
 
-void dump_crash_state(const char* reason, uint32_t vram_guess) {
-    FILE* fp = stderr;
+void dump_crash_state(FILE* fp, const char* reason, uint32_t vram_guess) {
     std::fprintf(fp, "\n========================= NATIVE CRASH =========================\n");
     if (reason) std::fprintf(fp, "Reason: %s\n", reason);
     if (vram_guess != 0) {
@@ -386,10 +387,26 @@ void dump_crash_state(const char* reason, uint32_t vram_guess) {
 void final_dump_and_die(const char* reason, uint32_t vram_guess,
                         const void* const* native_pcs, int native_pcs_n,
                         const char* kind) {
-    dump_crash_state(reason, vram_guess);
+    FILE* report = g_crash_file != nullptr ? g_crash_file : stderr;
+    dump_crash_state(report, reason, vram_guess);
     if (native_pcs && native_pcs_n > 0)
-        print_native_backtrace(stderr, native_pcs, native_pcs_n, kind);
-    std::fflush(stderr);
+        print_native_backtrace(report, native_pcs, native_pcs_n, kind);
+    std::fflush(report);
+#if !defined(_WIN32)
+    if (report != stderr) {
+        dump_crash_state(stderr, reason, vram_guess);
+        if (native_pcs && native_pcs_n > 0)
+            print_native_backtrace(stderr, native_pcs, native_pcs_n, kind);
+        std::fflush(stderr);
+    }
+#elif defined(_WIN32)
+    if (lambo_log_console_requested() && report != stderr) {
+        dump_crash_state(stderr, reason, vram_guess);
+        if (native_pcs && native_pcs_n > 0)
+            print_native_backtrace(stderr, native_pcs, native_pcs_n, kind);
+        std::fflush(stderr);
+    }
+#endif
     // _Exit (not abort): we finished the dump; do not re-enter via abort->SIGABRT.
     std::_Exit(EXIT_FAILURE);
 }
@@ -452,11 +469,21 @@ LONG WINAPI win32_vectored_handler(EXCEPTION_POINTERS* ep) {
         // dump path's own fprintf would re-fault it. _resetstkoflw bumps
         // RSP past the guard, then we print a minimal banner and exit.
         _resetstkoflw();
-        std::fprintf(stderr,
+        FILE* report = g_crash_file != nullptr ? g_crash_file : stderr;
+        std::fprintf(report,
             "\n========================= NATIVE CRASH =========================\n"
             "Reason: EXCEPTION_STACK_OVERFLOW (code 0x%08lX at %p)\n"
             "(dump truncated: stack overflow -- no native backtrace recoverable)\n",
             (unsigned long)code, ep->ExceptionRecord->ExceptionAddress);
+        std::fflush(report);
+        if (report != stderr && lambo_log_console_requested()) {
+            std::fprintf(stderr,
+                "\n========================= NATIVE CRASH =========================\n"
+                "Reason: EXCEPTION_STACK_OVERFLOW (code 0x%08lX at %p)\n"
+                "(dump truncated: stack overflow -- no native backtrace recoverable)\n",
+                (unsigned long)code, ep->ExceptionRecord->ExceptionAddress);
+            std::fflush(stderr);
+        }
         std::_Exit(EXIT_FAILURE);
     }
     // Raw code + faulting address in the banner: a field report with only a
@@ -510,7 +537,7 @@ void install_posix() {
     alt_stack.ss_size  = sizeof(alt_stack_buf);
     alt_stack.ss_flags = 0;
     if (sigaltstack(&alt_stack, nullptr) != 0)
-        std::fprintf(stderr, "[crash] sigaltstack failed; stack-overflow dumps may not land\n");
+        LAMBO_LOG_WARN("crash", "sigaltstack failed; stack-overflow dumps may not land\n");
 
     struct sigaction sa{};
     sa.sa_sigaction = posix_signal_handler;
@@ -524,7 +551,7 @@ void install_posix() {
     int fatal[] = { SIGSEGV, SIGBUS, SIGFPE, SIGILL };
     for (int s : fatal) {
         if (sigaction(s, &sa, nullptr) != 0)
-            std::fprintf(stderr, "[crash] sigaction(%d) failed; crash dumps disabled for this signal\n", s);
+            LAMBO_LOG_WARN("crash", "sigaction(%d) failed; crash dumps disabled for this signal\n", s);
     }
 }
 
@@ -535,18 +562,38 @@ void install() {
     static std::atomic<bool> once{false};
     bool expected = false;
     if (!once.compare_exchange_strong(expected, true)) return;
+    // Open a crash-specific destination before installing the handler. The
+    // handler does not enter the normal logger (its mutex/heap may be unsafe).
+    {
+        std::filesystem::path report_dir;
+        const char* log_path = lambo_log_path();
+        if (const char* override_dir = std::getenv("LAMBO_LOG_DIR");
+            override_dir != nullptr && override_dir[0] != '\0') {
+            report_dir = std::filesystem::path{override_dir} / "crashes";
+        } else if (log_path != nullptr && log_path[0] != '\0') {
+            report_dir = std::filesystem::path{log_path}.parent_path().parent_path() / "crashes";
+        } else {
+            report_dir = std::filesystem::current_path() / "crashes";
+        }
+        std::error_code ec;
+        std::filesystem::create_directories(report_dir, ec);
+        if (!ec) {
+            const auto report_path = report_dir / "crash-report.txt";
+            g_crash_file = std::fopen(report_path.string().c_str(), "wb");
+        }
+    }
 #if defined(LAMBO_CRASH_POSIX)
-    // Install handlers BEFORE the syms file IO: a slow disk read of the
-    // .toml must not race a fault on another thread that just started.
+    // Install handlers before the symbol-table IO, but only after the durable
+    // crash destination above is ready.
     install_posix();
 #endif
     find_and_load_symbol_table();
 #if defined(LAMBO_CRASH_WIN32)
     void* veh = AddVectoredExceptionHandler(0, win32_vectored_handler);
     if (veh == nullptr)
-        std::fprintf(stderr, "[crash] AddVectoredExceptionHandler returned NULL; dumps UNRELIABLE\n");
+        LAMBO_LOG_WARN("crash", "AddVectoredExceptionHandler returned NULL; dumps UNRELIABLE\n");
 #endif
-    std::fprintf(stderr, "[crash] native crash handler installed (%s)\n",
+    LAMBO_LOG_INFO("crash", "native crash handler installed (%s)\n",
 #if defined(LAMBO_CRASH_WIN32)
                  "Win32 AddVectoredExceptionHandler"
 #else

--- a/src/lambo_crash.cpp
+++ b/src/lambo_crash.cpp
@@ -16,9 +16,12 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <ctime>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 #include <mutex>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -27,12 +30,14 @@
 #include "librecomp/sections.h"
 #include "recomp.h"
 #include "lambo_log.h"
+#include "lambo_paths.h"
 
 #if defined(_WIN32)
     #define LAMBO_CRASH_WIN32 1
     #include <windows.h>
     #include <dbghelp.h>
     #include <malloc.h>
+    #include <process.h>
     #pragma comment(lib, "dbghelp.lib")
 #else
     #define LAMBO_CRASH_POSIX 1
@@ -204,6 +209,7 @@ const SymbolInfo* lookup(uint32_t vram, uint32_t* out_offset_bytes) {
 namespace {
 std::unordered_map<const void*, uint32_t> g_native_to_vram;
 FILE* g_crash_file = nullptr;
+std::filesystem::path g_crash_report_path;
 } // namespace
 
 extern "C" void lambo_crash_register_code_ptrs(
@@ -387,6 +393,13 @@ void dump_crash_state(FILE* fp, const char* reason, uint32_t vram_guess) {
 void final_dump_and_die(const char* reason, uint32_t vram_guess,
                         const void* const* native_pcs, int native_pcs_n,
                         const char* kind) {
+    if (g_crash_file == nullptr && !g_crash_report_path.empty()) {
+#if defined(_WIN32)
+        g_crash_file = _wfopen(g_crash_report_path.c_str(), L"wb");
+#else
+        g_crash_file = std::fopen(g_crash_report_path.string().c_str(), "wb");
+#endif
+    }
     FILE* report = g_crash_file != nullptr ? g_crash_file : stderr;
     dump_crash_state(report, reason, vram_guess);
     if (native_pcs && native_pcs_n > 0)
@@ -469,6 +482,9 @@ LONG WINAPI win32_vectored_handler(EXCEPTION_POINTERS* ep) {
         // dump path's own fprintf would re-fault it. _resetstkoflw bumps
         // RSP past the guard, then we print a minimal banner and exit.
         _resetstkoflw();
+        if (g_crash_file == nullptr && !g_crash_report_path.empty()) {
+            g_crash_file = _wfopen(g_crash_report_path.c_str(), L"wb");
+        }
         FILE* report = g_crash_file != nullptr ? g_crash_file : stderr;
         std::fprintf(report,
             "\n========================= NATIVE CRASH =========================\n"
@@ -562,24 +578,37 @@ void install() {
     static std::atomic<bool> once{false};
     bool expected = false;
     if (!once.compare_exchange_strong(expected, true)) return;
-    // Open a crash-specific destination before installing the handler. The
-    // handler does not enter the normal logger (its mutex/heap may be unsafe).
+    // Resolve a crash-specific destination before installing the handler. The
+    // file itself is opened only after a crash, so a later reproduction cannot
+    // erase the previous report and ordinary sessions leave no empty file.
     {
         std::filesystem::path report_dir;
-        const char* log_path = lambo_log_path();
         if (const char* override_dir = std::getenv("LAMBO_LOG_DIR");
             override_dir != nullptr && override_dir[0] != '\0') {
             report_dir = std::filesystem::path{override_dir} / "crashes";
-        } else if (log_path != nullptr && log_path[0] != '\0') {
-            report_dir = std::filesystem::path{log_path}.parent_path().parent_path() / "crashes";
         } else {
-            report_dir = std::filesystem::current_path() / "crashes";
+            report_dir = lambo::paths::app_state_dir() / "crashes";
         }
         std::error_code ec;
         std::filesystem::create_directories(report_dir, ec);
         if (!ec) {
-            const auto report_path = report_dir / "crash-report.txt";
-            g_crash_file = std::fopen(report_path.string().c_str(), "wb");
+            const auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+            std::tm tm{};
+#if defined(_WIN32)
+            localtime_s(&tm, &now);
+#else
+            localtime_r(&now, &tm);
+#endif
+            std::ostringstream name;
+            name << "crash-" << std::put_time(&tm, "%Y%m%d-%H%M%S")
+                 << "-" << static_cast<unsigned long>(
+#if defined(_WIN32)
+                     _getpid()
+#else
+                     getpid()
+#endif
+                 ) << ".txt";
+            g_crash_report_path = report_dir / name.str();
         }
     }
 #if defined(LAMBO_CRASH_POSIX)

--- a/src/lambo_log.cpp
+++ b/src/lambo_log.cpp
@@ -1,4 +1,5 @@
 #include "lambo_log.h"
+#include "lambo_paths.h"
 
 #include <algorithm>
 #include <atomic>
@@ -26,8 +27,8 @@
 
 namespace {
 
-std::atomic<int> g_level{LAMBO_LEVEL_WARN};
-bool g_console_requested = false;
+std::atomic_bool g_console_requested{false};
+std::atomic_bool g_stderr_sink{false};
 bool g_initialized = false;
 std::mutex g_mutex;
 std::ofstream g_file;
@@ -67,21 +68,7 @@ std::filesystem::path log_directory() {
         override_dir != nullptr && override_dir[0] != '\0') {
         return std::filesystem::path{override_dir};
     }
-    std::error_code ec;
-    if (std::filesystem::exists("portable.txt", ec))
-        return std::filesystem::current_path() / "logs";
-#if defined(_WIN32)
-    if (const wchar_t* localappdata = _wgetenv(L"LOCALAPPDATA");
-        localappdata != nullptr && localappdata[0] != L'\0') {
-        return std::filesystem::path{localappdata} / "LamborghiniRecomp" / "logs";
-    }
-#else
-    if (const char* xdg = std::getenv("XDG_CONFIG_HOME"); xdg != nullptr && xdg[0] != '\0')
-        return std::filesystem::path{xdg} / "LamborghiniRecomp" / "logs";
-    if (const char* home = std::getenv("HOME"); home != nullptr && home[0] != '\0')
-        return std::filesystem::path{home} / ".config" / "LamborghiniRecomp" / "logs";
-#endif
-    return std::filesystem::current_path() / "logs";
+    return lambo::paths::app_state_dir() / "logs";
 }
 
 unsigned long process_id() {
@@ -102,8 +89,17 @@ void open_console() {
         error_handle != INVALID_HANDLE_VALUE && GetFileType(error_handle) != FILE_TYPE_UNKNOWN;
     // Existing consoles already have correctly inherited CRT handles. This
     // also preserves deliberate stdout/stderr redirection from a shell.
-    if (GetConsoleWindow() != nullptr || inherited_sink) return;
-    if (AllocConsole() == 0) return;
+    if (GetConsoleWindow() != nullptr || inherited_sink) {
+        g_stderr_sink.store(true, std::memory_order_release);
+        return;
+    }
+    {
+        // A GUI process started from cmd/PowerShell often has no inherited
+        // standard handles. Attach to that parent before falling back to a
+        // new console, so --console behaves like a normal CLI switch.
+        if (AttachConsole(ATTACH_PARENT_PROCESS) == 0 && AllocConsole() == 0) return;
+    }
+    g_stderr_sink.store(true, std::memory_order_release);
     FILE* stream = nullptr;
     (void)freopen_s(&stream, "CONIN$", "r", stdin);
     (void)freopen_s(&stream, "CONOUT$", "w", stdout);
@@ -119,24 +115,29 @@ void prune_old_logs(const std::filesystem::path& directory) {
     std::error_code ec;
     for (const auto& entry : std::filesystem::directory_iterator(directory, ec)) {
         if (ec) break;
-        if (entry.is_regular_file(ec) &&
-            entry.path().filename().string().rfind("lamborghini-", 0) == 0)
+        const auto filename = entry.path().filename();
+        if (entry.is_regular_file(ec) && filename.extension() == ".log" &&
+            filename.stem().string().rfind("lamborghini-", 0) == 0)
             files.push_back(entry);
     }
     std::sort(files.begin(), files.end(), [](const auto& a, const auto& b) {
-        return a.path().filename().string() > b.path().filename().string();
+        return a.path().filename() > b.path().filename();
     });
     for (size_t i = 10; i < files.size(); ++i) (void)std::filesystem::remove(files[i], ec);
 }
 
 } // namespace
 
+extern "C" {
+volatile int g_log_threshold = LAMBO_LEVEL_WARN;
+}
 bool lambo_log_enabled = false;
 
 extern "C" bool lambo_log_parse_args(int argc, char** argv) {
     g_error.clear();
     g_console_requested = false;
     LamboLogLevel requested = LAMBO_LEVEL_WARN;
+    bool valid = true;
     for (int i = 1; i < argc; ++i) {
         const char* arg = argv[i];
         if (arg == nullptr) continue;
@@ -148,18 +149,21 @@ extern "C" bool lambo_log_parse_args(int argc, char** argv) {
         } else if (std::strncmp(arg, "--log-level=", 12) == 0) {
             if (!parse_level(arg + 12, &requested)) {
                 g_error = "--log-level must be error, warn, info, debug, or trace";
-                return false;
+                valid = false;
             }
         } else if (std::strcmp(arg, "--log-level") == 0) {
-            if (i + 1 >= argc || !parse_level(argv[++i], &requested)) {
+            if (i + 1 >= argc) {
                 g_error = "--log-level requires error, warn, info, debug, or trace";
-                return false;
+                valid = false;
+            } else if (!parse_level(argv[++i], &requested)) {
+                g_error = "--log-level requires error, warn, info, debug, or trace";
+                valid = false;
             }
         }
     }
-    g_level.store(static_cast<int>(requested), std::memory_order_release);
+    __atomic_store_n(&g_log_threshold, static_cast<int>(requested), __ATOMIC_RELEASE);
     lambo_log_enabled = requested >= LAMBO_LEVEL_DEBUG;
-    return true;
+    return valid;
 }
 
 extern "C" void lambo_log_parse_flag(int argc, char** argv) {
@@ -170,8 +174,18 @@ extern "C" const char* lambo_log_last_error(void) { return g_error.c_str(); }
 
 extern "C" bool lambo_log_initialize(void) {
     std::lock_guard<std::mutex> lock(g_mutex);
-    if (g_initialized) return g_file.good() || g_console_requested;
-    if (g_console_requested) open_console();
+    if (g_initialized) return g_file.good() || g_console_requested.load(std::memory_order_acquire);
+    if (g_console_requested.load(std::memory_order_acquire)) open_console();
+#if defined(_WIN32)
+    if (!g_stderr_sink.load(std::memory_order_acquire)) {
+        HANDLE error_handle = GetStdHandle(STD_ERROR_HANDLE);
+        g_stderr_sink.store(error_handle != nullptr && error_handle != INVALID_HANDLE_VALUE &&
+                                GetFileType(error_handle) != FILE_TYPE_UNKNOWN,
+                            std::memory_order_release);
+    }
+#else
+    g_stderr_sink.store(true, std::memory_order_release);
+#endif
     const std::filesystem::path directory = log_directory();
     std::error_code ec;
     std::filesystem::create_directories(directory, ec);
@@ -194,20 +208,30 @@ extern "C" bool lambo_log_initialize(void) {
         }
     }
     g_initialized = true;
-    return g_file.good() || g_console_requested;
+    return g_file.good() || g_stderr_sink.load(std::memory_order_acquire);
 }
 
-extern "C" const char* lambo_log_path(void) { return g_path.c_str(); }
+extern "C" const char* lambo_log_path(void) {
+    // Return a per-thread snapshot so callers never retain a pointer into the
+    // mutable path string while shutdown/reinitialization holds g_mutex.
+    thread_local std::string path_snapshot;
+    std::lock_guard<std::mutex> lock(g_mutex);
+    path_snapshot = g_path;
+    return path_snapshot.c_str();
+}
 extern "C" void lambo_log_shutdown(void) {
     std::lock_guard<std::mutex> lock(g_mutex);
+    if (g_file.good()) g_file.flush();
     g_file.close();
+    g_path.clear();
+    g_stderr_sink.store(false, std::memory_order_release);
+    g_initialized = false;
 }
-extern "C" bool lambo_log_console_requested(void) { return g_console_requested; }
+extern "C" bool lambo_log_console_requested(void) {
+    return g_console_requested.load(std::memory_order_acquire);
+}
 extern "C" LamboLogLevel lambo_log_level(void) {
-    return static_cast<LamboLogLevel>(g_level.load(std::memory_order_acquire));
-}
-extern "C" bool lambo_log_would_emit(LamboLogLevel level) {
-    return static_cast<int>(level) <= g_level.load(std::memory_order_relaxed);
+    return static_cast<LamboLogLevel>(__atomic_load_n(&g_log_threshold, __ATOMIC_ACQUIRE));
 }
 
 extern "C" void lambo_log_write(LamboLogLevel level, const char* tag, const char* format, ...) {
@@ -232,6 +256,11 @@ extern "C" void lambo_log_write(LamboLogLevel level, const char* tag, const char
     line << '[' << timestamp << "] [" << level_name(level) << "] ["
          << (tag != nullptr ? tag : "log") << "] " << message;
     const std::string text = line.str();
-    if (g_file.good()) { g_file << text; g_file.flush(); }
-    if (g_console_requested) { std::fwrite(text.data(), 1, text.size(), stderr); std::fflush(stderr); }
+    if (g_file.good()) g_file << text;
+    if (g_stderr_sink.load(std::memory_order_acquire))
+        std::fwrite(text.data(), 1, text.size(), stderr);
+    if (level == LAMBO_LEVEL_ERROR) {
+        if (g_file.good()) g_file.flush();
+        if (g_stderr_sink.load(std::memory_order_acquire)) std::fflush(stderr);
+    }
 }

--- a/src/lambo_log.cpp
+++ b/src/lambo_log.cpp
@@ -1,14 +1,237 @@
 #include "lambo_log.h"
 
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdarg>
+#include <cstdio>
 #include <cstring>
+#include <ctime>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace {
+
+std::atomic<int> g_level{LAMBO_LEVEL_WARN};
+bool g_console_requested = false;
+bool g_initialized = false;
+std::mutex g_mutex;
+std::ofstream g_file;
+std::string g_path;
+std::string g_error;
+
+const char* level_name(LamboLogLevel level) {
+    switch (level) {
+        case LAMBO_LEVEL_ERROR: return "error";
+        case LAMBO_LEVEL_WARN:  return "warn";
+        case LAMBO_LEVEL_INFO:  return "info";
+        case LAMBO_LEVEL_DEBUG: return "debug";
+        case LAMBO_LEVEL_TRACE: return "trace";
+    }
+    return "unknown";
+}
+
+bool parse_level(const char* value, LamboLogLevel* out) {
+    if (value == nullptr || out == nullptr) return false;
+    struct Name { const char* text; LamboLogLevel level; };
+    constexpr Name names[] = {
+        {"error", LAMBO_LEVEL_ERROR}, {"warn", LAMBO_LEVEL_WARN},
+        {"warning", LAMBO_LEVEL_WARN}, {"info", LAMBO_LEVEL_INFO},
+        {"debug", LAMBO_LEVEL_DEBUG}, {"trace", LAMBO_LEVEL_TRACE}
+    };
+    for (const Name& name : names) {
+        if (std::strcmp(value, name.text) == 0) {
+            *out = name.level;
+            return true;
+        }
+    }
+    return false;
+}
+
+std::filesystem::path log_directory() {
+    if (const char* override_dir = std::getenv("LAMBO_LOG_DIR");
+        override_dir != nullptr && override_dir[0] != '\0') {
+        return std::filesystem::path{override_dir};
+    }
+    std::error_code ec;
+    if (std::filesystem::exists("portable.txt", ec))
+        return std::filesystem::current_path() / "logs";
+#if defined(_WIN32)
+    if (const wchar_t* localappdata = _wgetenv(L"LOCALAPPDATA");
+        localappdata != nullptr && localappdata[0] != L'\0') {
+        return std::filesystem::path{localappdata} / "LamborghiniRecomp" / "logs";
+    }
+#else
+    if (const char* xdg = std::getenv("XDG_CONFIG_HOME"); xdg != nullptr && xdg[0] != '\0')
+        return std::filesystem::path{xdg} / "LamborghiniRecomp" / "logs";
+    if (const char* home = std::getenv("HOME"); home != nullptr && home[0] != '\0')
+        return std::filesystem::path{home} / ".config" / "LamborghiniRecomp" / "logs";
+#endif
+    return std::filesystem::current_path() / "logs";
+}
+
+unsigned long process_id() {
+#if defined(_WIN32)
+    return static_cast<unsigned long>(_getpid());
+#else
+    return static_cast<unsigned long>(getpid());
+#endif
+}
+
+void open_console() {
+#if defined(_WIN32)
+    // A test harness or terminal may already have supplied a pipe/console
+    // handle even when GetConsoleWindow() is null. Preserve that inherited
+    // sink; only create a new window for an Explorer-style launch.
+    HANDLE error_handle = GetStdHandle(STD_ERROR_HANDLE);
+    const bool inherited_sink = error_handle != nullptr &&
+        error_handle != INVALID_HANDLE_VALUE && GetFileType(error_handle) != FILE_TYPE_UNKNOWN;
+    // Existing consoles already have correctly inherited CRT handles. This
+    // also preserves deliberate stdout/stderr redirection from a shell.
+    if (GetConsoleWindow() != nullptr || inherited_sink) return;
+    if (AllocConsole() == 0) return;
+    FILE* stream = nullptr;
+    (void)freopen_s(&stream, "CONIN$", "r", stdin);
+    (void)freopen_s(&stream, "CONOUT$", "w", stdout);
+    (void)freopen_s(&stream, "CONOUT$", "w", stderr);
+    clearerr(stdin);
+    clearerr(stdout);
+    clearerr(stderr);
+#endif
+}
+
+void prune_old_logs(const std::filesystem::path& directory) {
+    std::vector<std::filesystem::directory_entry> files;
+    std::error_code ec;
+    for (const auto& entry : std::filesystem::directory_iterator(directory, ec)) {
+        if (ec) break;
+        if (entry.is_regular_file(ec) &&
+            entry.path().filename().string().rfind("lamborghini-", 0) == 0)
+            files.push_back(entry);
+    }
+    std::sort(files.begin(), files.end(), [](const auto& a, const auto& b) {
+        return a.path().filename().string() > b.path().filename().string();
+    });
+    for (size_t i = 10; i < files.size(); ++i) (void)std::filesystem::remove(files[i], ec);
+}
+
+} // namespace
 
 bool lambo_log_enabled = false;
 
-void lambo_log_parse_flag(int argc, char** argv) {
+extern "C" bool lambo_log_parse_args(int argc, char** argv) {
+    g_error.clear();
+    g_console_requested = false;
+    LamboLogLevel requested = LAMBO_LEVEL_WARN;
     for (int i = 1; i < argc; ++i) {
-        if (argv[i] && std::strcmp(argv[i], "--lambo-debug") == 0) {
-            lambo_log_enabled = true;
-            return;
+        const char* arg = argv[i];
+        if (arg == nullptr) continue;
+        if (std::strcmp(arg, "--console") == 0) {
+            g_console_requested = true;
+        } else if (std::strcmp(arg, "--verbose") == 0 ||
+                   std::strcmp(arg, "--lambo-debug") == 0) {
+            requested = LAMBO_LEVEL_DEBUG;
+        } else if (std::strncmp(arg, "--log-level=", 12) == 0) {
+            if (!parse_level(arg + 12, &requested)) {
+                g_error = "--log-level must be error, warn, info, debug, or trace";
+                return false;
+            }
+        } else if (std::strcmp(arg, "--log-level") == 0) {
+            if (i + 1 >= argc || !parse_level(argv[++i], &requested)) {
+                g_error = "--log-level requires error, warn, info, debug, or trace";
+                return false;
+            }
         }
     }
+    g_level.store(static_cast<int>(requested), std::memory_order_release);
+    lambo_log_enabled = requested >= LAMBO_LEVEL_DEBUG;
+    return true;
+}
+
+extern "C" void lambo_log_parse_flag(int argc, char** argv) {
+    (void)lambo_log_parse_args(argc, argv);
+}
+
+extern "C" const char* lambo_log_last_error(void) { return g_error.c_str(); }
+
+extern "C" bool lambo_log_initialize(void) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (g_initialized) return g_file.good() || g_console_requested;
+    if (g_console_requested) open_console();
+    const std::filesystem::path directory = log_directory();
+    std::error_code ec;
+    std::filesystem::create_directories(directory, ec);
+    if (!ec) {
+        const auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+        std::tm tm{};
+#if defined(_WIN32)
+        localtime_s(&tm, &now);
+#else
+        localtime_r(&now, &tm);
+#endif
+        std::ostringstream name;
+        name << "lamborghini-" << std::put_time(&tm, "%Y%m%d-%H%M%S")
+             << "-" << process_id() << ".log";
+        const std::filesystem::path path = directory / name.str();
+        g_file.open(path, std::ios::out | std::ios::app);
+        if (g_file.good()) {
+            g_path = path.string();
+            prune_old_logs(directory);
+        }
+    }
+    g_initialized = true;
+    return g_file.good() || g_console_requested;
+}
+
+extern "C" const char* lambo_log_path(void) { return g_path.c_str(); }
+extern "C" void lambo_log_shutdown(void) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_file.close();
+}
+extern "C" bool lambo_log_console_requested(void) { return g_console_requested; }
+extern "C" LamboLogLevel lambo_log_level(void) {
+    return static_cast<LamboLogLevel>(g_level.load(std::memory_order_acquire));
+}
+extern "C" bool lambo_log_would_emit(LamboLogLevel level) {
+    return static_cast<int>(level) <= g_level.load(std::memory_order_relaxed);
+}
+
+extern "C" void lambo_log_write(LamboLogLevel level, const char* tag, const char* format, ...) {
+    if (!lambo_log_would_emit(level)) return;
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (!g_initialized) return;
+    const auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    std::tm tm{};
+#if defined(_WIN32)
+    localtime_s(&tm, &now);
+#else
+    localtime_r(&now, &tm);
+#endif
+    char timestamp[32]{};
+    std::strftime(timestamp, sizeof(timestamp), "%Y-%m-%d %H:%M:%S", &tm);
+    char message[4096]{};
+    va_list args;
+    va_start(args, format);
+    std::vsnprintf(message, sizeof(message), format, args);
+    va_end(args);
+    std::ostringstream line;
+    line << '[' << timestamp << "] [" << level_name(level) << "] ["
+         << (tag != nullptr ? tag : "log") << "] " << message;
+    const std::string text = line.str();
+    if (g_file.good()) { g_file << text; g_file.flush(); }
+    if (g_console_requested) { std::fwrite(text.data(), 1, text.size(), stderr); std::fflush(stderr); }
 }

--- a/src/lambo_log.h
+++ b/src/lambo_log.h
@@ -1,10 +1,5 @@
-// First-party debug-logging gate (--lambo-debug). C/C++ portable; routed from
-// C TUs via plain C-linkage symbols (no namespace gymnastics).
-//
-// C-linkage chosen so C TUs (lambo_savestate.c, lambo_warp.c, libultra_stubs.c)
-// can use the same gate as C++ without a wrapper. lambo_crash.cpp and the
-// opt-in env-var features (LAMBO_PAK_TRACE, LAMBO_DL_INSPECT, ...) are NOT
-// routed through this header.
+// First-party logging and Windows console policy. C-linkage keeps this API
+// usable from the small C translation units as well as C++.
 
 #ifndef LAMBO_LOG_H
 #define LAMBO_LOG_H
@@ -16,18 +11,44 @@
 extern "C" {
 #endif
 
+typedef enum LamboLogLevel {
+    LAMBO_LEVEL_ERROR = 0,
+    LAMBO_LEVEL_WARN  = 1,
+    LAMBO_LEVEL_INFO  = 2,
+    LAMBO_LEVEL_DEBUG = 3,
+    LAMBO_LEVEL_TRACE = 4
+} LamboLogLevel;
+
+// Source-compatible fast path for existing hot-loop probes. It is true when
+// the selected threshold includes debug messages.
 extern bool lambo_log_enabled;
-void lambo_log_parse_flag(int argc, char** argv);
+bool lambo_log_parse_args(int argc, char** argv);
+void lambo_log_parse_flag(int argc, char** argv); // compatibility entry point
+const char* lambo_log_last_error(void);
+bool lambo_log_initialize(void);
+void lambo_log_shutdown(void);
+const char* lambo_log_path(void);
+bool lambo_log_console_requested(void);
+LamboLogLevel lambo_log_level(void);
+bool lambo_log_would_emit(LamboLogLevel level);
+void lambo_log_write(LamboLogLevel level, const char* tag, const char* format, ...);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-// `tag` MUST be a string literal -- concatenation happens here, not via printf
-// format. Args are NOT evaluated when the gate is closed (they live inside an
-// untaken if branch).
-#define LAMBO_LOG(tag, ...) \
-    do { if (lambo_log_enabled) fprintf(stderr, "[" tag "] " __VA_ARGS__); } while (0)
+// `tag` MUST be a string literal. Arguments remain inside the untaken branch,
+// so expensive formatting expressions are not evaluated at a disabled level.
+#define LAMBO_LOG_AT(level, tag, ...) \
+    do { if (lambo_log_would_emit(level)) lambo_log_write(level, tag, __VA_ARGS__); } while (0)
+
+// Existing diagnostics are debug-level by design.
+#define LAMBO_LOG(tag, ...) LAMBO_LOG_AT(LAMBO_LEVEL_DEBUG, tag, __VA_ARGS__)
+#define LAMBO_LOG_ERROR(tag, ...) LAMBO_LOG_AT(LAMBO_LEVEL_ERROR, tag, __VA_ARGS__)
+#define LAMBO_LOG_WARN(tag, ...) LAMBO_LOG_AT(LAMBO_LEVEL_WARN, tag, __VA_ARGS__)
+#define LAMBO_LOG_INFO(tag, ...) LAMBO_LOG_AT(LAMBO_LEVEL_INFO, tag, __VA_ARGS__)
+#define LAMBO_LOG_DEBUG(tag, ...) LAMBO_LOG_AT(LAMBO_LEVEL_DEBUG, tag, __VA_ARGS__)
+#define LAMBO_LOG_TRACE(tag, ...) LAMBO_LOG_AT(LAMBO_LEVEL_TRACE, tag, __VA_ARGS__)
 
 // Crash dumps and fatal early-init errors only -- never gate a line behind
 // this for convenience.

--- a/src/lambo_log.h
+++ b/src/lambo_log.h
@@ -22,6 +22,7 @@ typedef enum LamboLogLevel {
 // Source-compatible fast path for existing hot-loop probes. It is true when
 // the selected threshold includes debug messages.
 extern bool lambo_log_enabled;
+extern volatile int g_log_threshold;
 bool lambo_log_parse_args(int argc, char** argv);
 void lambo_log_parse_flag(int argc, char** argv); // compatibility entry point
 const char* lambo_log_last_error(void);
@@ -30,7 +31,6 @@ void lambo_log_shutdown(void);
 const char* lambo_log_path(void);
 bool lambo_log_console_requested(void);
 LamboLogLevel lambo_log_level(void);
-bool lambo_log_would_emit(LamboLogLevel level);
 void lambo_log_write(LamboLogLevel level, const char* tag, const char* format, ...);
 
 #ifdef __cplusplus
@@ -41,6 +41,13 @@ void lambo_log_write(LamboLogLevel level, const char* tag, const char* format, .
 // so expensive formatting expressions are not evaluated at a disabled level.
 #define LAMBO_LOG_AT(level, tag, ...) \
     do { if (lambo_log_would_emit(level)) lambo_log_write(level, tag, __VA_ARGS__); } while (0)
+
+// Keep disabled probes to one inlined atomic load/compare. GCC/Clang are the
+// supported native toolchains for this project (including MinGW on Windows).
+static inline bool lambo_log_would_emit(LamboLogLevel level) {
+    return (int)level <=
+        __atomic_load_n(&g_log_threshold, __ATOMIC_RELAXED);
+}
 
 // Existing diagnostics are debug-level by design.
 #define LAMBO_LOG(tag, ...) LAMBO_LOG_AT(LAMBO_LEVEL_DEBUG, tag, __VA_ARGS__)

--- a/src/lambo_menu.cpp
+++ b/src/lambo_menu.cpp
@@ -447,7 +447,7 @@ void toggle_fullscreen() {
     if (g_window == nullptr) return;
     const bool fullscreen = (SDL_GetWindowFlags(g_window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0;
     if (SDL_SetWindowFullscreen(g_window, fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0) != 0) {
-        LAMBO_LOG("config", "fullscreen toggle FAILED: %s\n", SDL_GetError());
+        LAMBO_LOG_WARN("config", "fullscreen toggle FAILED: %s\n", SDL_GetError());
         return;
     }
     set_window_menu(fullscreen ? nullptr : g_menu_bar);
@@ -456,7 +456,7 @@ void toggle_fullscreen() {
                                : ultramodern::renderer::WindowMode::Windowed;
     // Window mode is owned by SDL and deliberately not sent through RT64.
     lambo::config::update_saved_window_mode(cfg.wm_option);
-    LAMBO_LOG("config", "fullscreen %s (menu / F11 / Alt+Enter)\n", fullscreen ? "ON" : "OFF");
+    LAMBO_LOG_INFO("config", "fullscreen %s (menu / F11 / Alt+Enter)\n", fullscreen ? "ON" : "OFF");
     refresh();
 }
 
@@ -475,13 +475,13 @@ void toggle_fullscreen() {
     if (g_window == nullptr) return;
     const bool fullscreen = (SDL_GetWindowFlags(g_window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0;
     if (SDL_SetWindowFullscreen(g_window, fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0) != 0) {
-        LAMBO_LOG("config", "fullscreen toggle FAILED: %s\n", SDL_GetError());
+        LAMBO_LOG_WARN("config", "fullscreen toggle FAILED: %s\n", SDL_GetError());
         return;
     }
     lambo::config::update_saved_window_mode(
         fullscreen ? ultramodern::renderer::WindowMode::Fullscreen
                    : ultramodern::renderer::WindowMode::Windowed);
-    LAMBO_LOG("config", "fullscreen %s (F11 / Alt+Enter)\n", fullscreen ? "ON" : "OFF");
+    LAMBO_LOG_INFO("config", "fullscreen %s (F11 / Alt+Enter)\n", fullscreen ? "ON" : "OFF");
 }
 } // namespace lambo::menu
 

--- a/src/lambo_pak_storage.cpp
+++ b/src/lambo_pak_storage.cpp
@@ -1,4 +1,5 @@
 #include "lambo_pak_storage.h"
+#include "lambo_log.h"
 
 #include <array>
 #include <chrono>
@@ -58,7 +59,7 @@ void publish_snapshot(StorageState& storage, std::unique_lock<std::mutex>& lock)
 #else
         lambo_pak_write_file(path.c_str(), image.data());
 #endif
-    if (!result.ok) std::fprintf(stderr, "[pak] save failed: %s\n", result.error);
+    if (!result.ok) LAMBO_LOG_ERROR("pak", "save failed: %s\n", result.error);
     lock.lock();
     storage.last_result = result;
     storage.writing = false;

--- a/src/lambo_paths.h
+++ b/src/lambo_paths.h
@@ -1,0 +1,55 @@
+#ifndef LAMBO_PATHS_H
+#define LAMBO_PATHS_H
+
+#include <cstdlib>
+#include <filesystem>
+
+#if defined(_WIN32)
+#include <cwchar>
+#endif
+
+// One platform-aware authority for per-user application data. The public
+// lambo::config::app_config_dir() forwards here for existing callers, while
+// logging/crash reporting can use the state sibling without depending on the
+// full graphics-config implementation.
+namespace lambo::paths {
+
+inline std::filesystem::path app_config_dir() {
+    std::error_code ec;
+    if (std::filesystem::exists("portable.txt", ec))
+        return std::filesystem::current_path();
+#if defined(_WIN32)
+    if (const wchar_t* localappdata = _wgetenv(L"LOCALAPPDATA");
+        localappdata != nullptr && localappdata[0] != L'\0')
+        return std::filesystem::path{localappdata} / "LamborghiniRecomp";
+#else
+    // Runtime history such as logs belongs in the state hierarchy rather than
+    // the config hierarchy, which users commonly synchronize as dotfiles.
+    if (const char* xdg = std::getenv("XDG_CONFIG_HOME");
+        xdg != nullptr && xdg[0] != '\0')
+        return std::filesystem::path{xdg} / "LamborghiniRecomp";
+    if (const char* home = std::getenv("HOME"); home != nullptr && home[0] != '\0')
+        return std::filesystem::path{home} / ".config" / "LamborghiniRecomp";
+#endif
+    return std::filesystem::current_path();
+}
+
+inline std::filesystem::path app_state_dir() {
+    std::error_code ec;
+    if (std::filesystem::exists("portable.txt", ec))
+        return std::filesystem::current_path();
+#if defined(_WIN32)
+    return app_config_dir();
+#else
+    if (const char* state = std::getenv("XDG_STATE_HOME");
+        state != nullptr && state[0] != '\0')
+        return std::filesystem::path{state} / "LamborghiniRecomp";
+    if (const char* home = std::getenv("HOME"); home != nullptr && home[0] != '\0')
+        return std::filesystem::path{home} / ".local" / "state" / "LamborghiniRecomp";
+    return std::filesystem::current_path();
+#endif
+}
+
+} // namespace lambo::paths
+
+#endif // LAMBO_PATHS_H

--- a/src/lambo_player_name.cpp
+++ b/src/lambo_player_name.cpp
@@ -53,7 +53,7 @@ std::string load_saved_name() {
         std::string name = field->get<std::string>();
         return valid_name(name) ? name : std::string{};
     } catch (const nlohmann::json::exception& e) {
-        LAMBO_LOG("name", "%s unparseable (%s); keeping ROM default\n",
+        LAMBO_LOG_WARN("name", "%s unparseable (%s); keeping ROM default\n",
                   path.string().c_str(), e.what());
         return {};
     }
@@ -67,13 +67,13 @@ void save_name(const std::string& name) {
 
     std::ofstream out{tmp};
     if (!out.good()) {
-        LAMBO_LOG("name", "cannot write %s\n", tmp.string().c_str());
+        LAMBO_LOG_ERROR("name", "cannot write %s\n", tmp.string().c_str());
         return;
     }
     out << nlohmann::json{{"name", name}}.dump(4) << '\n';
     out.flush();
     if (!out.good()) {
-        LAMBO_LOG("name", "write to %s failed\n", tmp.string().c_str());
+        LAMBO_LOG_ERROR("name", "write to %s failed\n", tmp.string().c_str());
         return;
     }
     out.close();
@@ -88,7 +88,7 @@ void save_name(const std::string& name) {
     }
 #endif
     if (ec) {
-        LAMBO_LOG("name", "cannot publish %s\n", path.string().c_str());
+        LAMBO_LOG_ERROR("name", "cannot publish %s\n", path.string().c_str());
     }
 }
 
@@ -108,7 +108,7 @@ extern "C" void lambo_player_name_seed(uint8_t* rdram) {
     for (int i = 0; i < kNameStride; ++i) {
         MEM_B(i, dst) = i < (int)saved.size() ? saved[(size_t)i] : 0;
     }
-    LAMBO_LOG("name", "seeded player name: %s\n", saved.c_str());
+    LAMBO_LOG_INFO("name", "seeded player name: %s\n", saved.c_str());
 }
 
 extern "C" void lambo_player_name_save(uint8_t* rdram) {
@@ -124,5 +124,5 @@ extern "C" void lambo_player_name_save(uint8_t* rdram) {
     if (!valid_name(name)) return;
 
     save_name(name);
-    LAMBO_LOG("name", "saved player name: %s\n", name.c_str());
+    LAMBO_LOG_INFO("name", "saved player name: %s\n", name.c_str());
 }

--- a/src/libultra_stubs.c
+++ b/src/libultra_stubs.c
@@ -17,6 +17,7 @@
 #include "recomp.h"
 #include "lambo_pak_io.h"
 #include "lambo_pak_storage.h"
+#include "lambo_log.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -172,11 +173,11 @@ static void lambo_pak_ensure_loaded(void) {
     loaded = 1;
     result = lambo_pak_storage_load(g_lambo_pak_image);
     if (result.ok) {
-        fprintf(stderr, "[pak] loaded %s from %s\n",
-                lambo_pak_format_name(result.format), lambo_pak_storage_path());
+        LAMBO_LOG_INFO("pak", "loaded %s from %s\n",
+                       lambo_pak_format_name(result.format), lambo_pak_storage_path());
         return;
     }
-    fprintf(stderr, "[pak] %s; using a fresh formatted Pak in memory\n", result.error);
+    LAMBO_LOG_WARN("pak", "%s; using a fresh formatted Pak in memory\n", result.error);
     lambo_pak_format();                                         /* fresh formatted pak (memory only) */
 }
 
@@ -287,7 +288,7 @@ static void lambo_joybus_answer(uint8_t* rdram, gpr buf, const LamboPad* pads) {
                         /* gate the addr bytes on tx>=3 (same as the WRITE tracer): a degenerate
                          * short read frame near the end of the 0x40 buffer passes the pos+2+tx+rx
                          * guard but has no addr bytes, so reading pos+3/pos+4 would run off the end */
-                        fprintf(stderr, "[paktrc] READ  ch=%d tx=%d rx=%d addr=%04x served=%s crc=%02x\n",
+                        LAMBO_LOG_TRACE("paktrc", "READ  ch=%d tx=%d rx=%d addr=%04x served=%s crc=%02x\n",
                                 channel, tx, rx,
                                 (unsigned)(tx >= 3 ? (((MEM_BU(pos + 3, buf) << 8) | MEM_BU(pos + 4, buf)) & 0xFFE0u) : 0xFFFFu),
                                 (has_pak && rx == 33) ? "image" : "nopak",
@@ -312,7 +313,7 @@ static void lambo_joybus_answer(uint8_t* rdram, gpr buf, const LamboPad* pads) {
                         MEM_B(0, resp) = (signed char)(crc ^ 0xFF);             /* no pak */
                     }
                     if (lambo_pak_trace())
-                        fprintf(stderr, "[paktrc] WRITE ch=%d tx=%d rx=%d addr=%04x data0=%02x served=%s ack=%02x\n",
+                        LAMBO_LOG_TRACE("paktrc", "WRITE ch=%d tx=%d rx=%d addr=%04x data0=%02x served=%s ack=%02x\n",
                                 channel, tx, rx,
                                 (unsigned)(tx >= 3 ? (((MEM_BU(pos + 3, buf) << 8) | MEM_BU(pos + 4, buf)) & 0xFFE0u) : 0xFFFFu),
                                 (unsigned)(tx >= 3 ? MEM_BU(0, data) : 0),
@@ -322,7 +323,7 @@ static void lambo_joybus_answer(uint8_t* rdram, gpr buf, const LamboPad* pads) {
                 }
                 default: /* unknown command: no response */
                     if (lambo_pak_trace())
-                        fprintf(stderr, "[paktrc] UNKN  ch=%d tx=%d rx=%d cmd=%02x (no response)\n", channel, tx, rx, cmd);
+                        LAMBO_LOG_TRACE("paktrc", "UNKN  ch=%d tx=%d rx=%d cmd=%02x (no response)\n", channel, tx, rx, cmd);
                     MEM_B(pos + 1, buf) = (signed char)(rx | 0x80);
                     break;
                 }
@@ -356,8 +357,8 @@ static void lambo_pak_channel_probe(uint8_t* rdram, gpr buf) {
             gpr resp = buf + (gpr)(pos + 2 + tx);
             if (pos + 2 + tx + rx > 0x40) return;
             pak_probe_logged = 1;
-            fprintf(stderr, "[pak] first frame in status/pak buffer: cmd=%02x resp=%02x %02x %02x\n",
-                    cmd, (unsigned)MEM_BU(0, resp), (unsigned)MEM_BU(1, resp), (unsigned)MEM_BU(2, resp));
+            LAMBO_LOG_DEBUG("pak", "first frame in status/pak buffer: cmd=%02x resp=%02x %02x %02x\n",
+                            cmd, (unsigned)MEM_BU(0, resp), (unsigned)MEM_BU(1, resp), (unsigned)MEM_BU(2, resp));
             return;
         }
     }
@@ -455,7 +456,7 @@ void func_8007F780(uint8_t* rdram, recomp_context* ctx) {
         static int input_probe_logged = 0;
         if (!input_probe_logged) {
             input_probe_logged = 1;
-            fprintf(stderr, "[input] pad read reached game: buttons=%04x dest=%s bytes45=%02x %02x stick=(%d,%d)\n",
+            LAMBO_LOG_DEBUG("input", "pad read reached game: buttons=%04x dest=%s bytes45=%02x %02x stick=(%d,%d)\n",
                     (unsigned)pads[0].button, std_read ? "menu" : "race",
                     (unsigned char)MEM_BU(4, buf), (unsigned char)MEM_BU(5, buf),
                     (int)pads[0].stick_x, (int)pads[0].stick_y);
@@ -558,7 +559,7 @@ void func_8007AC78(uint8_t* rdram, recomp_context* ctx) {
      * Natively bypasses the uninitialized pfs->queue and pfs->channel (which remain zero/uninitialized
      * since osMotorInit is skipped when a Controller Pak is detected) and directly drives the motor. */
     int channel = ((int32_t)ctx->r4 - 0x80110D68) / 40;
-    if (lambo_pak_trace()) fprintf(stderr, "[pak] MOTOR START ch=%d\n", channel);
+    if (lambo_pak_trace()) LAMBO_LOG_DEBUG("pak", "MOTOR START ch=%d\n", channel);
     if (channel == 0) {
         lambo_pak_set_rumble(1);
     }
@@ -568,7 +569,7 @@ void func_8007AC78(uint8_t* rdram, recomp_context* ctx) {
 void func_8007AB10(uint8_t* rdram, recomp_context* ctx) {
     /* osMotorStop: VRAM 0x80079f10 */
     int channel = ((int32_t)ctx->r4 - 0x80110D68) / 40;
-    if (lambo_pak_trace()) fprintf(stderr, "[pak] MOTOR STOP ch=%d\n", channel);
+    if (lambo_pak_trace()) LAMBO_LOG_DEBUG("pak", "MOTOR STOP ch=%d\n", channel);
     if (channel == 0) {
         lambo_pak_set_rumble(0);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -773,13 +773,15 @@ static int application_main(int argc, char** argv) {
     for (int i = 1; i < argc; ++i) {
         if (argv[i] && std::strcmp(argv[i], "--import-save") == 0) {
             if (i + 1 >= argc || argv[i + 1] == nullptr || argv[i + 1][0] == '\0') {
-                LAMBO_LOG_ERROR("cli", "--import-save requires an MPK, SRM, or DexDrive N64 file\n");
+                std::fprintf(stderr,
+                             "[error] [cli] --import-save requires an MPK, SRM, or DexDrive N64 file\n");
                 return 2;
             }
             import_path = argv[++i];
         } else if (argv[i] && std::strcmp(argv[i], "--controller-pak") == 0) {
             if (i + 1 >= argc || argv[i + 1] == nullptr || argv[i + 1][0] == '\0') {
-                LAMBO_LOG_ERROR("cli", "--controller-pak requires an MPK, SRM, or DexDrive N64 file\n");
+                std::fprintf(stderr,
+                             "[error] [cli] --controller-pak requires an MPK, SRM, or DexDrive N64 file\n");
                 return 2;
             }
             controller_pak_path = argv[++i];
@@ -787,17 +789,15 @@ static int application_main(int argc, char** argv) {
             // lambo_log_parse_args already validated and consumed this value;
             // keep the ROM selector from mistaking it for a ROM path.
             ++i;
-        } else if (argv[i] && (std::strncmp(argv[i], "--log-level=", 12) == 0 ||
-                              std::strcmp(argv[i], "--verbose") == 0 ||
-                              std::strcmp(argv[i], "--lambo-debug") == 0 ||
-                              std::strcmp(argv[i], "--console") == 0)) {
-            // Logging-only switches are handled by the logging pass above.
         } else if (argv[i] && argv[i][0] != '-' && argv[i][0] != '\0' &&
                    is_controller_pak_container(argv[i])) {
             import_path = argv[i];
         } else if (!rom_was_selected && argv[i] && argv[i][0] != '-' && argv[i][0] != '\0') {
             rom_path = argv[i];
             rom_was_selected = true;
+        } else if (argv[i] && argv[i][0] == '-') {
+            // Logging and future switches are parsed by their owning subsystem;
+            // they must never be mistaken for a ROM or save path here.
         }
     }
     LAMBO_LOG("probe", "ROM: %s\n", rom_path);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -750,10 +750,17 @@ static int application_main(int argc, char** argv) {
     // attaching/allocating the live stderr sink.
     if (!lambo_log_parse_args(argc, argv)) {
         (void)lambo_log_initialize();
-        LAMBO_LOG_ERROR("log", "%s\n", lambo_log_last_error());
+        // Command-line syntax errors must remain visible even when the user
+        // did not request a console or the log directory is unavailable.
+        std::fprintf(stderr, "[error] [log] %s\n", lambo_log_last_error());
         return 2;
     }
     (void)lambo_log_initialize();
+#if defined(_WIN32)
+    // SDL2main normally performs this when it owns WinMain. This target owns
+    // WinMain because it is a GUI-subsystem executable.
+    SDL_SetMainReady();
+#endif
     // Deterministic lighting self-test: no ROM, no runtime -- exercises the swrender
     // light-decode + lambert path on a synthetic DL and exits (tests/pivot/test_lighting.py).
     if (std::getenv("LAMBO_LIGHTING_SELFTEST")) {
@@ -776,6 +783,15 @@ static int application_main(int argc, char** argv) {
                 return 2;
             }
             controller_pak_path = argv[++i];
+        } else if (argv[i] && std::strcmp(argv[i], "--log-level") == 0) {
+            // lambo_log_parse_args already validated and consumed this value;
+            // keep the ROM selector from mistaking it for a ROM path.
+            ++i;
+        } else if (argv[i] && (std::strncmp(argv[i], "--log-level=", 12) == 0 ||
+                              std::strcmp(argv[i], "--verbose") == 0 ||
+                              std::strcmp(argv[i], "--lambo-debug") == 0 ||
+                              std::strcmp(argv[i], "--console") == 0)) {
+            // Logging-only switches are handled by the logging pass above.
         } else if (argv[i] && argv[i][0] != '-' && argv[i][0] != '\0' &&
                    is_controller_pak_container(argv[i])) {
             import_path = argv[i];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,12 +119,13 @@ static void thread_create_cb(uint8_t*, recomp_context*) {
 // thread actually runs its per-frame dispatch loop, those threads are live in native
 // osRecvMesg and race the munmap into a SIGSEGV. This is a headless boot/probe harness that is
 // quitting anyway, so skip the unwind and let process exit tear the game threads down.
-// (Graceful game-thread shutdown is RT64-integration work, #58.)
+    // (Graceful game-thread shutdown is RT64-integration work, #58.)
 [[noreturn]] static void boot_summary_and_exit() {
     LAMBO_LOG("probe", "boot summary; threads=%d vis=%d first_vi=%d max_state=%d swaps=%d\n",
                  g_threads.load(), g_vis.load(), (int)g_first_vi.load(), g_max_state.load(),
                  g_swaps.load());
     (void)lambo_pak_storage_flush();
+    lambo_log_shutdown();
     std::fflush(nullptr);
     std::_Exit(g_first_vi.load() ? 0 : 2);
 }
@@ -138,6 +139,7 @@ static void thread_create_cb(uint8_t*, recomp_context*) {
     // terminates the process below, so there is no cleanup benefit that can
     // justify touching either subsystem first.
     (void)lambo_pak_storage_flush();
+    lambo_log_shutdown();
     std::fflush(nullptr);
     std::_Exit(0);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -745,14 +745,20 @@ static std::filesystem::path unused_backup_path(const std::filesystem::path& pat
 }
 
 static int application_main(int argc, char** argv) {
+    // Parse and initialise logging before any startup path can emit a message.
+    // The Windows target is GUI-subsystem, so --console is responsible for
+    // attaching/allocating the live stderr sink.
+    if (!lambo_log_parse_args(argc, argv)) {
+        (void)lambo_log_initialize();
+        LAMBO_LOG_ERROR("log", "%s\n", lambo_log_last_error());
+        return 2;
+    }
+    (void)lambo_log_initialize();
     // Deterministic lighting self-test: no ROM, no runtime -- exercises the swrender
     // light-decode + lambert path on a synthetic DL and exits (tests/pivot/test_lighting.py).
     if (std::getenv("LAMBO_LIGHTING_SELFTEST")) {
         return headless::run_lighting_selftest();
     }
-    // Parse --lambo-debug BEFORE anything else that might print a [probe] line.
-    // The flag is read by every LAMBO_LOG() site via the lambo_log_enabled bool.
-    lambo_log_parse_flag(argc, argv);
     const char* rom_path = "Automobili Lamborghini (USA).z64";
     const char* import_path = nullptr;
     const char* controller_pak_path = nullptr;
@@ -760,13 +766,13 @@ static int application_main(int argc, char** argv) {
     for (int i = 1; i < argc; ++i) {
         if (argv[i] && std::strcmp(argv[i], "--import-save") == 0) {
             if (i + 1 >= argc || argv[i + 1] == nullptr || argv[i + 1][0] == '\0') {
-                std::fprintf(stderr, "--import-save requires an MPK, SRM, or DexDrive N64 file\n");
+                LAMBO_LOG_ERROR("cli", "--import-save requires an MPK, SRM, or DexDrive N64 file\n");
                 return 2;
             }
             import_path = argv[++i];
         } else if (argv[i] && std::strcmp(argv[i], "--controller-pak") == 0) {
             if (i + 1 >= argc || argv[i + 1] == nullptr || argv[i + 1][0] == '\0') {
-                std::fprintf(stderr, "--controller-pak requires an MPK, SRM, or DexDrive N64 file\n");
+                LAMBO_LOG_ERROR("cli", "--controller-pak requires an MPK, SRM, or DexDrive N64 file\n");
                 return 2;
             }
             controller_pak_path = argv[++i];
@@ -830,20 +836,20 @@ static int application_main(int argc, char** argv) {
     lambo_pak_storage_configure(active_pak_path_string.c_str());
 
     if (import_path != nullptr && controller_pak_path != nullptr) {
-        std::fprintf(stderr, "--import-save and --controller-pak cannot be used together\n");
+        LAMBO_LOG_ERROR("cli", "--import-save and --controller-pak cannot be used together\n");
         return 2;
     } else if (import_path != nullptr) {
         std::error_code error;
         const LamboPakIoResult source = lambo_pak_probe_file(import_path);
         if (!source.ok) {
-            std::fprintf(stderr, "[pak] import failed: %s\n", source.error);
+            LAMBO_LOG_ERROR("pak", "import failed: %s\n", source.error);
             return 2;
         }
         const bool source_is_destination =
             std::filesystem::equivalent(path_from_utf8(import_path), pak_path, error);
         if (source_is_destination && !error) {
-            std::fprintf(stderr, "[pak] selected save is already the active Controller Pak: %s\n",
-                         pak_path_string.c_str());
+            LAMBO_LOG_INFO("pak", "selected save is already the active Controller Pak: %s\n",
+                           pak_path_string.c_str());
         } else {
             error.clear();
             if (std::filesystem::exists(pak_path)) {
@@ -851,20 +857,20 @@ static int application_main(int argc, char** argv) {
                 std::filesystem::copy_file(pak_path, backup, error);
                 if (error) {
                     const std::string backup_string = path_to_utf8(backup);
-                    std::fprintf(stderr, "[pak] cannot back up existing save to %s: %s\n",
-                                 backup_string.c_str(), error.message().c_str());
+                    LAMBO_LOG_ERROR("pak", "cannot back up existing save to %s: %s\n",
+                                     backup_string.c_str(), error.message().c_str());
                     return 2;
                 }
                 const std::string backup_string = path_to_utf8(backup);
-                std::fprintf(stderr, "[pak] backed up existing save to %s\n", backup_string.c_str());
+                LAMBO_LOG_INFO("pak", "backed up existing save to %s\n", backup_string.c_str());
             }
             const LamboPakIoResult imported = lambo_pak_import_file(import_path, pak_path_string.c_str());
             if (!imported.ok) {
-                std::fprintf(stderr, "[pak] import failed: %s\n", imported.error);
+                LAMBO_LOG_ERROR("pak", "import failed: %s\n", imported.error);
                 return 2;
             }
-            std::fprintf(stderr, "[pak] imported %s to %s\n",
-                         lambo_pak_format_name(imported.format), pak_path_string.c_str());
+            LAMBO_LOG_INFO("pak", "imported %s to %s\n",
+                           lambo_pak_format_name(imported.format), pak_path_string.c_str());
         }
     } else if (controller_pak_path == nullptr && !std::filesystem::exists(pak_path)) {
         // One-time migration for builds before #176, which accidentally stored the
@@ -875,10 +881,10 @@ static int application_main(int argc, char** argv) {
             const LamboPakIoResult migrated =
                 lambo_pak_import_file(legacy_string.c_str(), pak_path_string.c_str());
             if (migrated.ok)
-                std::fprintf(stderr, "[pak] migrated legacy %s save to %s\n",
-                             lambo_pak_format_name(migrated.format), pak_path_string.c_str());
+                LAMBO_LOG_INFO("pak", "migrated legacy %s save to %s\n",
+                               lambo_pak_format_name(migrated.format), pak_path_string.c_str());
             else
-                std::fprintf(stderr, "[pak] legacy save migration failed: %s\n", migrated.error);
+                LAMBO_LOG_WARN("pak", "legacy save migration failed: %s\n", migrated.error);
         }
     }
     g_controls = std::make_unique<lambo::controls::SdlAdapter>();
@@ -897,7 +903,7 @@ static int application_main(int argc, char** argv) {
     std::u8string game_id = u8"lamborghini.us";
     recomp::RomValidationError verr = recomp::select_rom(rom_path, game_id);
     if (verr != recomp::RomValidationError::Good) {
-        LAMBO_LOG("probe", "select_rom FAILED (RomValidationError=%d)\n", (int)verr);
+        LAMBO_LOG_ERROR("rom", "select_rom FAILED (RomValidationError=%d)\n", (int)verr);
         return 1;
     }
     LAMBO_LOG("probe", "ROM validated; rom_hash matches\n");
@@ -913,7 +919,7 @@ static int application_main(int argc, char** argv) {
     g_startup_controller = &startup_controller;
     lambo::ui::set_startup_controller(&startup_controller);
     lambo::ui::install_render_hooks();
-    LAMBO_LOG("probe", "startup mode: %s\n",
+    LAMBO_LOG_INFO("startup", "startup mode: %s\n",
               startup_mode == lambo::StartupMode::Automatic ? "automatic" : "interactive");
 
     // Watchdog: guarantee automatic probes terminate and report. Only started for
@@ -1029,7 +1035,7 @@ static int application_main(int argc, char** argv) {
 }
 
 #if defined(_WIN32)
-int main(int, char**) {
+static int windows_command_line_main() {
     int argument_count = 0;
     wchar_t** wide_arguments = CommandLineToArgvW(GetCommandLineW(), &argument_count);
     if (wide_arguments == nullptr) return 2;
@@ -1054,6 +1060,13 @@ int main(int, char**) {
     for (std::string& argument : arguments) argument_pointers.push_back(argument.data());
     argument_pointers.push_back(nullptr);
     return application_main(argument_count, argument_pointers.data());
+}
+
+// The release executable uses the GUI subsystem so Explorer launches do not
+// create a console.  Keep argument parsing in one place and let application
+// logging decide whether --console needs to allocate a window.
+int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
+    return windows_command_line_main();
 }
 #else
 int main(int argc, char** argv) {

--- a/src/rt64_renderer.cpp
+++ b/src/rt64_renderer.cpp
@@ -197,7 +197,7 @@ void warn_about_gpu_driver(RT64::Application* app, ultramodern::renderer::Graphi
     lambo_gpu_advisory_message(severity, desc.name.c_str(), driver_version,
                                lambo::config::graphics_config_path().string().c_str(),
                                text, sizeof text);
-    LAMBO_LOG("gpu", "driver advisory:\n%s\n", text);
+    LAMBO_LOG_WARN("gpu", "driver advisory:\n%s\n", text);
     if (severity == LAMBO_GPU_ADVISORY_SEVERE) {
         // The affected user sees only a black window; a console line is not enough.
         // Post to the main thread's event pump, which owns showing the message box.
@@ -293,7 +293,7 @@ public:
         };
 
         if (!try_setup(to_rt64_api(cur_config.api_option))) {
-            LAMBO_LOG("rt64", "RT64::Application::setup FAILED (SetupResult=%d, api=%d)\n",
+            LAMBO_LOG_ERROR("rt64", "RT64::Application::setup FAILED (SetupResult=%d, api=%d)\n",
                          (int)setup_result, (int)cur_config.api_option);
             // RT64 auto-retries the other backend itself only when the API choice is
             // Automatic. For an EXPLICIT choice that fails to initialise we flip once
@@ -311,16 +311,16 @@ public:
                 app = nullptr;
                 return;
             }
-            LAMBO_LOG("rt64", "retrying with the other graphics API...\n");
+            LAMBO_LOG_WARN("rt64", "retrying with the other graphics API...\n");
             if (!try_setup(fallback)) {
-                LAMBO_LOG("rt64", "retry also FAILED (SetupResult=%d)\n", (int)setup_result);
+                LAMBO_LOG_ERROR("rt64", "retry also FAILED (SetupResult=%d)\n", (int)setup_result);
                 app = nullptr;
                 return;
             }
-            LAMBO_LOG("rt64", "retry succeeded (api=%d)\n", (int)chosen_api);
+            LAMBO_LOG_INFO("rt64", "retry succeeded (api=%d)\n", (int)chosen_api);
         }
 
-        LAMBO_LOG("rt64", "RT64 renderer initialised (api=%d)\n", (int)chosen_api);
+        LAMBO_LOG_INFO("rt64", "RT64 renderer initialised (api=%d)\n", (int)chosen_api);
 
         warn_about_gpu_driver(app.get(), chosen_api);
 
@@ -339,14 +339,14 @@ public:
             // Setting this non-empty makes TextureManager::dumpTexture write every
             // uploaded texture (raw TMEM + RDRAM + tile JSON) to the directory.
             app->state->dumpingTexturesDirectory = std::filesystem::path(dump_dir);
-            LAMBO_LOG("rt64", "texture dump enabled -> %s\n", dump_dir.c_str());
+            LAMBO_LOG_INFO("rt64", "texture dump enabled -> %s\n", dump_dir.c_str());
         }
 
         const std::string pack = lambo::config::texture_pack_path();
         if (!pack.empty()) {
             const bool ok = app->textureCache->loadReplacementDirectory(
                 RT64::ReplacementDirectory(std::filesystem::path(pack)));
-            LAMBO_LOG("rt64", "texture pack %s: %s\n",
+            LAMBO_LOG_INFO("rt64", "texture pack %s: %s\n",
                          ok ? "loaded" : "FAILED to load", pack.c_str());
         }
     }

--- a/src/stub_renderer.cpp
+++ b/src/stub_renderer.cpp
@@ -1563,10 +1563,10 @@ create_render_context(uint8_t* rdram, ultramodern::renderer::WindowHandle window
     if (lambo_rt64::enabled()) {
         auto rt64_ctx = lambo_rt64::create_render_context(rdram, window_handle, developer_mode);
         if (rt64_ctx) {
-            LAMBO_LOG("rt64", "RT64 renderer ACTIVE (default presenter)\n");
+            LAMBO_LOG_INFO("rt64", "RT64 renderer ACTIVE (default presenter)\n");
             return rt64_ctx;
         }
-        LAMBO_LOG("rt64", "RT64 setup failed -- falling back to headless swrender\n");
+        LAMBO_LOG_WARN("rt64", "RT64 setup failed -- falling back to headless swrender\n");
     }
     (void)window_handle;
     (void)developer_mode;

--- a/src/ui/lambo_ui.cpp
+++ b/src/ui/lambo_ui.cpp
@@ -302,7 +302,7 @@ void UiState::load_page(lambo::ui::Page page, bool push_history) {
     const std::filesystem::path path = asset_root() / descriptor.document;
     document = context->LoadDocument(path.string());
     if (document == nullptr) {
-        LAMBO_LOG("ui", "failed to load %s\n", path.string().c_str());
+        LAMBO_LOG_WARN("ui", "failed to load %s\n", path.string().c_str());
         g_visible.store(false, std::memory_order_release);
         g_capture.store(false, std::memory_order_release);
         current_page.reset();
@@ -321,7 +321,7 @@ void UiState::load_page(lambo::ui::Page page, bool push_history) {
     set_input_mode(input_mode);
     g_visible.store(true, std::memory_order_release);
     g_capture.store(true, std::memory_order_release);
-    LAMBO_LOG("ui", "opened %s page\n", descriptor.title);
+    LAMBO_LOG_INFO("ui", "opened %s page\n", descriptor.title);
 }
 
 void UiState::show_page(lambo::ui::Page page) {
@@ -365,7 +365,7 @@ void process_action(const std::string& action, const std::string& parameter) {
         auto* controller = g_startup_controller.load(std::memory_order_acquire);
         if (controller != nullptr && controller->request_play()) {
             if (g_state != nullptr) g_state->hide_pages();
-            LAMBO_LOG("ui", "Play accepted; launcher hidden\n");
+            LAMBO_LOG_INFO("ui", "Play accepted; launcher hidden\n");
         }
     } else if (action == "quit") {
         if (auto* controller = g_startup_controller.load(std::memory_order_acquire)) {
@@ -418,7 +418,7 @@ void init_hook(RT64::RenderInterface* interface, RT64::RenderDevice* device) {
     Rml::SetRenderInterface(state->render_interface.get_rml_interface());
     install_event_handlers(*state);
     if (!Rml::Initialise()) {
-        LAMBO_LOG("ui", "RmlUi initialisation failed\n");
+        LAMBO_LOG_ERROR("ui", "RmlUi initialisation failed\n");
         return;
     }
     Rml::Factory::RegisterEventListenerInstancer(&state->event_listener_instancer);
@@ -427,7 +427,7 @@ void init_hook(RT64::RenderInterface* interface, RT64::RenderDevice* device) {
     SDL_GetWindowSizeInPixels(g_window, &width, &height);
     state->context = Rml::CreateContext("lamborghini", {width, height});
     if (state->context == nullptr) {
-        LAMBO_LOG("ui", "RmlUi context creation failed\n");
+        LAMBO_LOG_ERROR("ui", "RmlUi context creation failed\n");
         Rml::Shutdown();
         return;
     }
@@ -443,7 +443,7 @@ void init_hook(RT64::RenderInterface* interface, RT64::RenderDevice* device) {
         } else if (std::filesystem::exists(fallback_path)) {
             use_path = &fallback_path;
         } else {
-            LAMBO_LOG("ui", "font %s not found (configured=%s, fallback=%s)\n",
+            LAMBO_LOG_WARN("ui", "font %s not found (configured=%s, fallback=%s)\n",
                 filename, configured_path.string().c_str(), fallback_path.string().c_str());
             return;
         }
@@ -453,13 +453,13 @@ void init_hook(RT64::RenderInterface* interface, RT64::RenderDevice* device) {
         const auto& data = state->font_data.back();
         const bool ok = !data.empty() && Rml::LoadFontFace(
             data, "Lato", Rml::Style::FontStyle::Normal, weight, false);
-        LAMBO_LOG("ui", "font %s: %s (path=%s)\n",
+        LAMBO_LOG_INFO("ui", "font %s: %s (path=%s)\n",
             filename, ok ? "loaded" : "FAILED", use_path->string().c_str());
     };
     load_font("LatoLatin-Regular.ttf", Rml::Style::FontWeight::Normal);
     load_font("LatoLatin-Bold.ttf", Rml::Style::FontWeight::Bold);
     g_state = std::move(state);
-    LAMBO_LOG("ui", "RmlUi render hooks initialised\n");
+    LAMBO_LOG_INFO("ui", "RmlUi render hooks initialised\n");
 }
 
 std::optional<lambo::ui::NavigationKey> navigation_key_from_button(uint8_t button) {

--- a/tests/test_lambo_log.cpp
+++ b/tests/test_lambo_log.cpp
@@ -42,6 +42,16 @@ int main() {
                "invalid log level reports a useful error");
     }
 
+    {
+        char a0[] = "game";
+        char a1[] = "--log-level=bogus";
+        char a2[] = "--console";
+        char* args[] = {a0, a1, a2};
+        expect(!lambo_log_parse_args(3, args), "invalid log level remains an error");
+        expect(lambo_log_console_requested(),
+               "console switch is still honored when another switch is invalid");
+    }
+
     const std::filesystem::path directory =
         std::filesystem::temp_directory_path() / "lambo-log-test";
     std::error_code ec;
@@ -73,6 +83,8 @@ int main() {
            "enabled messages include level and tag");
 
     input.close();
+    lambo_log_shutdown();
+    expect(lambo_log_initialize(), "logger can be initialized again after shutdown");
     lambo_log_shutdown();
     clear_env("LAMBO_LOG_DIR");
     std::filesystem::remove_all(directory, ec);

--- a/tests/test_lambo_log.cpp
+++ b/tests/test_lambo_log.cpp
@@ -1,0 +1,80 @@
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "lambo_log.h"
+
+namespace {
+void set_env(const char* name, const std::string& value) {
+#if defined(_WIN32)
+    _putenv_s(name, value.c_str());
+#else
+    setenv(name, value.c_str(), 1);
+#endif
+}
+
+void clear_env(const char* name) {
+#if defined(_WIN32)
+    _putenv_s(name, "");
+#else
+    unsetenv(name);
+#endif
+}
+}
+
+int main() {
+    int failures = 0;
+    auto expect = [&](bool condition, const char* message) {
+        if (!condition) {
+            std::fprintf(stderr, "FAIL: %s\n", message);
+            ++failures;
+        }
+    };
+
+    {
+        char a0[] = "game";
+        char a1[] = "--log-level=bogus";
+        char* args[] = {a0, a1};
+        expect(!lambo_log_parse_args(2, args), "invalid log level is rejected");
+        expect(std::string(lambo_log_last_error()).find("must be") != std::string::npos,
+               "invalid log level reports a useful error");
+    }
+
+    const std::filesystem::path directory =
+        std::filesystem::temp_directory_path() / "lambo-log-test";
+    std::error_code ec;
+    std::filesystem::remove_all(directory, ec);
+    set_env("LAMBO_LOG_DIR", directory.string());
+
+    char a0[] = "game";
+    char a1[] = "--verbose";
+    char a2[] = "--log-level=error";
+    char* args[] = {a0, a1, a2};
+    expect(lambo_log_parse_args(3, args), "valid log arguments are accepted");
+    expect(lambo_log_level() == LAMBO_LEVEL_ERROR,
+           "last log level argument wins deterministically");
+    expect(!lambo_log_would_emit(LAMBO_LEVEL_WARN), "error threshold filters warnings");
+    expect(lambo_log_would_emit(LAMBO_LEVEL_ERROR), "error threshold keeps errors");
+    expect(lambo_log_initialize(), "logger creates the session file");
+    expect(std::string(lambo_log_path()).find("lamborghini-") != std::string::npos,
+           "logger exposes the session file path");
+
+    lambo_log_write(LAMBO_LEVEL_WARN, "test", "hidden warning\n");
+    lambo_log_write(LAMBO_LEVEL_ERROR, "test", "visible error %d\n", 7);
+    std::ifstream input(lambo_log_path());
+    std::stringstream contents;
+    contents << input.rdbuf();
+    const std::string text = contents.str();
+    expect(text.find("hidden warning") == std::string::npos,
+           "filtered messages do not reach the file");
+    expect(text.find("[error] [test] visible error 7") != std::string::npos,
+           "enabled messages include level and tag");
+
+    input.close();
+    lambo_log_shutdown();
+    clear_env("LAMBO_LOG_DIR");
+    std::filesystem::remove_all(directory, ec);
+    return failures == 0 ? 0 : 1;
+}

--- a/tools/emu_instrumentation/probe_analog_brake.py
+++ b/tools/emu_instrumentation/probe_analog_brake.py
@@ -56,7 +56,7 @@ def run_sample(executable: Path, value: float | None) -> tuple[float, float]:
     else:
         environment["LAMBO_ANALOG_BRAKE"] = f"{value:.6f}"
     completed = subprocess.run(
-        [str(executable), "--lambo-debug"],
+        [str(executable), "--console", "--lambo-debug"],
         cwd=REPO,
         env=environment,
         text=True,
@@ -107,7 +107,7 @@ def run_menu_smoke(executable: Path) -> tuple[tuple[int, int], tuple[int, int]]:
     environment.pop("LAMBO_WARP", None)
     environment.pop("LAMBO_MODERN_INPUT", None)
     completed = subprocess.run(
-        [str(executable), "--lambo-debug"], cwd=REPO, env=environment,
+        [str(executable), "--console", "--lambo-debug"], cwd=REPO, env=environment,
         text=True, encoding="utf-8", errors="replace", stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT, timeout=90, check=False,
     )

--- a/tools/emu_instrumentation/probe_analog_throttle.py
+++ b/tools/emu_instrumentation/probe_analog_throttle.py
@@ -46,7 +46,7 @@ def run_sample(executable: Path, value: float | None, digital_a: bool = False) -
     else:
         environment.pop("LAMBO_MODERN_INPUT", None)
     completed = subprocess.run(
-        [str(executable), "--lambo-debug"],
+        [str(executable), "--console", "--lambo-debug"],
         cwd=REPO,
         env=environment,
         text=True,
@@ -93,7 +93,7 @@ def run_menu_smoke(executable: Path) -> tuple[tuple[int, int], tuple[int, int]]:
     environment.pop("LAMBO_WARP", None)
     environment.pop("LAMBO_MODERN_INPUT", None)
     completed = subprocess.run(
-        [str(executable), "--lambo-debug"], cwd=REPO, env=environment,
+        [str(executable), "--console", "--lambo-debug"], cwd=REPO, env=environment,
         text=True, encoding="utf-8", errors="replace", stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT, timeout=90, check=False,
     )


### PR DESCRIPTION
<!--
Replace this header with a 1-3 sentence summary of what the change does.
-->

## Why?

Closes # none - no linked issue was supplied

Make Windows launches quiet by default while preserving useful diagnostics for
support. The game is built for the GUI subsystem, `--console` is opt-in,
logging supports severity thresholds and per-session files, and crash reports
have a durable destination. This update also fixes the review regressions in
CLI parsing, SDL startup, path resolution, console attachment, lifecycle, and
log performance.

## How was it verified?

- [x] Built clean with `build.ps1` (Windows) - recompiler generation, full executable link, and RDRAM regression
- [x] Booted smoke-tested: attract -> title -> menu -> race (Windows SDL capped launches with and without `--console`, plus headless A-confirm menu smoke reaching state 8)
- [x] Logger parser/filter/file test passed with the MinGW C++ toolchain
- [x] Python analog instrumentation scripts compile
- [ ] Full CMake/CTest run - targeted logger, config, and Windows RDRAM tests passed; unrelated test binaries were not built
- [ ] If visual: screenshot or short clip attached / linked below
- [ ] If config/schema: defaults preserved when fields absent in `graphics.json`
- [ ] If new dep patch: mirrored in both `build.sh` AND `build.ps1` AND CI (`build-release.yml`)
- [ ] If new hook into recompiled code: also mirrored in `scripts/gen_syms_toml.py` (the `PATCH_BLOCKS`-stale trap)
- [x] No comments that explain what the code does (comments explain why)
- [x] No generated-with-agent footer

## Screenshots / video

Not applicable.

## Risk / rollback

The main risk is Windows entrypoint/subsystem integration; revert the two
commits introduced by this PR together to restore the pre-change
console/logger behavior.
