### PR TITLE
fix(no-lod): preserve circuit 6 camera PVS occlusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,15 @@ if(BUILD_TESTING)
     )
     add_test(NAME lambo_camera_projection_policy COMMAND lambo_camera_projection_tests)
 
+    add_executable(lambo_no_lod_policy_tests
+        tests/test_no_lod_policy.cpp
+        src/lambo_no_lod_policy.cpp
+    )
+    target_include_directories(lambo_no_lod_policy_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    add_test(NAME lambo_no_lod_policy COMMAND lambo_no_lod_policy_tests)
+
     add_executable(lambo_rt64_angular_velocity_tests
         tests/test_rt64_angular_velocity.cpp
         lib/rt64/src/hle/rt64_rigid_body.cpp
@@ -502,6 +511,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/lambo_fog_widescreen.cpp  # issue #83: widen dense 3P/4P fog to the 1P window/colour (DL rewrite, players>=3)
         src/lambo_sky_widescreen.cpp  # issue #84: draw the 1P/2P sky panorama in 3P/4P (patches.hook branch guard)
         src/lambo_no_lod.cpp   # issues #87/#91: emit the per-segment scenery layer in 2P-4P like 1P (patches.hook branch guards)
+        src/lambo_no_lod_policy.cpp # measured exceptions for synthesized PVS extras
         src/lambo_camera.cpp   # sense of speed: chase-camera distance/height + FOV delta float-bit shims for the hooks
         src/lambo_gpu_advisory.cpp  # issue #109: outdated-Intel-driver detection + user-facing fix advisory
         src/lambo_warp.c       # issue #12: developer warp menu (F1-F6 / LAMBO_WARP race-track warp)

--- a/docs/no_lod_audit.md
+++ b/docs/no_lod_audit.md
@@ -434,3 +434,24 @@ extraction script preserved in the session scratchpad. ROM scans were byte-patte
 searches over the .z64. Per-mode facts cite the #83/#84 measurement sessions
 (2026-07-09/10); nothing in this report rests on unverified session notes except where
 marked "probe needed".*
+
+## 13. Addendum (2026-09-03): circuit 6 synthesized-wall occlusion
+
+The full-track PVS synthesis on circuit 6 (index 5) exposed a canyon wall across
+the upper road at camera segment 2. The authored row is
+`[3,4,5,-1,1,0,-1,11,-1,-1]`; segment 55 is therefore not visible from that
+camera in the ROM path, but the synthesized extras previously appended it.
+
+A settled savestate frame-DL bisection first separated road (`record+0x4`), wall
+(`+0x8`), and far-scenery (`+0xC`) targets, then identified one occluded segment:
+circuit index 5, camera segment 2, segment 55. Replacing only that root `G_DL`
+with `G_SPNOOP` removed the obstruction; the final row gate produces the
+identical framebuffer hash while omitting segment 55 from synthesized extras.
+The wall DL `0x802E7BE0` is diagnostic evidence from that bisection, not a
+runtime identity check.
+
+`src/lambo_no_lod_policy.cpp` keeps that segment out of camera segment 2's
+synthesized extras only. Other camera rows are unchanged, and if an authored row
+explicitly names segment 55, the stock-prefix pass still emits it normally. The
+row builder checks only the existing road-pointer renderability field
+(`record+0x4`); wall and far-scenery pointers are not read by this exception.

--- a/src/lambo_no_lod.cpp
+++ b/src/lambo_no_lod.cpp
@@ -17,6 +17,7 @@
 #include "recomp.h"
 
 #include "lambo_config.h"
+#include "lambo_no_lod_policy.h"
 
 extern "C" unsigned long long lambo_camera_view_cone_cos_bits();
 
@@ -124,6 +125,17 @@ bool valid_guest_ptr(int32_t p) {
     return u >= 0x80000000u && u < 0x80800000u;
 }
 
+struct SegmentRecordView {
+    uint8_t* rdram;
+    gpr records;
+};
+
+bool segment_is_renderable(int segment, const void* context) {
+    const auto& view = *static_cast<const SegmentRecordView*>(context);
+    uint8_t* rdram = view.rdram;
+    return valid_guest_ptr(MEM_W(segment * 64 + 0x4, view.records));
+}
+
 // Rebuild the synthesized row for the viewport walk that is starting. The segment
 // count is not stored anywhere by the game -- it is (header+0x8 - header+0x4) / 20,
 // the size of the PVS block itself (verified exact on circuit 5: 1100/20 = 55 rows,
@@ -152,22 +164,16 @@ void build_synth_row(uint8_t* rdram) {
     int cam = MEM_H(0, kCamSegAddr);
     if (cam < 0 || cam >= n) return;
 
-    bool listed[256] = {};
-    int out = 0;
-    listed[cam] = true;  // the camera's own segment is drawn by its dedicated path
+    int16_t authored[10];
     for (int i = 0; i < 10; i++) {  // authored row first: stock drawn-list prefix
-        int e = MEM_H(cam * 20 + i * 2, (gpr)pvs);
-        if (e < 0 || e >= n || listed[e]) continue;
-        listed[e] = true;
-        s_synth_row[out++] = (int16_t)e;
+        authored[i] = static_cast<int16_t>(MEM_H(cam * 20 + i * 2, (gpr)pvs));
     }
-    for (int s = 0; s < n; s++) {
-        if (listed[s]) continue;
-        // Skip records with no road sub-DL (defends against sentinel/padding rows).
-        if (!valid_guest_ptr(MEM_W(s * 64 + 0x4, (gpr)recs))) continue;
-        s_synth_row[out++] = (int16_t)s;
-    }
-    s_synth_n = out;
+    SegmentRecordView records{rdram, (gpr)recs};
+    // The pure row policy keeps authored membership ahead of exclusions: a
+    // PVS-gated segment is withheld only when it would be a synthesized extra.
+    s_synth_n = lambo::no_lod::build_synthesized_row(
+        cur_circuit, n, cam, std::span<const int16_t>(authored),
+        &segment_is_renderable, &records, std::span<int16_t>(s_synth_row));
 }
 
 }  // namespace

--- a/src/lambo_no_lod_policy.cpp
+++ b/src/lambo_no_lod_policy.cpp
@@ -1,0 +1,79 @@
+#include "lambo_no_lod_policy.h"
+
+namespace {
+
+struct SynthesizedExtraExclusion {
+    int circuit;
+    int camera_segment;
+    int segment;
+};
+
+// These are measured exceptions to the optional full-track PVS synthesis. Keep
+// the table in this implementation file so the public seam stays about row
+// construction rather than ROM asset data.
+constexpr SynthesizedExtraExclusion kSynthesizedExtraExclusions[] = {
+    // Circuit 6 (index 5), segment 55 is occluded from camera segment 2 by the
+    // canyon wall identified in the 2026-09-03 frame-DL bisection.
+    {5, 2, 55},
+};
+
+constexpr int kMaxSegments = 256;
+constexpr std::size_t kAuthoredRowCapacity = 10;
+
+}  // namespace
+
+namespace lambo::no_lod {
+
+bool has_synthesized_extra_exclusions(int circuit, int camera_segment) {
+    for (const SynthesizedExtraExclusion& exclusion : kSynthesizedExtraExclusions) {
+        if (exclusion.circuit == circuit && exclusion.camera_segment == camera_segment) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool should_exclude_synthesized_extra(int circuit, int camera_segment, int segment) {
+    for (const SynthesizedExtraExclusion& exclusion : kSynthesizedExtraExclusions) {
+        if (exclusion.circuit == circuit &&
+            exclusion.camera_segment == camera_segment &&
+            exclusion.segment == segment) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int build_synthesized_row(int circuit, int segment_count, int camera_segment,
+                          std::span<const int16_t> authored,
+                          SegmentRenderable is_renderable, const void* renderable_context,
+                          std::span<int16_t> output) {
+    if (segment_count < 2 || segment_count > kMaxSegments ||
+        camera_segment < 0 || camera_segment >= segment_count ||
+        authored.size() != kAuthoredRowCapacity ||
+        output.size() < static_cast<std::size_t>(segment_count) ||
+        is_renderable == nullptr) {
+        return -1;
+    }
+
+    bool listed[kMaxSegments] = {};
+    int out = 0;
+    listed[camera_segment] = true;
+    for (int16_t segment : authored) {
+        if (segment < 0 || segment >= segment_count || listed[segment]) continue;
+        listed[segment] = true;
+        output[out++] = segment;
+    }
+
+    const bool has_exclusions = has_synthesized_extra_exclusions(circuit, camera_segment);
+    for (int segment = 0; segment < segment_count; ++segment) {
+        if (listed[segment] || !is_renderable(segment, renderable_context)) continue;
+        if (has_exclusions && should_exclude_synthesized_extra(circuit, camera_segment, segment)) {
+            continue;
+        }
+        output[out++] = static_cast<int16_t>(segment);
+    }
+    return out;
+}
+
+}  // namespace lambo::no_lod

--- a/src/lambo_no_lod_policy.h
+++ b/src/lambo_no_lod_policy.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+namespace lambo::no_lod {
+
+using SegmentRenderable = bool (*)(int segment, const void* context);
+
+bool has_synthesized_extra_exclusions(int circuit, int camera_segment);
+bool should_exclude_synthesized_extra(int circuit, int camera_segment, int segment);
+
+int build_synthesized_row(int circuit, int segment_count, int camera_segment,
+                          std::span<const int16_t> authored,
+                          SegmentRenderable is_renderable, const void* renderable_context,
+                          std::span<int16_t> output);
+
+}  // namespace lambo::no_lod

--- a/tests/test_no_lod_policy.cpp
+++ b/tests/test_no_lod_policy.cpp
@@ -1,0 +1,116 @@
+#include <array>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <span>
+
+#include "lambo_no_lod_policy.h"
+
+namespace {
+
+void expect(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+struct Renderability {
+    std::array<bool, 256> values{};
+};
+
+bool renderable_from_table(int segment, const void* context) {
+    const auto& table = *static_cast<const Renderability*>(context);
+    return table.values[segment];
+}
+
+int build_row(int circuit, int segment_count, int camera_segment,
+              std::span<const int16_t> authored, const Renderability& renderability,
+              std::span<int16_t> output) {
+    return lambo::no_lod::build_synthesized_row(
+        circuit, segment_count, camera_segment, authored,
+        &renderable_from_table, &renderability, output);
+}
+
+bool contains(std::span<const int16_t> row, int16_t segment) {
+    for (int16_t value : row) {
+        if (value == segment) return true;
+    }
+    return false;
+}
+
+bool has_duplicate(std::span<const int16_t> row) {
+    for (std::size_t i = 0; i < row.size(); ++i) {
+        for (std::size_t j = i + 1; j < row.size(); ++j) {
+            if (row[i] == row[j]) return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+int main() {
+    using lambo::no_lod::has_synthesized_extra_exclusions;
+    using lambo::no_lod::should_exclude_synthesized_extra;
+
+    expect(has_synthesized_extra_exclusions(5, 2),
+           "circuit 6 camera segment 2 has a measured synthesized-extra exception");
+    expect(!has_synthesized_extra_exclusions(5, 3),
+           "other circuit 6 cameras can short-circuit the policy scan");
+    expect(!has_synthesized_extra_exclusions(4, 2),
+           "circuits without exceptions can short-circuit the policy scan");
+    expect(should_exclude_synthesized_extra(5, 2, 55),
+           "the measured circuit 6 camera-2 segment-55 exception is active");
+    expect(!should_exclude_synthesized_extra(5, 3, 55),
+           "an unverified camera segment must not inherit the exception");
+    expect(!should_exclude_synthesized_extra(4, 2, 55),
+           "an adjacent circuit must not inherit the exception");
+    expect(!should_exclude_synthesized_extra(5, 2, 54),
+           "an adjacent segment must not inherit the exception");
+
+    Renderability renderability;
+    renderability.values.fill(true);
+    renderability.values[6] = false;
+    std::array<int16_t, 57> output{};
+    const std::array<int16_t, 10> authored = {3, 4, 3, -1, 1, 0, -1, 11, -1, -1};
+    int count = build_row(5, 57, 2, authored, renderability, output);
+    expect(count > 0, "a valid row produces entries");
+    expect(!contains(std::span<const int16_t>(output.data(), count), 55),
+           "segment 55 is withheld when it is only a synthesized extra");
+    expect(!contains(std::span<const int16_t>(output.data(), count), 6),
+           "non-renderable segment records are skipped");
+    expect(contains(std::span<const int16_t>(output.data(), count), 3),
+           "authored entries are preserved");
+    expect(!has_duplicate(std::span<const int16_t>(output.data(), count)),
+           "duplicate authored entries are emitted only once");
+
+    count = build_row(5, 57, 3, authored, renderability, output);
+    expect(contains(std::span<const int16_t>(output.data(), count), 55),
+           "an unverified camera retains segment 55 as a synthesized extra");
+
+    const std::array<int16_t, 10> authored_segment_55 = {55, 3, 4, 5, -1, 1, 0, 11, -1, -1};
+    count = build_row(5, 57, 2, authored_segment_55, renderability, output);
+    expect(count > 0 && output[0] == 55,
+           "authored membership takes precedence over synthesized-extra exclusions");
+
+    const std::array<int16_t, 10> valid_authored = {3, 4, 5, -1, 1, 0, -1, 11, -1, -1};
+    const std::array<int16_t, 9> short_authored = {3, 4, 5, -1, 1, 0, -1, 11, -1};
+    std::array<int16_t, 1> undersized_output{};
+    expect(build_row(5, 1, 0, valid_authored, renderability, output) == -1,
+           "segment counts below two are rejected");
+    expect(build_row(5, 257, 0, valid_authored, renderability, output) == -1,
+           "segment counts above the row limit are rejected");
+    expect(build_row(5, 57, -1, valid_authored, renderability, output) == -1,
+           "negative camera segments are rejected");
+    expect(build_row(5, 57, 57, valid_authored, renderability, output) == -1,
+           "camera segments outside the row are rejected");
+    expect(build_row(5, 57, 2, short_authored, renderability, output) == -1,
+           "malformed authored rows are rejected");
+    expect(build_row(5, 57, 2, valid_authored, renderability, undersized_output) == -1,
+           "undersized output buffers are rejected");
+    expect(lambo::no_lod::build_synthesized_row(
+               5, 57, 2, std::span<const int16_t>(valid_authored), nullptr,
+               nullptr, std::span<int16_t>(output)) == -1,
+           "a missing renderability adapter is rejected");
+}


### PR DESCRIPTION
Keeps the measured circuit 6 occluded segment out of synthesized full-track PVS extras only for camera segment 2. The exception data now lives in a dedicated implementation file; row construction uses spans and a renderability adapter, preserving authored PVS membership without reading wall or far-scenery display-list pointers.

## Why?

Closes #181

Refs #87

## How was it verified?

- [x] Built clean with `build.sh` (Linux) / `build.ps1` (Windows) - no manual cmake incantation
- [x] Booted smoke-tested: attract -> title -> menu -> race
- [ ] If visual: screenshot or short clip attached / linked below
- [ ] If config/schema: defaults preserved when fields absent in `graphics.json`
- [ ] If new dep patch: mirrored in both `build.sh` AND `build.ps1` AND CI (`build-release.yml`)
- [ ] If new hook into recompiled code: also mirrored in `scripts/gen_syms_toml.py` (the `PATCH_BLOCKS`-stale trap)
- [x] No comments that explain *what* the code does (only *why* - see `CLAUDE.md`)
- [x] No "Generated with Claude Code" footer in commits or PR description

Additional verification:

- `build.ps1` completed recompiler regeneration, executable linking, and the Windows RDRAM reservation test.
- `lambo_no_lod_policy`, `lambo_config_live_updates`, and `lambo_ui_settings_bindings` pass (3/3).
- The headless A-confirm menu smoke observed the race transition at state 8.
- A 320x240 software-renderer capture reached race state; the settled frame dump contains no `0x802E7BE0` wall display-list reference.

## Screenshots / video

No external attachment. The automated capture was used as a diagnostic assertion; its generated files were not committed.

## Risk / rollback

Risk is limited to the measured circuit index 5, camera segment 2, segment 55 exception; revert commit `aa52144` to restore the prior behavior.
