### PR TITLE
feat(harness): add deterministic game replay runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ dma_validation/
 *.log
 *.stackdump
 scratch/
+artifacts/
 # gdb batch backtrace/logging dumps from native port debugging
 gdb_bt*.txt
 # framebuffer / display-list render captures from the port

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,12 @@ Same approach as [Snowboard Kids 2 Recompiled](https://github.com/cdlewis/snowbo
 ## Test discipline
 
 Gate on what changed. Recompilation-config / runtime-glue changes → build + boot smoke.
+For an autonomous race/render smoke after building, run
+`python tools/run_game_scenario.py scenarios/harness-smoke.json`; it isolates config/Pak
+artifacts and verifies the requested track actually loaded, 30 Hz guest input consumption,
+vehicle motion, framebuffer swaps, and a complete BMP. See `docs/automation-harness.md`.
+Replay EOF proves the recorded controls ran, not that a lap completed. Keep neutral pre-roll
+and use the same warp or settled save-state when recording/replaying a regression fixture.
 
 ## Tracker
 Use Github Issues

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ if(BUILD_TESTING)
         src/libultra_stubs.c
         src/lambo_pak_io.c
         src/lambo_pak_storage.cpp
+        src/lambo_log.cpp
     )
     target_include_directories(lambo_controller_pak_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
@@ -127,6 +128,7 @@ if(BUILD_TESTING)
         tests/test_pak_storage.cpp
         src/lambo_pak_storage.cpp
         src/lambo_pak_io.c
+        src/lambo_log.cpp
     )
     target_include_directories(lambo_controller_pak_storage_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
@@ -170,6 +172,7 @@ if(BUILD_TESTING)
     add_executable(lambo_input_replay_tests
         tests/test_lambo_replay.cpp
         src/lambo_replay.cpp
+        src/lambo_file.cpp
     )
     target_include_directories(lambo_input_replay_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
@@ -182,6 +185,7 @@ if(BUILD_TESTING)
         src/controls/lambo_controls.cpp
         src/lambo_config.cpp
         src/lambo_log.cpp
+        src/lambo_file.cpp
     )
     target_include_directories(lambo_controls_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
@@ -195,6 +199,7 @@ if(BUILD_TESTING)
         src/controls/lambo_controls.cpp
         src/lambo_config.cpp
         src/lambo_log.cpp
+        src/lambo_file.cpp
     )
     target_include_directories(lambo_controls_capture_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
@@ -209,6 +214,7 @@ if(BUILD_TESTING)
         src/controls/lambo_controls.cpp
         src/lambo_config.cpp
         src/lambo_log.cpp
+        src/lambo_file.cpp
     )
     target_include_directories(lambo_ui_controls_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
@@ -220,21 +226,25 @@ if(BUILD_TESTING)
     add_executable(lambo_analog_throttle_tests
         tests/test_analog_throttle.cpp
         src/lambo_analog_throttle.cpp
+        src/lambo_log.cpp
     )
     target_include_directories(lambo_analog_throttle_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${N64MR}/N64Recomp/include
     )
+    target_link_libraries(lambo_analog_throttle_tests PRIVATE Threads::Threads)
     add_test(NAME lambo_analog_throttle_bridge COMMAND lambo_analog_throttle_tests)
 
     add_executable(lambo_analog_brake_tests
         tests/test_analog_brake.cpp
         src/lambo_analog_brake.cpp
+        src/lambo_log.cpp
     )
     target_include_directories(lambo_analog_brake_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${N64MR}/N64Recomp/include
     )
+    target_link_libraries(lambo_analog_brake_tests PRIVATE Threads::Threads)
     add_test(NAME lambo_analog_brake_bridge COMMAND lambo_analog_brake_tests)
 
     add_executable(lambo_ui_input_tests
@@ -436,6 +446,7 @@ if(BUILD_TESTING)
         src/controls/lambo_controls_sdl.cpp
         src/lambo_config.cpp
         src/lambo_log.cpp
+        src/lambo_file.cpp
     )
     target_include_directories(lambo_controls_sdl_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
@@ -505,6 +516,8 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/lambo_input_gate.cpp # controller capture/neutral-release barrier (issue #126)
         src/lambo_replay.cpp    # versioned effective-input trace parser/recorder
         src/lambo_replay_runtime.cpp # game-dispatch-clock record/replay harness
+        src/lambo_harness_report.cpp
+        src/lambo_file.cpp
         src/lambo_analog_throttle.cpp # issue #128: atomic native-port throttle bridge + race hook
         src/lambo_analog_brake.cpp    # issue #152: atomic native-port brake bridge + race hook
         src/controls/lambo_controls.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,8 +540,8 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/lambo_menu.cpp     # lightweight native Win32 menu bar; live config actions + persistence
         src/lambo_startup.cpp  # runtime-ready -> Play startup state machine (issue #126)
         src/lambo_input_gate.cpp # controller capture/neutral-release barrier (issue #126)
-        src/lambo_replay.cpp    # versioned effective-input trace parser/recorder
-        src/lambo_replay_runtime.cpp # game-dispatch-clock record/replay harness
+        src/lambo_replay.cpp
+        src/lambo_replay_runtime.cpp
         src/lambo_harness_report.cpp
         src/lambo_file.cpp
         src/lambo_analog_throttle.cpp # issue #128: atomic native-port throttle bridge + race hook

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,16 @@ if(BUILD_TESTING)
     )
     add_test(NAME lambo_input_capture_gate COMMAND lambo_input_gate_tests)
 
+    add_executable(lambo_input_replay_tests
+        tests/test_lambo_replay.cpp
+        src/lambo_replay.cpp
+    )
+    target_include_directories(lambo_input_replay_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${N64MR}/thirdparty
+    )
+    add_test(NAME lambo_input_record_replay COMMAND lambo_input_replay_tests)
+
     add_executable(lambo_controls_tests
         tests/test_controls.cpp
         src/controls/lambo_controls.cpp
@@ -259,6 +269,10 @@ if(BUILD_TESTING)
             COMMAND ${LAMBO_PYTHON_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_quit_path.py
                 ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+        add_test(NAME lambo_game_scenario_runner
+            COMMAND ${LAMBO_PYTHON_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_game_scenario.py
         )
     else()
         message(WARNING "Python not found; Python-based tests will not be registered")
@@ -489,6 +503,8 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/lambo_menu.cpp     # lightweight native Win32 menu bar; live config actions + persistence
         src/lambo_startup.cpp  # runtime-ready -> Play startup state machine (issue #126)
         src/lambo_input_gate.cpp # controller capture/neutral-release barrier (issue #126)
+        src/lambo_replay.cpp    # versioned effective-input trace parser/recorder
+        src/lambo_replay_runtime.cpp # game-dispatch-clock record/replay harness
         src/lambo_analog_throttle.cpp # issue #128: atomic native-port throttle bridge + race hook
         src/lambo_analog_brake.cpp    # issue #152: atomic native-port brake bridge + race hook
         src/controls/lambo_controls.cpp

--- a/README.md
+++ b/README.md
@@ -151,6 +151,24 @@ only the default warning/error output, while `--verbose` still records a file
 when the game is launched by double-click. The older `--lambo-debug` flag remains
 accepted as an alias for `--verbose`.
 
+## Automated game harness
+
+The port can record the final N64 input seen by the game and replay it on the
+30 Hz game-dispatch clock, including analog throttle and brake. Combined with
+the developer warp, headless renderer, bounded runs, and machine-readable result
+files, this lets an automated agent reproduce a drive and collect evidence with
+no window focus or controller attached.
+
+Run the checked-in end-to-end smoke scenario with:
+
+```sh
+python tools/run_game_scenario.py scenarios/harness-smoke.json
+```
+
+See **[docs/automation-harness.md](./docs/automation-harness.md)** for recording
+a lap, replaying from a settled save-state, the trace format, scenario assertions,
+and the trade-offs between open-loop replay and future closed-loop driving.
+
 ## Building
 
 See **[BUILDING.md](./BUILDING.md)**. In brief: clone with submodules, supply your ROM, run the recompile step, then configure and build with CMake.

--- a/docs/automation-harness.md
+++ b/docs/automation-harness.md
@@ -1,0 +1,187 @@
+# Automated game harness
+
+The harness makes a real game run repeatable and bounded. It starts through the
+normal race loader (or a local save-state), applies effective N64 input on game
+updates, captures frames, and emits a JSON result that a script can assert on.
+It does not replace physics, teleport the car along a route, or invent a second
+simulation.
+
+## Why input replay is the first driver
+
+The repo already had four useful pieces: `LAMBO_WARP`, RDRAM save/load, the
+headless software renderer, and fixed held/pulsed input. The alternatives were:
+
+- Reuse the game's demo or opponent AI. This is the best prospective closed-loop
+  driver, but the player/AI slot handoff and lap semantics have not yet been
+  verified. Enabling it by guessed flags could test a different code path from a
+  human-controlled race.
+- Steer from screenshots or synthetic OS key events. That is wall-clock and
+  focus dependent, Windows-specific in the existing helper, and too slow for a
+  reliable 30 Hz feedback loop.
+- Keep a save-state atlas. This is excellent for settled visual bug locations,
+  but it neither drives through gameplay nor captures native thread state.
+- Record the final guest-visible input. This exercises the normal controller,
+  vehicle, physics, race, and rendering paths; works headlessly; and is small
+  enough to ship and inspect. That is the implemented baseline.
+
+Open-loop input can drift after intentional physics changes or collisions. Record
+time-trial runs where possible. If that becomes limiting, the next step is to
+measure the original AI/demo seam or add feedback against verified vehicle pose
+and waypoint fields—not to hide divergence with teleports.
+
+## Run a scenario
+
+After building `lamborghini_modern`, run:
+
+```sh
+python tools/run_game_scenario.py scenarios/harness-smoke.json
+```
+
+Use `--exe PATH` for a non-default build and `--artifacts-dir DIR` to choose the
+artifact parent. Each invocation gets a unique directory containing the original
+scenario, a rerunnable `scenario-resolved.json`, copied replay/save fixtures with
+SHA-256 hashes, the managed environment, stdout/stderr, the native
+`harness-result.json`, and the runner's final `runner-result.json`. A wall-clock
+timeout is only a deadlock backstop; input timing never uses it.
+
+The smoke trace holds A after the starting countdown and then releases it. It
+proves warp, game-clock replay, vehicle motion, rendering, clean EOF, and result
+assertions; it is deliberately not presented as a completed lap.
+`scenarios/harness-one-frame-a.json` is a shorter timing regression proving that
+even a one-frame A press reaches the guest pad and a full dispatcher update.
+
+A scenario can select these fields:
+
+```json
+{
+  "schema": 1,
+  "name": "circuit-1-lap",
+  "headless": true,
+  "warp": "1:1:0:1",
+  "warp_mode": 0,
+  "max_vis": 7200,
+  "input": {
+    "replay": "../recordings/circuit-1-time-trial.jsonl",
+    "start_state": 8,
+    "start_delay": 0,
+    "exit_on_end": true
+  },
+  "capture": {
+    "path": "circuit-1-last.bmp",
+    "state": 8,
+    "every": 300
+  },
+  "expect": {
+    "max_state_at_least": 8,
+    "replay_complete": true,
+    "min_swaps": 60,
+    "min_abs_player_speed": 10,
+    "capture": true
+  }
+}
+```
+
+`warp` uses the existing `circuit:laps:car:players` syntax. `warp_mode: 0` is
+time trial; omit it for the normal single-race mode (`2`). Relative replay and
+save-state paths resolve beside the scenario file. Capture paths are always
+relative to that invocation's unique artifact directory, so concurrent runs
+cannot consume or overwrite each other's evidence. The runner clears inherited
+input/warp/state variables and redirects graphics config and Controller Pak
+storage into the same isolated directory. It also runs from copied replay/save
+fixtures, so changing the source file during a run cannot change its evidence.
+The strict scenario wrapper currently accepts only runtime-verified car `0`;
+measure another car-select value before widening that validation.
+The developer warp also accepts 1–2 laps for short tests even though the normal
+single-race menu starts at 3; this is an explicit harness extension, not a claim
+about menu options.
+
+Choose either `warp` or `state_load` as the bootstrap for a scenario. Combining
+them is rejected because the save-state hook runs after the warp hook and would
+restore the warp's guest configuration in the same update, making the requested
+track assertion ambiguous.
+
+## Record a drive or lap
+
+Launch a windowed time trial and drive it normally. PowerShell example:
+
+```powershell
+$env:LAMBO_WARP = '1:3:0:1'
+$env:LAMBO_WARP_MODE = '0'
+$env:LAMBO_INPUT_RECORD = 'recordings/circuit-1-time-trial.jsonl'
+$env:LAMBO_INPUT_START_STATE = '8'
+./build/lamborghini_modern.exe --console --verbose
+```
+
+Recording begins on the first top-level game update in state 8, so it includes
+the race countdown. Close the game after the desired finish; the trace is
+atomically published only after clean finalization. Consecutive identical input
+frames are run-length encoded. Record one trace for each initial
+track/car/mode/state combination that needs coverage.
+Keep a short neutral pre-roll (the checked-in smoke uses one) and replay from
+the same warp or settled save-state so the first button-edge history matches.
+
+To record from an exact local fixture, set `LAMBO_STATE_LOAD` instead of a warp.
+The save-state rule still applies: park and let asset
+streaming settle before saving. An `.lstate` contains only the low 8 MiB of guest
+RAM, not native thread, renderer, or audio state. Loading another state after
+playback or recording begins is therefore reported as an explicit failure rather
+than silently rewinding only half of the system.
+
+## Direct record/replay controls
+
+| Environment variable | Meaning |
+|---|---|
+| `LAMBO_INPUT_RECORD=path` | Record one effective-input trace; mutually exclusive with replay. |
+| `LAMBO_INPUT_REPLAY=path` | Replay a validated trace exclusively on controller port 0. |
+| `LAMBO_INPUT_START_STATE=n` | Arm until this top-level game state; default `8` (race). |
+| `LAMBO_INPUT_START_DELAY=n` | Wait this many game-dispatch updates after reaching the state. |
+| `LAMBO_INPUT_EXIT_ON_END=0/1` | Exit after replay EOF; default `1`. Input stays neutral at EOF. |
+| `LAMBO_HARNESS_RESULT=path` | Atomically write the machine-readable final outcome. |
+
+Scenario replay defaults to requiring EOF even when `exit_on_end` is false. Set
+`expect.replay_complete` to false explicitly for a deliberately partial run; the
+runner still requires that at least one trace frame reached a game update.
+
+Playback replaces physical, held, and pulsed port-0 sources after it starts.
+Before it starts, normal inputs still work so menus can be navigated. The UI
+capture/release barrier pauses consumption and feeds neutral input while open.
+The trace clock comes from `func_800028D0`, which runs once per game update
+(about 30 Hz), rather than the 60 Hz VI callback or a controller poll that may
+occur a variable number of times. Replay stages the decoded pad immediately
+before the ROM's own held/pressed-mask derivation. The following dispatcher
+verifies that pad, consumes it, and counts it only at the common epilogue. Thus
+even a one-frame movie cannot finish before its button reaches a game update.
+
+## Trace format
+
+Traces are strict JSON Lines. All records are validated before the first replay
+frame is exposed:
+
+```jsonl
+{"type":"header","format":"lambo-input-trace","version":1,"clock":"game-dispatch","ports":1}
+{"type":"run","frames":90,"buttons":32768,"stick_x":0,"stick_y":0,"throttle_analog":false,"throttle":0,"brake_analog":false,"brake":0}
+{"type":"end","frames":90}
+```
+
+`buttons` is the final 16-bit `OSContPad` mask; sticks are integers from -80 to
+80. Pedal values are exact normalized integers from 0 to 65535 and have an
+explicit analog-mode flag. The trailer total must equal the sum of positive run
+lengths. Unknown fields, duplicate keys, bad ranges, unsupported versions, and
+incomplete traces are rejected.
+
+## Current oracles and limits
+
+The native result reports process reason/status, VI and framebuffer-swap counts,
+top-level state, the loader's live circuit, the applied warp or save-state
+bootstrap, player-channel vehicle/speed, and replay/guest-pad progress. The
+runner verifies requested warp values against both the cursor writes and the
+track actually loaded, every consumed replay frame's guest-pad application, state 8,
+EOF, sustained swaps, nonzero vehicle speed, and structurally complete renderer
+BMP captures (including their declared byte size).
+
+There is not yet a verified lap-counter/finish oracle. Trace EOF proves the
+recorded control sequence ran, not that a lap completed. A real lap recording is
+the right fixture for measuring the finish-line fields; only then should a lap
+assertion be added. Headless software rendering exercises display-list output,
+but RT64-specific shaders, presentation, and native UI still need an optional
+windowed visual run.

--- a/docs/automation-harness.md
+++ b/docs/automation-harness.md
@@ -40,7 +40,7 @@ python tools/run_game_scenario.py scenarios/harness-smoke.json
 Use `--exe PATH` for a non-default build and `--artifacts-dir DIR` to choose the
 artifact parent. Each invocation gets a unique directory containing the original
 scenario, a rerunnable `scenario-resolved.json`, copied replay/save fixtures with
-SHA-256 hashes, the managed environment, stdout/stderr, the native
+a small size manifest, the managed environment, stdout/stderr, the native
 `harness-result.json`, and the runner's final `runner-result.json`. A wall-clock
 timeout is only a deadlock backstop; input timing never uses it.
 
@@ -89,8 +89,8 @@ cannot consume or overwrite each other's evidence. The runner clears inherited
 input/warp/state variables and redirects graphics config and Controller Pak
 storage into the same isolated directory. It also runs from copied replay/save
 fixtures, so changing the source file during a run cannot change its evidence.
-The strict scenario wrapper currently accepts only runtime-verified car `0`;
-measure another car-select value before widening that validation.
+The scenario wrapper currently accepts only runtime-verified car `0`; measure
+another car-select value before widening that validation.
 The developer warp also accepts 1–2 laps for short tests even though the normal
 single-race menu starts at 3; this is an explicit harness extension, not a claim
 about menu options.
@@ -176,8 +176,10 @@ top-level state, the loader's live circuit, the applied warp or save-state
 bootstrap, player-channel vehicle/speed, and replay/guest-pad progress. The
 runner verifies requested warp values against both the cursor writes and the
 track actually loaded, every consumed replay frame's guest-pad application, state 8,
-EOF, sustained swaps, nonzero vehicle speed, and structurally complete renderer
-BMP captures (including their declared byte size).
+EOF, sustained swaps, nonzero vehicle speed, and a non-empty renderer capture.
+The headless renderer itself writes complete 24-bit BMPs; the runner deliberately
+keeps capture validation shallow so it remains a glue script rather than a second
+image parser.
 
 There is not yet a verified lap-counter/finish oracle. Trace EOF proves the
 recorded control sequence ran, not that a lap completed. A real lap recording is

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -553,11 +553,30 @@ text = "extern void lambo_warp_tick(uint8_t*, recomp_context*); lambo_warp_tick(
 # Issue #22 — developer save-state. Same top-level dispatcher (runs every frame in every
 # state), one instruction past the warp hook: N64Recomp rejects two hooks on the exact same
 # vram, and 0x80001CD4 is still the frame-boundary entry. Snapshots/restores rdram[0..8MiB)
-# on an F5/F9 or LAMBO_STATE_LOAD request; native in src/lambo_savestate.c.
+# on an F7/F8 or LAMBO_STATE_LOAD request; native in src/lambo_savestate.c.
 [[patches.hook]]
 func = "func_800028D0"
 before_vram = 0x80001CD4
 text = "extern void lambo_savestate_tick(uint8_t*, recomp_context*); lambo_savestate_tick(rdram, ctx);"
+
+# Deterministic input record/replay harness. The controller hook replaces/records
+# the decoded pad before the ROM derives its held/pressed masks. The following
+# dispatcher entry verifies that staged pad and freezes its analog channels; the
+# common epilogue counts it only after the 30 Hz game update has returned.
+[[patches.hook]]
+func = "func_800028D0"
+before_vram = 0x80001CD8
+text = "extern void lambo_replay_dispatch_begin(uint8_t*); lambo_replay_dispatch_begin(rdram);"
+
+[[patches.hook]]
+func = "func_800028D0"
+before_vram = 0x800024E8
+text = "extern void lambo_replay_dispatch_end(uint8_t*); lambo_replay_dispatch_end(rdram);"
+
+[[patches.hook]]
+func = "BootLoadInitialAssets"
+before_vram = 0x8000193C
+text = "extern void lambo_replay_input_tick(uint8_t*); lambo_replay_input_tick(rdram);"
 
 # Issue #128 — true analog throttle. Capture the pedal demand immediately before the
 # stock human-driver A/Z branch, then apply the selected native port's continuous target

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -559,10 +559,6 @@ func = "func_800028D0"
 before_vram = 0x80001CD4
 text = "extern void lambo_savestate_tick(uint8_t*, recomp_context*); lambo_savestate_tick(rdram, ctx);"
 
-# Deterministic input record/replay harness. The controller hook replaces/records
-# the decoded pad before the ROM derives its held/pressed masks. The following
-# dispatcher entry verifies that staged pad and freezes its analog channels; the
-# common epilogue counts it only after the 30 Hz game update has returned.
 [[patches.hook]]
 func = "func_800028D0"
 before_vram = 0x80001CD8

--- a/recordings/README.md
+++ b/recordings/README.md
@@ -1,0 +1,13 @@
+# Input recordings
+
+Files here are versioned, run-length encoded effective N64 controller traces for
+the automated game harness. See [the harness guide](../docs/automation-harness.md)
+for the format, recording command, and replay limitations.
+
+`harness-smoke.jsonl` is a synthetic mechanism test, not a driven lap. Name real
+fixtures by circuit, mode, car, and purpose so their required starting conditions
+remain obvious, for example `circuit-1-time-trial-car-0.jsonl`.
+
+`harness-one-frame-a.jsonl` is the phase-boundary regression: its sole A-button
+frame must be verified in guest RAM and pass through one complete dispatcher
+update before EOF can stop the process.

--- a/recordings/harness-one-frame-a.jsonl
+++ b/recordings/harness-one-frame-a.jsonl
@@ -1,0 +1,3 @@
+{"type":"header","format":"lambo-input-trace","version":1,"clock":"game-dispatch","ports":1}
+{"type":"run","frames":1,"buttons":32768,"stick_x":0,"stick_y":0,"throttle_analog":false,"throttle":0,"brake_analog":false,"brake":0}
+{"type":"end","frames":1}

--- a/recordings/harness-smoke.jsonl
+++ b/recordings/harness-smoke.jsonl
@@ -1,0 +1,5 @@
+{"type":"header","format":"lambo-input-trace","version":1,"clock":"game-dispatch","ports":1}
+{"type":"run","frames":120,"buttons":0,"stick_x":0,"stick_y":0,"throttle_analog":false,"throttle":0,"brake_analog":false,"brake":0}
+{"type":"run","frames":450,"buttons":32768,"stick_x":0,"stick_y":0,"throttle_analog":false,"throttle":0,"brake_analog":false,"brake":0}
+{"type":"run","frames":30,"buttons":0,"stick_x":0,"stick_y":0,"throttle_analog":false,"throttle":0,"brake_analog":false,"brake":0}
+{"type":"end","frames":600}

--- a/scenarios/harness-one-frame-a.json
+++ b/scenarios/harness-one-frame-a.json
@@ -1,0 +1,19 @@
+{
+  "schema": 1,
+  "name": "harness-one-frame-a",
+  "headless": true,
+  "warp": "1:1:0:1",
+  "warp_mode": 0,
+  "max_vis": 1200,
+  "input": {
+    "replay": "../recordings/harness-one-frame-a.jsonl",
+    "start_state": 8,
+    "start_delay": 0,
+    "exit_on_end": true
+  },
+  "expect": {
+    "max_state_at_least": 8,
+    "replay_complete": true,
+    "min_swaps": 1
+  }
+}

--- a/scenarios/harness-smoke.json
+++ b/scenarios/harness-smoke.json
@@ -1,0 +1,25 @@
+{
+  "schema": 1,
+  "name": "harness-smoke",
+  "headless": true,
+  "warp": "1:1:0:1",
+  "warp_mode": 0,
+  "max_vis": 2400,
+  "input": {
+    "replay": "../recordings/harness-smoke.jsonl",
+    "start_state": 8,
+    "start_delay": 0,
+    "exit_on_end": true
+  },
+  "capture": {
+    "path": "harness-smoke.bmp",
+    "state": 8
+  },
+  "expect": {
+    "max_state_at_least": 8,
+    "replay_complete": true,
+    "min_swaps": 60,
+    "min_abs_player_speed": 10,
+    "capture": true
+  }
+}

--- a/scripts/gen_syms_toml.py
+++ b/scripts/gen_syms_toml.py
@@ -924,6 +924,25 @@ func = "func_800028D0"
 before_vram = 0x80001CD4
 text = "extern void lambo_savestate_tick(uint8_t*, recomp_context*); lambo_savestate_tick(rdram, ctx);"
 
+# Deterministic input record/replay harness. The controller hook replaces/records
+# the decoded pad before the ROM derives its held/pressed masks. The following
+# dispatcher entry verifies that staged pad and freezes its analog channels; the
+# common epilogue counts it only after the 30 Hz game update has returned.
+[[patches.hook]]
+func = "func_800028D0"
+before_vram = 0x80001CD8
+text = "extern void lambo_replay_dispatch_begin(uint8_t*); lambo_replay_dispatch_begin(rdram);"
+
+[[patches.hook]]
+func = "func_800028D0"
+before_vram = 0x800024E8
+text = "extern void lambo_replay_dispatch_end(uint8_t*); lambo_replay_dispatch_end(rdram);"
+
+[[patches.hook]]
+func = "BootLoadInitialAssets"
+before_vram = 0x8000193C
+text = "extern void lambo_replay_input_tick(uint8_t*); lambo_replay_input_tick(rdram);"
+
 # Issue #128 — true analog throttle. Capture the pedal demand immediately before the
 # stock human-driver A/Z branch, then apply the selected native port's continuous target
 # at the common merge. The two hooks preserve the ROM's +/-10 pedal ramp, including exact

--- a/scripts/gen_syms_toml.py
+++ b/scripts/gen_syms_toml.py
@@ -924,10 +924,6 @@ func = "func_800028D0"
 before_vram = 0x80001CD4
 text = "extern void lambo_savestate_tick(uint8_t*, recomp_context*); lambo_savestate_tick(rdram, ctx);"
 
-# Deterministic input record/replay harness. The controller hook replaces/records
-# the decoded pad before the ROM derives its held/pressed masks. The following
-# dispatcher entry verifies that staged pad and freezes its analog channels; the
-# common epilogue counts it only after the 30 Hz game update has returned.
 [[patches.hook]]
 func = "func_800028D0"
 before_vram = 0x80001CD8

--- a/src/controls/lambo_controls.cpp
+++ b/src/controls/lambo_controls.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cerrno>
 #include <cctype>
 #include <cmath>
 #include <cstdio>
@@ -11,16 +10,11 @@
 #include <fstream>
 #include <limits>
 #include <sstream>
-#include <system_error>
-
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#endif
 
 #include "json/json.hpp"
 
 #include "lambo_config.h"
+#include "lambo_file.h"
 
 namespace {
 
@@ -305,20 +299,6 @@ void merge_profile(json& destination, const Profile& profile) {
     }
 }
 
-bool atomic_replace(const std::filesystem::path& temporary,
-                    const std::filesystem::path& destination, std::string& error) {
-#ifdef _WIN32
-    if (MoveFileExW(temporary.c_str(), destination.c_str(),
-                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) return true;
-    error = "MoveFileExW failed (" + std::to_string(GetLastError()) + ")";
-    return false;
-#else
-    if (::rename(temporary.c_str(), destination.c_str()) == 0) return true;
-    error = std::strerror(errno);
-    return false;
-#endif
-}
-
 } // namespace
 
 namespace lambo::controls {
@@ -597,7 +577,7 @@ SaveResult save_config(ControlsConfig& config, const std::filesystem::path& path
         output.flush();
         if (!output) { result.error = "could not flush temporary file"; output.close(); std::filesystem::remove(temporary, ec); return result; }
     }
-    if (!atomic_replace(temporary, path, result.error)) {
+    if (!lambo::file::atomic_replace(temporary, path, result.error)) {
         std::filesystem::remove(temporary, ec);
         return result;
     }

--- a/src/lambo_analog_brake.cpp
+++ b/src/lambo_analog_brake.cpp
@@ -3,12 +3,11 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
-#include <cmath>
-#include <cstdio>
 #include <cstdint>
 
 #include "recomp.h"
 #include "lambo_log.h"
+#include "lambo_input_quantize.h"
 
 // Guest seam (measured live, see docs/analog-brake.md):
 // - Brake demand is the float at vehicle offset 0xA0. Stock digital play ramps
@@ -43,12 +42,6 @@ std::atomic<bool> g_probe_enabled{false};
 std::array<float, lambo::analog_brake::kPortCount> g_ramp{};
 std::array<std::atomic<unsigned>, lambo::analog_brake::kPortCount> g_probe_frames{};
 
-uint16_t quantize(float value) {
-    if (!std::isfinite(value) || value <= 0.0f) return 0;
-    if (value >= 1.0f) return UINT16_MAX;
-    return static_cast<uint16_t>(std::lround(value * static_cast<float>(UINT16_MAX)));
-}
-
 float bits_to_float(uint32_t bits) {
     static_assert(sizeof(float) == sizeof(uint32_t));
     float out;
@@ -69,7 +62,7 @@ namespace lambo::analog_brake {
 void publish(unsigned port, bool analog_mode, float effective_value) {
     if (port >= kPortCount) return;
     const uint32_t packed = analog_mode
-        ? kAnalogEnabled | static_cast<uint32_t>(quantize(effective_value))
+        ? kAnalogEnabled | static_cast<uint32_t>(lambo::input::quantize_normalized(effective_value))
         : 0u;
     g_ports[port].store(packed, std::memory_order_release);
 }

--- a/src/lambo_analog_throttle.cpp
+++ b/src/lambo_analog_throttle.cpp
@@ -3,12 +3,11 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
-#include <cmath>
-#include <cstdio>
 #include <cstdint>
 
 #include "recomp.h"
 #include "lambo_log.h"
+#include "lambo_input_quantize.h"
 
 namespace {
 
@@ -32,12 +31,6 @@ std::array<std::atomic<unsigned>, lambo::analog_throttle::kPortCount> g_probe_fr
 std::array<int16_t, lambo::analog_throttle::kPortCount> g_previous_demand{};
 std::array<bool, lambo::analog_throttle::kPortCount> g_previous_valid{};
 
-uint16_t quantize(float value) {
-    if (!std::isfinite(value) || value <= 0.0f) return 0;
-    if (value >= 1.0f) return UINT16_MAX;
-    return static_cast<uint16_t>(std::lround(value * static_cast<float>(UINT16_MAX)));
-}
-
 } // namespace
 
 namespace lambo::analog_throttle {
@@ -45,7 +38,7 @@ namespace lambo::analog_throttle {
 void publish(unsigned port, bool analog_mode, float effective_value) {
     if (port >= kPortCount) return;
     const uint32_t packed = analog_mode
-        ? kAnalogEnabled | static_cast<uint32_t>(quantize(effective_value))
+        ? kAnalogEnabled | static_cast<uint32_t>(lambo::input::quantize_normalized(effective_value))
         : 0u;
     g_ports[port].store(packed, std::memory_order_release);
 }

--- a/src/lambo_file.cpp
+++ b/src/lambo_file.cpp
@@ -1,0 +1,37 @@
+#include "lambo_file.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <system_error>
+
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+namespace lambo::file {
+
+bool atomic_replace(const std::filesystem::path& source,
+                    const std::filesystem::path& destination,
+                    std::string& error) {
+#if defined(_WIN32)
+    if (MoveFileExW(source.c_str(), destination.c_str(),
+                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) != 0) {
+        return true;
+    }
+    const std::error_code ec{static_cast<int>(GetLastError()), std::system_category()};
+#else
+    if (std::rename(source.c_str(), destination.c_str()) == 0) return true;
+    const std::error_code ec{errno, std::generic_category()};
+#endif
+    error = "could not publish temporary file '" + source.string() + "' as '" +
+            destination.string() + "': " + ec.message();
+    return false;
+}
+
+} // namespace lambo::file

--- a/src/lambo_file.h
+++ b/src/lambo_file.h
@@ -1,0 +1,15 @@
+#ifndef LAMBO_FILE_H
+#define LAMBO_FILE_H
+
+#include <filesystem>
+#include <string>
+
+namespace lambo::file {
+
+bool atomic_replace(const std::filesystem::path& source,
+                    const std::filesystem::path& destination,
+                    std::string& error);
+
+} // namespace lambo::file
+
+#endif // LAMBO_FILE_H

--- a/src/lambo_harness_report.cpp
+++ b/src/lambo_harness_report.cpp
@@ -1,0 +1,282 @@
+#include "lambo_harness_report.h"
+
+#include "json/json.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <mutex>
+#include <string>
+#include <utility>
+
+#include "lambo_file.h"
+#include "lambo_log.h"
+#include "lambo_replay_runtime.h"
+
+extern uint8_t* g_lambo_rdram;
+
+extern "C" int lambo_warp_env_applied(void);
+extern "C" int lambo_warp_env_failed(void);
+extern "C" int lambo_warp_env_circuit(void);
+extern "C" int lambo_warp_env_laps(void);
+extern "C" int lambo_warp_env_car(void);
+extern "C" int lambo_warp_env_players(void);
+extern "C" int lambo_warp_env_mode(void);
+extern "C" int lambo_savestate_env_load_applied(void);
+extern "C" int lambo_savestate_env_load_failed(void);
+
+namespace lambo::harness {
+namespace {
+
+using json = nlohmann::json;
+
+struct Metrics {
+    std::mutex mutex;
+    Snapshot snapshot;
+    std::uint32_t last_vi_buffer{};
+    int last_state{-1};
+    int last_menu_screen{-9999};
+    int last_menu_sub{-9999};
+    int swaps_at_last_log{};
+};
+
+Metrics g_metrics;
+
+bool environment_requested(const char* name) {
+    const char* value = std::getenv(name);
+    return value != nullptr && value[0] != '\0';
+}
+
+std::uint32_t guest_word(const std::uint8_t* rdram, std::uint32_t address) {
+    return *reinterpret_cast<const std::uint32_t*>(rdram + (address - 0x80000000u));
+}
+
+std::uint32_t guest_halfword(const std::uint8_t* rdram, std::uint32_t address) {
+    const std::uint32_t word = guest_word(rdram, address & ~3u);
+    return (address & 2u) ? (word & 0xFFFFu) : (word >> 16);
+}
+
+void state_probe_locked(int vi) {
+    const std::uint8_t* rdram = g_lambo_rdram;
+    if (rdram == nullptr) return;
+    const int state = static_cast<int>(guest_halfword(rdram, 0x800CE6ACu));
+    if (state < 0 || state > 16) return;
+
+    g_metrics.snapshot.current_state = state;
+    if (state > g_metrics.snapshot.max_state) g_metrics.snapshot.max_state = state;
+    if (state == 8) {
+        const int circuit = static_cast<int16_t>(guest_halfword(rdram, 0x800CE794u));
+        if (circuit >= 0 && circuit < 6) g_metrics.snapshot.loaded_circuit = circuit + 1;
+
+        constexpr std::uint32_t kVehicleBase = 0x800B69A8u;
+        constexpr std::uint32_t kVehicleStride = 0x10Cu;
+        for (int vehicle = 0; vehicle < 6; ++vehicle) {
+            const std::uint32_t base = kVehicleBase +
+                static_cast<std::uint32_t>(vehicle) * kVehicleStride;
+            if (static_cast<int16_t>(guest_halfword(rdram, base + 0x0Eu)) != 1) continue;
+            const int speed = static_cast<int32_t>(guest_word(rdram, base + 0x90u));
+            g_metrics.snapshot.player_vehicle = vehicle;
+            g_metrics.snapshot.player_speed = speed;
+            const int magnitude = speed == std::numeric_limits<int>::min()
+                ? std::numeric_limits<int>::max() : std::abs(speed);
+            if (magnitude > g_metrics.snapshot.max_abs_player_speed) {
+                g_metrics.snapshot.max_abs_player_speed = magnitude;
+            }
+            break;
+        }
+    }
+    if (state != g_metrics.last_state) {
+        LAMBO_LOG("state", "vi=%d  state=%d (was %d)\n", vi, state, g_metrics.last_state);
+        g_metrics.last_state = state;
+    }
+}
+
+void menu_probe_locked(int vi) {
+    const std::uint8_t* rdram = g_lambo_rdram;
+    if (rdram == nullptr) return;
+    const int screen = static_cast<int16_t>(guest_halfword(rdram, 0x80098562u));
+    const int sub = static_cast<int16_t>(guest_halfword(rdram, 0x80098560u));
+    g_metrics.snapshot.current_menu_screen = screen;
+    if (screen != g_metrics.last_menu_screen || sub != g_metrics.last_menu_sub) {
+        LAMBO_LOG("menu", "vi=%d  screen=%d sub=%d (was %d/%d)\n",
+                  vi, screen, sub, g_metrics.last_menu_screen, g_metrics.last_menu_sub);
+        g_metrics.last_menu_screen = screen;
+        g_metrics.last_menu_sub = sub;
+    }
+}
+
+void pace_probe_locked(int vi) {
+    const std::uint8_t* rdram = g_lambo_rdram;
+    if (rdram == nullptr) return;
+    const std::uint32_t next = guest_word(rdram, 0x8008D1A4u);
+    if (next < 0x80000000u || next >= 0x80800000u) return;
+    const std::uint32_t buffer = guest_word(rdram, next + 0x4u);
+    if (buffer != g_metrics.last_vi_buffer) {
+        g_metrics.last_vi_buffer = buffer;
+        ++g_metrics.snapshot.swaps;
+    }
+    if ((vi % 600) == 0) {
+        LAMBO_LOG("pace", "vi=%d swaps_last_600vi=%d (~%.1f fps)\n",
+                  vi, g_metrics.snapshot.swaps - g_metrics.swaps_at_last_log,
+                  (g_metrics.snapshot.swaps - g_metrics.swaps_at_last_log) / 10.0);
+        g_metrics.swaps_at_last_log = g_metrics.snapshot.swaps;
+    }
+}
+
+} // namespace
+
+void note_thread_created() {
+    int count = 0;
+    {
+        std::lock_guard lock(g_metrics.mutex);
+        count = ++g_metrics.snapshot.threads;
+    }
+    if (count <= 12) LAMBO_LOG("probe", "game thread #%d started (osCreateThread)\n", count);
+}
+
+int vis_count() {
+    std::lock_guard lock(g_metrics.mutex);
+    return g_metrics.snapshot.vis;
+}
+
+int sample_vi() {
+    std::lock_guard lock(g_metrics.mutex);
+    const int vi = ++g_metrics.snapshot.vis;
+    state_probe_locked(vi);
+    menu_probe_locked(vi);
+    pace_probe_locked(vi);
+    if (!g_metrics.snapshot.first_vi) {
+        g_metrics.snapshot.first_vi = true;
+        LAMBO_LOG("probe", "FIRST VI retrace\n");
+    }
+    return vi;
+}
+
+Snapshot snapshot() {
+    std::lock_guard lock(g_metrics.mutex);
+    return g_metrics.snapshot;
+}
+
+void log_boot_summary() {
+    const Snapshot value = snapshot();
+    LAMBO_LOG("probe", "boot summary; threads=%d vis=%d first_vi=%d max_state=%d swaps=%d\n",
+              value.threads, value.vis, static_cast<int>(value.first_vi), value.max_state,
+              value.swaps);
+}
+
+Outcome finalize_outcome(const char* reason, int exit_code) {
+    lambo::replay_runtime::finalize();
+    const lambo::replay_runtime::Status replay = lambo::replay_runtime::status();
+    std::string effective_reason = reason == nullptr ? std::string{} : reason;
+    if (replay.failed) {
+        exit_code = 2;
+        const std::string terminal = lambo::replay_runtime::terminal_reason();
+        effective_reason = terminal.empty() ? "replay_failed" : terminal;
+    }
+    return {std::move(effective_reason), exit_code};
+}
+
+void write_result(const Outcome& outcome) {
+    const char* value = std::getenv("LAMBO_HARNESS_RESULT");
+    if (value == nullptr || value[0] == '\0') return;
+
+    try {
+        const Snapshot metrics = snapshot();
+        const lambo::replay_runtime::Status replay = lambo::replay_runtime::status();
+        const std::filesystem::path output(value);
+        std::error_code error;
+        if (!output.parent_path().empty()) {
+            std::filesystem::create_directories(output.parent_path(), error);
+            if (error) {
+                LAMBO_LOG_ERROR("harness", "cannot create result directory for %s: %s\n",
+                                value, error.message().c_str());
+                return;
+            }
+        }
+
+        const json result = {
+            {"schema", 1},
+            {"outcome", outcome.exit_code == 0 ? "passed" : "failed"},
+            {"reason", outcome.reason},
+            {"exit_code", outcome.exit_code},
+            {"vis", metrics.vis},
+            {"swaps", metrics.swaps},
+            {"max_state", metrics.max_state},
+            {"final_state", metrics.current_state},
+            {"menu_screen", metrics.current_menu_screen},
+            {"loaded_circuit", metrics.loaded_circuit},
+            {"player_vehicle", metrics.player_vehicle},
+            {"player_speed", metrics.player_speed},
+            {"max_abs_player_speed", metrics.max_abs_player_speed},
+            {"warp", {
+                {"requested", environment_requested("LAMBO_WARP")},
+                {"applied", lambo_warp_env_applied() != 0},
+                {"failed", lambo_warp_env_failed() != 0},
+                {"circuit", lambo_warp_env_circuit()},
+                {"laps", lambo_warp_env_laps()},
+                {"car", lambo_warp_env_car()},
+                {"players", lambo_warp_env_players()},
+                {"mode", lambo_warp_env_mode()}}},
+            {"state_load", {
+                {"requested", environment_requested("LAMBO_STATE_LOAD")},
+                {"applied", lambo_savestate_env_load_applied() != 0},
+                {"failed", lambo_savestate_env_load_failed() != 0}}},
+            {"replay", {
+                {"configured", replay.configured},
+                {"recording", replay.recording},
+                {"active", replay.active},
+                {"complete", replay.complete},
+                {"failed", replay.failed},
+                {"total_frames", replay.total_frames},
+                {"frames_consumed", replay.frames_consumed},
+                {"guest_frames_verified", replay.guest_frames_verified},
+                {"dispatcher_ticks", replay.dispatcher_ticks}}}
+        };
+
+        std::filesystem::path temporary = output;
+        temporary += ".tmp";
+        struct TemporaryCleanup {
+            const std::filesystem::path& path;
+            bool owned{};
+            bool published{};
+            ~TemporaryCleanup() {
+                if (owned && !published) {
+                    std::error_code ignored;
+                    std::filesystem::remove(path, ignored);
+                }
+            }
+        } cleanup{temporary};
+        std::ofstream stream(temporary, std::ios::binary | std::ios::trunc);
+        if (!stream.is_open()) {
+            LAMBO_LOG_ERROR("harness", "cannot write result file %s\n", value);
+            return;
+        }
+        cleanup.owned = true;
+        stream << result.dump(2) << '\n';
+        stream.flush();
+        const bool write_ok = stream.good();
+        stream.close();
+        const bool close_ok = !stream.fail();
+        if (!write_ok || !close_ok) {
+            LAMBO_LOG_ERROR("harness", "failed while writing result file %s\n", value);
+            return;
+        }
+
+        std::string publish_error;
+        if (!lambo::file::atomic_replace(temporary, output, publish_error)) {
+            LAMBO_LOG_ERROR("harness", "%s\n", publish_error.c_str());
+            return;
+        }
+        cleanup.published = true;
+    } catch (const std::exception& exception) {
+        LAMBO_LOG_ERROR("harness", "cannot serialize result %s: %s\n", value, exception.what());
+    } catch (...) {
+        LAMBO_LOG_ERROR("harness", "cannot serialize result %s: unknown exception\n", value);
+    }
+}
+
+} // namespace lambo::harness

--- a/src/lambo_harness_report.h
+++ b/src/lambo_harness_report.h
@@ -1,0 +1,39 @@
+#ifndef LAMBO_HARNESS_REPORT_H
+#define LAMBO_HARNESS_REPORT_H
+
+#include <cstdint>
+#include <string>
+
+namespace lambo::harness {
+
+struct Snapshot {
+    int threads{};
+    int vis{};
+    bool first_vi{};
+    int max_state{};
+    int current_state{};
+    int current_menu_screen{-1};
+    int loaded_circuit{};
+    int swaps{};
+    int player_vehicle{-1};
+    int player_speed{};
+    int max_abs_player_speed{};
+};
+
+struct Outcome {
+    std::string reason;
+    int exit_code{};
+};
+
+void note_thread_created();
+int vis_count();
+int sample_vi();
+Snapshot snapshot();
+void log_boot_summary();
+
+Outcome finalize_outcome(const char* reason, int exit_code);
+void write_result(const Outcome& outcome);
+
+} // namespace lambo::harness
+
+#endif // LAMBO_HARNESS_REPORT_H

--- a/src/lambo_input_quantize.h
+++ b/src/lambo_input_quantize.h
@@ -1,0 +1,17 @@
+#ifndef LAMBO_INPUT_QUANTIZE_H
+#define LAMBO_INPUT_QUANTIZE_H
+
+#include <cmath>
+#include <cstdint>
+
+namespace lambo::input {
+
+inline std::uint16_t quantize_normalized(float value) noexcept {
+    if (!std::isfinite(value) || value <= 0.0f) return 0;
+    if (value >= 1.0f) return UINT16_MAX;
+    return static_cast<std::uint16_t>(std::lround(value * static_cast<float>(UINT16_MAX)));
+}
+
+} // namespace lambo::input
+
+#endif // LAMBO_INPUT_QUANTIZE_H

--- a/src/lambo_replay.cpp
+++ b/src/lambo_replay.cpp
@@ -1,30 +1,18 @@
 #include "lambo_replay.h"
 
 #include "json/json.hpp"
+#include "lambo_file.h"
 
 #include <algorithm>
-#include <cerrno>
-#include <cstdio>
 #include <fstream>
 #include <initializer_list>
 #include <limits>
 #include <sstream>
-#include <stdexcept>
-#include <string_view>
 #include <system_error>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 #include <vector>
-
-#if defined(_WIN32)
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#include <windows.h>
-#endif
 
 namespace lambo::replay {
 namespace {
@@ -279,39 +267,19 @@ json run_record(std::uint64_t frames, const InputFrame& input) {
                 {"brake", input.brake}};
 }
 
-bool atomic_replace(const std::filesystem::path& source,
-                    const std::filesystem::path& destination, std::string& error) {
-#if defined(_WIN32)
-    if (MoveFileExW(source.c_str(), destination.c_str(),
-                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) != 0) {
-        return true;
-    }
-    const std::error_code ec{static_cast<int>(GetLastError()), std::system_category()};
-#else
-    if (std::rename(source.c_str(), destination.c_str()) == 0) return true;
-    const std::error_code ec{errno, std::generic_category()};
-#endif
-    error = "could not publish temporary trace '" + display_path(source) + "' as '" +
-            display_path(destination) + "': " + ec.message();
-    return false;
-}
-
 } // namespace
 
 Trace::Trace(std::vector<Run> runs, std::uint64_t total_frames)
     : runs_(std::move(runs)), total_frames_(total_frames) {}
 
-const InputFrame& Trace::frame_at(std::uint64_t index) const {
-    if (index >= total_frames_) {
-        std::ostringstream error;
-        error << "replay frame " << index << " is out of range for " << total_frames_
-              << "-frame trace";
-        throw std::out_of_range(error.str());
-    }
+bool Trace::frame_at(std::uint64_t index, InputFrame& output) const noexcept {
+    if (index >= total_frames_) return false;
     const auto run = std::lower_bound(
         runs_.begin(), runs_.end(), index,
         [](const Run& candidate, std::uint64_t frame) { return candidate.end_frame <= frame; });
-    return run->input;
+    if (run == runs_.end()) return false;
+    output = run->input;
+    return true;
 }
 
 LoadResult load_trace(const std::filesystem::path& path) {
@@ -408,13 +376,11 @@ struct Recorder::Impl {
     enum class State { Failed, Writing, Finalized };
 
     explicit Impl(std::filesystem::path path)
-        : destination(std::move(path)), temporary(destination) {
+        : destination(std::move(path)) {
         if (destination.empty()) {
             error_message = "trace destination path is empty";
             return;
         }
-        temporary += ".tmp";
-
         const std::filesystem::path parent = destination.parent_path();
         if (!parent.empty()) {
             std::error_code ec;
@@ -425,61 +391,27 @@ struct Recorder::Impl {
                 return;
             }
         }
-
-        output.open(temporary, std::ios::binary | std::ios::out | std::ios::trunc);
-        if (!output.is_open()) {
-            error_message = "could not open temporary trace '" + display_path(temporary) + "'";
-            return;
-        }
-        owns_temporary = true;
-        output << header_record().dump() << '\n';
-        if (!output.good()) {
-            fail("could not write header to temporary trace '" + display_path(temporary) + "'");
-            return;
-        }
         state = State::Writing;
     }
 
-    ~Impl() {
-        if (state != State::Finalized) discard_temporary();
-    }
+    ~Impl() = default;
 
     bool fail(std::string message) {
         if (error_message.empty()) error_message = std::move(message);
         state = State::Failed;
-        discard_temporary();
         return false;
     }
 
-    void discard_temporary() noexcept {
-        if (output.is_open()) output.close();
-        if (owns_temporary && !temporary.empty()) {
-            std::error_code ignored;
-            std::filesystem::remove(temporary, ignored);
-            owns_temporary = false;
-        }
-    }
-
-    bool flush_pending() {
-        if (!pending.has_value()) return true;
-        output << run_record(pending_frames, *pending).dump() << '\n';
-        if (!output.good()) {
-            return fail("could not write run to temporary trace '" +
-                        display_path(temporary) + "'");
-        }
-        pending.reset();
-        pending_frames = 0;
-        return true;
-    }
-
     std::filesystem::path destination;
-    std::filesystem::path temporary;
-    std::ofstream output;
     std::optional<InputFrame> pending;
     std::uint64_t pending_frames{};
     std::uint64_t observed_frames{};
+    struct Run {
+        std::uint64_t frames{};
+        InputFrame input{};
+    };
+    std::vector<Run> runs;
     State state{State::Failed};
-    bool owns_temporary{};
     std::string error_message;
 };
 
@@ -513,7 +445,7 @@ bool Recorder::observe(const InputFrame& input) {
     } else if (*impl_->pending == input) {
         ++impl_->pending_frames;
     } else {
-        if (!impl_->flush_pending()) return false;
+        impl_->runs.push_back(Impl::Run{impl_->pending_frames, *impl_->pending});
         impl_->pending = input;
         impl_->pending_frames = 1;
     }
@@ -527,26 +459,60 @@ bool Recorder::finalize() {
     if (impl_->observed_frames == 0) {
         return impl_->fail("cannot finalize a trace with no input frames");
     }
-    if (!impl_->flush_pending()) return false;
 
-    impl_->output << json{{"type", "end"}, {"frames", impl_->observed_frames}}.dump()
-                  << '\n';
-    impl_->output.flush();
-    if (!impl_->output.good()) {
-        return impl_->fail("could not finish temporary trace '" +
-                           display_path(impl_->temporary) + "'");
+    if (impl_->pending.has_value()) {
+        impl_->runs.push_back(Impl::Run{impl_->pending_frames, *impl_->pending});
+        impl_->pending.reset();
+        impl_->pending_frames = 0;
     }
-    impl_->output.close();
-    if (impl_->output.fail()) {
-        return impl_->fail("could not close temporary trace '" +
-                           display_path(impl_->temporary) + "'");
+
+    const std::filesystem::path parent = impl_->destination.parent_path();
+    if (!parent.empty()) {
+        std::error_code directory_error;
+        std::filesystem::create_directories(parent, directory_error);
+        if (directory_error) {
+            return impl_->fail("could not create trace directory '" + display_path(parent) +
+                               "': " + directory_error.message());
+        }
+    }
+
+    std::filesystem::path temporary = impl_->destination;
+    temporary += ".tmp";
+    struct TemporaryCleanup {
+        const std::filesystem::path& path;
+        bool owned{};
+        bool published{};
+        ~TemporaryCleanup() {
+            if (owned && !published) {
+                std::error_code ignored;
+                std::filesystem::remove(path, ignored);
+            }
+        }
+    } cleanup{temporary};
+    std::ofstream output(temporary, std::ios::binary | std::ios::out | std::ios::trunc);
+    if (!output.is_open()) {
+        return impl_->fail("could not open temporary trace '" + display_path(temporary) + "'");
+    }
+    cleanup.owned = true;
+    output << header_record().dump() << '\n';
+    for (const Impl::Run& run : impl_->runs) {
+        output << run_record(run.frames, run.input).dump() << '\n';
+    }
+    output << json{{"type", "end"}, {"frames", impl_->observed_frames}}.dump() << '\n';
+    output.flush();
+    const bool write_ok = output.good();
+    output.close();
+    const bool close_ok = !output.fail();
+    if (!write_ok || !close_ok) {
+        return impl_->fail("could not finish temporary trace '" +
+                           display_path(temporary) + "'");
     }
 
     std::string publish_error;
-    if (!atomic_replace(impl_->temporary, impl_->destination, publish_error)) {
+    if (!lambo::file::atomic_replace(temporary, impl_->destination, publish_error)) {
         return impl_->fail(std::move(publish_error));
     }
-    impl_->owns_temporary = false;
+    cleanup.published = true;
     impl_->state = Impl::State::Finalized;
     return true;
 }

--- a/src/lambo_replay.cpp
+++ b/src/lambo_replay.cpp
@@ -1,0 +1,562 @@
+#include "lambo_replay.h"
+
+#include "json/json.hpp"
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdio>
+#include <fstream>
+#include <initializer_list>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string_view>
+#include <system_error>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+namespace lambo::replay {
+namespace {
+
+using json = nlohmann::json;
+
+constexpr char kFormat[] = "lambo-input-trace";
+constexpr char kClock[] = "game-dispatch";
+constexpr std::uint64_t kVersion = 1;
+constexpr std::uint64_t kPorts = 1;
+
+std::string display_path(const std::filesystem::path& path) {
+    const std::string text = path.string();
+    return text.empty() ? std::string{"<empty path>"} : text;
+}
+
+LoadResult load_failure(const std::filesystem::path& path, std::uint64_t line,
+                        const std::string& message) {
+    std::ostringstream error;
+    error << "trace '" << display_path(path) << "'";
+    if (line != 0) error << " line " << line;
+    error << ": " << message;
+    return LoadResult{std::nullopt, error.str()};
+}
+
+bool parse_json_line(const std::string& line, json& result, std::string& error) {
+    std::vector<std::unordered_set<std::string>> object_keys;
+    std::string duplicate_key;
+    const json::parser_callback_t reject_duplicates =
+        [&](int, json::parse_event_t event, json& parsed) {
+            if (event == json::parse_event_t::object_start) {
+                object_keys.emplace_back();
+            } else if (event == json::parse_event_t::key && !object_keys.empty()) {
+                const std::string key = parsed.get<std::string>();
+                if (!object_keys.back().insert(key).second && duplicate_key.empty()) {
+                    duplicate_key = key;
+                }
+            } else if (event == json::parse_event_t::object_end && !object_keys.empty()) {
+                object_keys.pop_back();
+            }
+            return true;
+        };
+
+    try {
+        result = json::parse(line, reject_duplicates);
+    } catch (const json::exception& exception) {
+        error = std::string{"invalid JSON: "} + exception.what();
+        return false;
+    }
+    if (!duplicate_key.empty()) {
+        error = "duplicate field '" + duplicate_key + "'";
+        return false;
+    }
+    return true;
+}
+
+bool has_field(const json& record, std::string_view field) {
+    return record.find(std::string{field}) != record.end();
+}
+
+bool has_exact_fields(const json& record,
+                      std::initializer_list<std::string_view> expected,
+                      std::string_view record_name, std::string& error) {
+    if (!record.is_object()) {
+        error = std::string{record_name} + " record must be a JSON object";
+        return false;
+    }
+
+    for (const std::string_view field : expected) {
+        if (!has_field(record, field)) {
+            error = std::string{record_name} + " record is missing field '" +
+                    std::string{field} + "'";
+            return false;
+        }
+    }
+    for (auto it = record.begin(); it != record.end(); ++it) {
+        const bool known = std::find(expected.begin(), expected.end(), it.key()) != expected.end();
+        if (!known) {
+            error = std::string{record_name} + " record has unknown field '" + it.key() + "'";
+            return false;
+        }
+    }
+    return true;
+}
+
+bool read_string(const json& record, std::string_view field, std::string_view expected,
+                 std::string& error) {
+    const json& value = record.at(std::string{field});
+    if (!value.is_string()) {
+        error = "field '" + std::string{field} + "' must be a string";
+        return false;
+    }
+    const std::string actual = value.get<std::string>();
+    if (actual != expected) {
+        error = "field '" + std::string{field} + "' must be '" +
+                std::string{expected} + "' (got '" + actual + "')";
+        return false;
+    }
+    return true;
+}
+
+bool read_unsigned(const json& record, std::string_view field, std::uint64_t minimum,
+                   std::uint64_t maximum, std::uint64_t& result, std::string& error) {
+    const json& value = record.at(std::string{field});
+    if (!value.is_number_unsigned()) {
+        error = "field '" + std::string{field} + "' must be an unsigned integer";
+        return false;
+    }
+    result = value.get<std::uint64_t>();
+    if (result < minimum || result > maximum) {
+        std::ostringstream range_error;
+        range_error << "field '" << field << "' must be in [" << minimum << ", "
+                    << maximum << "] (got " << result << ')';
+        error = range_error.str();
+        return false;
+    }
+    return true;
+}
+
+bool read_signed(const json& record, std::string_view field, std::int64_t minimum,
+                 std::int64_t maximum, std::int64_t& result, std::string& error) {
+    const json& value = record.at(std::string{field});
+    if (value.is_number_unsigned()) {
+        const std::uint64_t unsigned_value = value.get<std::uint64_t>();
+        if (unsigned_value > static_cast<std::uint64_t>(maximum)) {
+            std::ostringstream range_error;
+            range_error << "field '" << field << "' must be in [" << minimum << ", "
+                        << maximum << "] (got " << unsigned_value << ')';
+            error = range_error.str();
+            return false;
+        }
+        result = static_cast<std::int64_t>(unsigned_value);
+    } else if (value.is_number_integer()) {
+        result = value.get<std::int64_t>();
+    } else {
+        error = "field '" + std::string{field} + "' must be an integer";
+        return false;
+    }
+
+    if (result < minimum || result > maximum) {
+        std::ostringstream range_error;
+        range_error << "field '" << field << "' must be in [" << minimum << ", "
+                    << maximum << "] (got " << result << ')';
+        error = range_error.str();
+        return false;
+    }
+    return true;
+}
+
+bool read_bool(const json& record, std::string_view field, bool& result, std::string& error) {
+    const json& value = record.at(std::string{field});
+    if (!value.is_boolean()) {
+        error = "field '" + std::string{field} + "' must be a boolean";
+        return false;
+    }
+    result = value.get<bool>();
+    return true;
+}
+
+bool validate_header(const json& record, std::string& error) {
+    if (!has_exact_fields(record, {"type", "format", "version", "clock", "ports"},
+                          "header", error)) {
+        return false;
+    }
+    if (!read_string(record, "type", "header", error) ||
+        !read_string(record, "format", kFormat, error) ||
+        !read_string(record, "clock", kClock, error)) {
+        return false;
+    }
+    std::uint64_t value = 0;
+    if (!read_unsigned(record, "version", kVersion, kVersion, value, error)) return false;
+    if (!read_unsigned(record, "ports", kPorts, kPorts, value, error)) return false;
+    return true;
+}
+
+bool parse_input_run(const json& record, std::uint64_t& frames, InputFrame& input,
+                     std::string& error) {
+    if (!has_exact_fields(record,
+                          {"type", "frames", "buttons", "stick_x", "stick_y",
+                           "throttle_analog", "throttle", "brake_analog", "brake"},
+                          "run", error)) {
+        return false;
+    }
+    if (!read_string(record, "type", "run", error)) return false;
+
+    std::uint64_t value = 0;
+    if (!read_unsigned(record, "frames", 1, std::numeric_limits<std::uint64_t>::max(),
+                       frames, error)) {
+        return false;
+    }
+    if (!read_unsigned(record, "buttons", 0, std::numeric_limits<std::uint16_t>::max(),
+                       value, error)) {
+        return false;
+    }
+    input.buttons = static_cast<std::uint16_t>(value);
+
+    std::int64_t signed_value = 0;
+    if (!read_signed(record, "stick_x", -80, 80, signed_value, error)) return false;
+    input.stick_x = static_cast<std::int8_t>(signed_value);
+    if (!read_signed(record, "stick_y", -80, 80, signed_value, error)) return false;
+    input.stick_y = static_cast<std::int8_t>(signed_value);
+
+    if (!read_bool(record, "throttle_analog", input.throttle_analog, error)) return false;
+    if (!read_unsigned(record, "throttle", 0, std::numeric_limits<std::uint16_t>::max(),
+                       value, error)) {
+        return false;
+    }
+    input.throttle = static_cast<std::uint16_t>(value);
+
+    if (!read_bool(record, "brake_analog", input.brake_analog, error)) return false;
+    if (!read_unsigned(record, "brake", 0, std::numeric_limits<std::uint16_t>::max(),
+                       value, error)) {
+        return false;
+    }
+    input.brake = static_cast<std::uint16_t>(value);
+    return true;
+}
+
+bool parse_end(const json& record, std::uint64_t& frames, std::string& error) {
+    if (!has_exact_fields(record, {"type", "frames"}, "end", error)) return false;
+    if (!read_string(record, "type", "end", error)) return false;
+    return read_unsigned(record, "frames", 1, std::numeric_limits<std::uint64_t>::max(),
+                         frames, error);
+}
+
+bool input_is_valid(const InputFrame& input, std::string& error) {
+    if (input.stick_x < -80 || input.stick_x > 80) {
+        error = "stick_x must be in [-80, 80]";
+        return false;
+    }
+    if (input.stick_y < -80 || input.stick_y > 80) {
+        error = "stick_y must be in [-80, 80]";
+        return false;
+    }
+    return true;
+}
+
+json header_record() {
+    return json{{"type", "header"}, {"format", kFormat}, {"version", kVersion},
+                {"clock", kClock}, {"ports", kPorts}};
+}
+
+json run_record(std::uint64_t frames, const InputFrame& input) {
+    return json{{"type", "run"},
+                {"frames", frames},
+                {"buttons", input.buttons},
+                {"stick_x", static_cast<int>(input.stick_x)},
+                {"stick_y", static_cast<int>(input.stick_y)},
+                {"throttle_analog", input.throttle_analog},
+                {"throttle", input.throttle},
+                {"brake_analog", input.brake_analog},
+                {"brake", input.brake}};
+}
+
+bool atomic_replace(const std::filesystem::path& source,
+                    const std::filesystem::path& destination, std::string& error) {
+#if defined(_WIN32)
+    if (MoveFileExW(source.c_str(), destination.c_str(),
+                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) != 0) {
+        return true;
+    }
+    const std::error_code ec{static_cast<int>(GetLastError()), std::system_category()};
+#else
+    if (std::rename(source.c_str(), destination.c_str()) == 0) return true;
+    const std::error_code ec{errno, std::generic_category()};
+#endif
+    error = "could not publish temporary trace '" + display_path(source) + "' as '" +
+            display_path(destination) + "': " + ec.message();
+    return false;
+}
+
+} // namespace
+
+Trace::Trace(std::vector<Run> runs, std::uint64_t total_frames)
+    : runs_(std::move(runs)), total_frames_(total_frames) {}
+
+const InputFrame& Trace::frame_at(std::uint64_t index) const {
+    if (index >= total_frames_) {
+        std::ostringstream error;
+        error << "replay frame " << index << " is out of range for " << total_frames_
+              << "-frame trace";
+        throw std::out_of_range(error.str());
+    }
+    const auto run = std::lower_bound(
+        runs_.begin(), runs_.end(), index,
+        [](const Run& candidate, std::uint64_t frame) { return candidate.end_frame <= frame; });
+    return run->input;
+}
+
+LoadResult load_trace(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input.is_open()) {
+        return load_failure(path, 0, "could not open file");
+    }
+
+    std::string line;
+    std::uint64_t line_number = 1;
+    if (!std::getline(input, line)) {
+        if (input.bad()) return load_failure(path, 0, "I/O error while reading header");
+        return load_failure(path, 0, "file is empty; expected a header record");
+    }
+
+    json record;
+    std::string validation_error;
+    if (!parse_json_line(line, record, validation_error)) {
+        return load_failure(path, line_number, validation_error);
+    }
+
+    if (!validate_header(record, validation_error)) {
+        return load_failure(path, line_number, validation_error);
+    }
+
+    std::vector<Trace::Run> runs;
+    std::uint64_t total_frames = 0;
+    bool found_end = false;
+
+    while (std::getline(input, line)) {
+        ++line_number;
+        if (!parse_json_line(line, record, validation_error)) {
+            return load_failure(path, line_number, validation_error);
+        }
+        if (!record.is_object()) {
+            return load_failure(path, line_number, "record must be a JSON object");
+        }
+        const auto type_it = record.find("type");
+        if (type_it == record.end()) {
+            return load_failure(path, line_number, "record is missing field 'type'");
+        }
+        if (!type_it->is_string()) {
+            return load_failure(path, line_number, "field 'type' must be a string");
+        }
+        if (found_end) {
+            return load_failure(path, line_number, "record appears after the end trailer");
+        }
+
+        const std::string type = type_it->get<std::string>();
+        if (type == "run") {
+            std::uint64_t frames = 0;
+            InputFrame frame{};
+            if (!parse_input_run(record, frames, frame, validation_error)) {
+                return load_failure(path, line_number, validation_error);
+            }
+            if (frames > std::numeric_limits<std::uint64_t>::max() - total_frames) {
+                return load_failure(path, line_number,
+                                    "cumulative frame count overflows uint64");
+            }
+            total_frames += frames;
+            runs.push_back(Trace::Run{total_frames, frame});
+        } else if (type == "end") {
+            if (runs.empty()) {
+                return load_failure(path, line_number,
+                                    "end trailer requires at least one run record");
+            }
+            std::uint64_t declared_frames = 0;
+            if (!parse_end(record, declared_frames, validation_error)) {
+                return load_failure(path, line_number, validation_error);
+            }
+            if (declared_frames != total_frames) {
+                std::ostringstream mismatch;
+                mismatch << "end frame count " << declared_frames
+                         << " does not match run total " << total_frames;
+                return load_failure(path, line_number, mismatch.str());
+            }
+            found_end = true;
+        } else {
+            return load_failure(path, line_number,
+                                "unknown record type '" + type + "'");
+        }
+    }
+
+    if (input.bad()) {
+        return load_failure(path, line_number, "I/O error while reading trace");
+    }
+    if (!found_end) {
+        return load_failure(path, line_number, "missing end trailer");
+    }
+    return LoadResult{Trace{std::move(runs), total_frames}, {}};
+}
+
+struct Recorder::Impl {
+    enum class State { Failed, Writing, Finalized };
+
+    explicit Impl(std::filesystem::path path)
+        : destination(std::move(path)), temporary(destination) {
+        if (destination.empty()) {
+            error_message = "trace destination path is empty";
+            return;
+        }
+        temporary += ".tmp";
+
+        const std::filesystem::path parent = destination.parent_path();
+        if (!parent.empty()) {
+            std::error_code ec;
+            std::filesystem::create_directories(parent, ec);
+            if (ec) {
+                error_message = "could not create trace directory '" + display_path(parent) +
+                                "': " + ec.message();
+                return;
+            }
+        }
+
+        output.open(temporary, std::ios::binary | std::ios::out | std::ios::trunc);
+        if (!output.is_open()) {
+            error_message = "could not open temporary trace '" + display_path(temporary) + "'";
+            return;
+        }
+        owns_temporary = true;
+        output << header_record().dump() << '\n';
+        if (!output.good()) {
+            fail("could not write header to temporary trace '" + display_path(temporary) + "'");
+            return;
+        }
+        state = State::Writing;
+    }
+
+    ~Impl() {
+        if (state != State::Finalized) discard_temporary();
+    }
+
+    bool fail(std::string message) {
+        if (error_message.empty()) error_message = std::move(message);
+        state = State::Failed;
+        discard_temporary();
+        return false;
+    }
+
+    void discard_temporary() noexcept {
+        if (output.is_open()) output.close();
+        if (owns_temporary && !temporary.empty()) {
+            std::error_code ignored;
+            std::filesystem::remove(temporary, ignored);
+            owns_temporary = false;
+        }
+    }
+
+    bool flush_pending() {
+        if (!pending.has_value()) return true;
+        output << run_record(pending_frames, *pending).dump() << '\n';
+        if (!output.good()) {
+            return fail("could not write run to temporary trace '" +
+                        display_path(temporary) + "'");
+        }
+        pending.reset();
+        pending_frames = 0;
+        return true;
+    }
+
+    std::filesystem::path destination;
+    std::filesystem::path temporary;
+    std::ofstream output;
+    std::optional<InputFrame> pending;
+    std::uint64_t pending_frames{};
+    std::uint64_t observed_frames{};
+    State state{State::Failed};
+    bool owns_temporary{};
+    std::string error_message;
+};
+
+Recorder::Recorder(std::filesystem::path path)
+    : impl_(std::make_unique<Impl>(std::move(path))) {}
+
+Recorder::~Recorder() = default;
+
+bool Recorder::ready() const noexcept {
+    return impl_->state == Impl::State::Writing;
+}
+
+bool Recorder::observe(const InputFrame& input) {
+    if (impl_->state == Impl::State::Finalized) {
+        impl_->error_message = "cannot observe input after recorder finalization";
+        return false;
+    }
+    if (impl_->state != Impl::State::Writing) return false;
+
+    std::string validation_error;
+    if (!input_is_valid(input, validation_error)) {
+        return impl_->fail("invalid input observation: " + validation_error);
+    }
+    if (impl_->observed_frames == std::numeric_limits<std::uint64_t>::max()) {
+        return impl_->fail("recorded frame count overflows uint64");
+    }
+
+    if (!impl_->pending.has_value()) {
+        impl_->pending = input;
+        impl_->pending_frames = 1;
+    } else if (*impl_->pending == input) {
+        ++impl_->pending_frames;
+    } else {
+        if (!impl_->flush_pending()) return false;
+        impl_->pending = input;
+        impl_->pending_frames = 1;
+    }
+    ++impl_->observed_frames;
+    return true;
+}
+
+bool Recorder::finalize() {
+    if (impl_->state == Impl::State::Finalized) return true;
+    if (impl_->state != Impl::State::Writing) return false;
+    if (impl_->observed_frames == 0) {
+        return impl_->fail("cannot finalize a trace with no input frames");
+    }
+    if (!impl_->flush_pending()) return false;
+
+    impl_->output << json{{"type", "end"}, {"frames", impl_->observed_frames}}.dump()
+                  << '\n';
+    impl_->output.flush();
+    if (!impl_->output.good()) {
+        return impl_->fail("could not finish temporary trace '" +
+                           display_path(impl_->temporary) + "'");
+    }
+    impl_->output.close();
+    if (impl_->output.fail()) {
+        return impl_->fail("could not close temporary trace '" +
+                           display_path(impl_->temporary) + "'");
+    }
+
+    std::string publish_error;
+    if (!atomic_replace(impl_->temporary, impl_->destination, publish_error)) {
+        return impl_->fail(std::move(publish_error));
+    }
+    impl_->owns_temporary = false;
+    impl_->state = Impl::State::Finalized;
+    return true;
+}
+
+std::uint64_t Recorder::total_frames() const noexcept {
+    return impl_->observed_frames;
+}
+
+const std::string& Recorder::error() const noexcept {
+    return impl_->error_message;
+}
+
+} // namespace lambo::replay

--- a/src/lambo_replay.h
+++ b/src/lambo_replay.h
@@ -1,0 +1,94 @@
+#ifndef LAMBO_REPLAY_H
+#define LAMBO_REPLAY_H
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace lambo::replay {
+
+// Controller state observed at one game-dispatch tick. Values deliberately
+// retain the N64 controller's native widths; traces still validate every
+// field before exposing any frame to playback.
+struct InputFrame {
+    std::uint16_t buttons{};
+    std::int8_t stick_x{};
+    std::int8_t stick_y{};
+    bool throttle_analog{};
+    std::uint16_t throttle{};
+    bool brake_analog{};
+    std::uint16_t brake{};
+
+    friend bool operator==(const InputFrame&, const InputFrame&) = default;
+};
+
+class Trace;
+struct LoadResult;
+
+LoadResult load_trace(const std::filesystem::path& path);
+
+// An immutable, run-length encoded trace. frame_at() uses a zero-based frame
+// index and throws std::out_of_range when index >= total_frames().
+class Trace {
+public:
+    Trace() = default;
+
+    [[nodiscard]] bool empty() const noexcept { return total_frames_ == 0; }
+    [[nodiscard]] std::uint64_t total_frames() const noexcept { return total_frames_; }
+    [[nodiscard]] const InputFrame& frame_at(std::uint64_t index) const;
+
+private:
+    struct Run {
+        std::uint64_t end_frame{}; // Exclusive cumulative frame index.
+        InputFrame input{};
+    };
+
+    explicit Trace(std::vector<Run> runs, std::uint64_t total_frames);
+
+    std::vector<Run> runs_;
+    std::uint64_t total_frames_{};
+
+    friend LoadResult load_trace(const std::filesystem::path& path);
+};
+
+// Loading is intentionally non-throwing for file, syntax, and schema errors so
+// a command-line harness can report a diagnostic without unwinding the game.
+struct LoadResult {
+    std::optional<Trace> trace;
+    std::string error;
+
+    [[nodiscard]] explicit operator bool() const noexcept { return trace.has_value(); }
+};
+
+// Streams a trace to <path>.tmp, coalescing consecutive identical frames. The
+// destination is only replaced by finalize(); every other exit removes the
+// temporary file and leaves an existing destination untouched.
+class Recorder {
+public:
+    explicit Recorder(std::filesystem::path path);
+    ~Recorder();
+
+    Recorder(const Recorder&) = delete;
+    Recorder& operator=(const Recorder&) = delete;
+    Recorder(Recorder&&) = delete;
+    Recorder& operator=(Recorder&&) = delete;
+
+    // True only while observations are accepted. It becomes false after either
+    // a failure or successful finalization; error() distinguishes those cases.
+    [[nodiscard]] bool ready() const noexcept;
+    [[nodiscard]] bool observe(const InputFrame& input);
+    [[nodiscard]] bool finalize();
+    [[nodiscard]] std::uint64_t total_frames() const noexcept;
+    [[nodiscard]] const std::string& error() const noexcept;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace lambo::replay
+
+#endif // LAMBO_REPLAY_H

--- a/src/lambo_replay.h
+++ b/src/lambo_replay.h
@@ -31,18 +31,18 @@ struct LoadResult;
 LoadResult load_trace(const std::filesystem::path& path);
 
 // An immutable, run-length encoded trace. frame_at() uses a zero-based frame
-// index and throws std::out_of_range when index >= total_frames().
+// index and returns false when the index is outside the trace.
 class Trace {
 public:
     Trace() = default;
 
     [[nodiscard]] bool empty() const noexcept { return total_frames_ == 0; }
     [[nodiscard]] std::uint64_t total_frames() const noexcept { return total_frames_; }
-    [[nodiscard]] const InputFrame& frame_at(std::uint64_t index) const;
+    [[nodiscard]] bool frame_at(std::uint64_t index, InputFrame& output) const noexcept;
 
 private:
     struct Run {
-        std::uint64_t end_frame{}; // Exclusive cumulative frame index.
+        std::uint64_t end_frame{};
         InputFrame input{};
     };
 
@@ -63,9 +63,7 @@ struct LoadResult {
     [[nodiscard]] explicit operator bool() const noexcept { return trace.has_value(); }
 };
 
-// Streams a trace to <path>.tmp, coalescing consecutive identical frames. The
-// destination is only replaced by finalize(); every other exit removes the
-// temporary file and leaves an existing destination untouched.
+// Finalization is the publication boundary, so an abandoned capture cannot replace a prior trace.
 class Recorder {
 public:
     explicit Recorder(std::filesystem::path path);
@@ -76,8 +74,6 @@ public:
     Recorder(Recorder&&) = delete;
     Recorder& operator=(Recorder&&) = delete;
 
-    // True only while observations are accepted. It becomes false after either
-    // a failure or successful finalization; error() distinguishes those cases.
     [[nodiscard]] bool ready() const noexcept;
     [[nodiscard]] bool observe(const InputFrame& input);
     [[nodiscard]] bool finalize();

--- a/src/lambo_replay.h
+++ b/src/lambo_replay.h
@@ -10,9 +10,7 @@
 
 namespace lambo::replay {
 
-// Controller state observed at one game-dispatch tick. Values deliberately
-// retain the N64 controller's native widths; traces still validate every
-// field before exposing any frame to playback.
+// Native widths preserve guest comparisons; traces validate every field before playback.
 struct InputFrame {
     std::uint16_t buttons{};
     std::int8_t stick_x{};
@@ -30,8 +28,7 @@ struct LoadResult;
 
 LoadResult load_trace(const std::filesystem::path& path);
 
-// An immutable, run-length encoded trace. frame_at() uses a zero-based frame
-// index and returns false when the index is outside the trace.
+// Immutable storage keeps playback stable while the game advances.
 class Trace {
 public:
     Trace() = default;

--- a/src/lambo_replay_runtime.cpp
+++ b/src/lambo_replay_runtime.cpp
@@ -1,0 +1,602 @@
+#include "lambo_replay_runtime.h"
+
+#include <atomic>
+#include <cerrno>
+#include <climits>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+
+#include "lambo_analog_brake.h"
+#include "lambo_analog_throttle.h"
+#include "lambo_input_gate.h"
+#include "lambo_log.h"
+#include "recomp.h"
+
+namespace {
+
+constexpr gpr kGameStateAddress = (gpr)(int32_t)0x800CE6ACu;
+constexpr gpr kPortZeroPadAddress = (gpr)(int32_t)0x800A39E0u;
+constexpr gpr kPortZeroHeldAddress = (gpr)(int32_t)0x800A39F8u;
+constexpr gpr kPortZeroPressedAddress = (gpr)(int32_t)0x800A3A00u;
+
+std::optional<lambo::replay::Trace> g_trace;
+std::unique_ptr<lambo::replay::Recorder> g_recorder;
+
+std::atomic<bool> g_configured{false};
+std::atomic<bool> g_recording{false};
+std::atomic<bool> g_active{false};
+std::atomic<bool> g_owns_input{false};
+std::atomic<bool> g_complete{false};
+std::atomic<bool> g_failed{false};
+std::atomic<bool> g_exit_on_end{true};
+std::atomic<bool> g_block_physical_analog{false};
+std::atomic<std::uint64_t> g_frames_consumed{0};
+std::atomic<std::uint64_t> g_guest_frames_verified{0};
+std::atomic<std::uint64_t> g_dispatcher_ticks{0};
+std::atomic<std::uint64_t> g_load_generation{0};
+
+std::mutex g_input_mutex;
+lambo::replay::InputFrame g_playback_input{};
+lambo::replay::InputFrame g_record_input{};
+std::mutex g_analog_mutex;
+
+std::mutex g_error_mutex;
+std::string g_error;
+std::string g_terminal_reason;
+
+std::mutex g_recorder_mutex;
+bool g_finalized = false;
+
+// The fields below are owned by the game-dispatch thread.
+int g_start_state = 8;
+std::uint64_t g_start_delay = 0;
+std::uint64_t g_eligible_ticks = 0;
+std::uint64_t g_cursor = 0;
+std::uint64_t g_seen_load_generation = 0;
+bool g_frame_staged = false;
+bool g_frame_in_dispatch = false;
+bool g_frame_verified = false;
+bool g_bootstrap_neutral_in_dispatch = false;
+bool g_input_was_suppressed = false;
+
+void set_error(std::string message, std::string reason) {
+    {
+        std::lock_guard lock(g_error_mutex);
+        g_error = std::move(message);
+        g_terminal_reason = std::move(reason);
+    }
+    g_failed.store(true, std::memory_order_release);
+}
+
+bool parse_integer_env(const char* name, long long default_value,
+                       long long minimum, long long maximum, long long& output) {
+    const char* value = std::getenv(name);
+    if (value == nullptr || value[0] == '\0') {
+        output = default_value;
+        return true;
+    }
+    errno = 0;
+    char* end = nullptr;
+    const long long parsed = std::strtoll(value, &end, 10);
+    if (errno == ERANGE || end == value || end == nullptr || *end != '\0' ||
+        parsed < minimum || parsed > maximum) {
+        set_error(std::string(name) + " must be an integer in [" +
+                  std::to_string(minimum) + ", " + std::to_string(maximum) + "]",
+                  "invalid_configuration");
+        return false;
+    }
+    output = parsed;
+    return true;
+}
+
+bool parse_bool_env(const char* name, bool default_value, bool& output) {
+    const char* value = std::getenv(name);
+    if (value == nullptr || value[0] == '\0') {
+        output = default_value;
+        return true;
+    }
+    const std::string text(value);
+    if (text == "1" || text == "true" || text == "TRUE" ||
+        text == "yes" || text == "YES" || text == "on" || text == "ON") {
+        output = true;
+        return true;
+    }
+    if (text == "0" || text == "false" || text == "FALSE" ||
+        text == "no" || text == "NO" || text == "off" || text == "OFF") {
+        output = false;
+        return true;
+    }
+    set_error(std::string(name) + " must be 0/1, true/false, yes/no, or on/off",
+              "invalid_configuration");
+    return false;
+}
+
+void publish_analog_unlocked(const lambo::replay::InputFrame& input) {
+    constexpr float kU16Max = 65535.0f;
+    lambo::analog_throttle::publish(0, input.throttle_analog,
+        static_cast<float>(input.throttle) / kU16Max);
+    lambo::analog_brake::publish(0, input.brake_analog,
+        static_cast<float>(input.brake) / kU16Max);
+}
+
+std::uint16_t normalized_u16(float value) {
+    constexpr float kU16Max = 65535.0f;
+    if (value <= 0.0f) return 0;
+    if (value >= 1.0f) return UINT16_MAX;
+    return static_cast<std::uint16_t>(value * kU16Max + 0.5f);
+}
+
+lambo::replay::InputFrame read_guest_input(std::uint8_t* rdram) {
+    lambo::replay::InputFrame input{};
+    input.buttons = static_cast<std::uint16_t>(MEM_HU(0, kPortZeroPadAddress));
+    input.stick_x = static_cast<std::int8_t>(MEM_B(2, kPortZeroPadAddress));
+    input.stick_y = static_cast<std::int8_t>(MEM_B(3, kPortZeroPadAddress));
+    float analog = 0.0f;
+    input.throttle_analog = lambo::analog_throttle::sample(0, analog);
+    input.throttle = normalized_u16(analog);
+    analog = 0.0f;
+    input.brake_analog = lambo::analog_brake::sample(0, analog);
+    input.brake = normalized_u16(analog);
+    return input;
+}
+
+std::uint16_t button_mask_with_stick(const lambo::replay::InputFrame& input) {
+    std::uint16_t mask = input.buttons;
+    if (input.stick_x < -50) mask |= 0x0200u;
+    if (input.stick_x > 50) mask |= 0x0100u;
+    if (input.stick_y < -50) mask |= 0x0400u;
+    if (input.stick_y > 50) mask |= 0x0800u;
+    return mask;
+}
+
+void write_guest_input(std::uint8_t* rdram, const lambo::replay::InputFrame& input) {
+    MEM_H(0, kPortZeroPadAddress) = input.buttons;
+    MEM_B(2, kPortZeroPadAddress) = input.stick_x;
+    MEM_B(3, kPortZeroPadAddress) = input.stick_y;
+}
+
+bool effective_input_matches(const lambo::replay::InputFrame& expected,
+                             const lambo::replay::InputFrame& observed) {
+    // In aggregate-controller mode the stock decoder may fold stick directions
+    // into the raw button halfword after our staging hook. Accept only that
+    // measured transform; all other fields must remain exact.
+    const bool buttons_match = observed.buttons == expected.buttons ||
+        observed.buttons == button_mask_with_stick(expected);
+    return buttons_match &&
+           expected.stick_x == observed.stick_x &&
+           expected.stick_y == observed.stick_y &&
+           expected.throttle_analog == observed.throttle_analog &&
+           (!expected.throttle_analog || expected.throttle == observed.throttle) &&
+           expected.brake_analog == observed.brake_analog &&
+           (!expected.brake_analog || expected.brake == observed.brake);
+}
+
+void install_playback_frame(std::uint8_t* rdram, std::uint64_t frame,
+                            bool acquire_ownership = false) {
+    const lambo::replay::InputFrame input = g_trace->frame_at(frame);
+    {
+        std::lock_guard lock(g_input_mutex);
+        g_playback_input = input;
+    }
+    std::lock_guard analog_lock(g_analog_mutex);
+    if (acquire_ownership) {
+        g_owns_input.store(true, std::memory_order_release);
+    }
+    publish_analog_unlocked(input);
+    write_guest_input(rdram, input);
+}
+
+void install_neutral_playback_frame(std::uint8_t* rdram = nullptr) {
+    const lambo::replay::InputFrame neutral{};
+    {
+        std::lock_guard lock(g_input_mutex);
+        g_playback_input = neutral;
+    }
+    std::lock_guard analog_lock(g_analog_mutex);
+    publish_analog_unlocked(neutral);
+    if (rdram != nullptr) write_guest_input(rdram, neutral);
+}
+
+void neutralize_guest_for_dispatch(std::uint8_t* rdram) {
+    const lambo::replay::InputFrame neutral{};
+    {
+        std::lock_guard analog_lock(g_analog_mutex);
+        publish_analog_unlocked(neutral);
+    }
+    write_guest_input(rdram, neutral);
+    MEM_H(0, kPortZeroHeldAddress) = 0;
+    MEM_H(0, kPortZeroPressedAddress) = 0;
+}
+
+bool recorder_observe_and_publish(const lambo::replay::InputFrame& input) {
+    std::lock_guard lock(g_recorder_mutex);
+    if (g_recorder == nullptr || g_finalized) return false;
+    if (!g_recorder->observe(input)) {
+        set_error(g_recorder->error(), "record_failed");
+        return false;
+    }
+    // Finalization takes the same mutex. Publish every observable counter
+    // before releasing it so an immediate-exit thread cannot serialize N
+    // frames but snapshot N-1 consumed/verified frames in the result.
+    const std::uint64_t count = g_recorder->total_frames();
+    g_frames_consumed.store(count, std::memory_order_release);
+    g_guest_frames_verified.store(count, std::memory_order_release);
+    return true;
+}
+
+void stage_recording_frame(std::uint8_t* rdram) {
+    // Freeze the final pedal values atomically with the sample. The dispatcher
+    // consumes them later than the controller decoder; without this ownership
+    // window, a main-thread publication could make the trace disagree with the
+    // physics update it claims to represent.
+    {
+        std::lock_guard analog_lock(g_analog_mutex);
+        g_record_input = read_guest_input(rdram);
+        g_block_physical_analog.store(true, std::memory_order_release);
+    }
+    g_frame_staged = true;
+}
+
+void release_recording_frame() {
+    std::lock_guard analog_lock(g_analog_mutex);
+    g_block_physical_analog.store(false, std::memory_order_release);
+}
+
+void update_start_eligibility(std::uint8_t* rdram) {
+    if (g_active.load(std::memory_order_acquire)) return;
+
+    const int state = static_cast<std::int16_t>(MEM_H(0, kGameStateAddress));
+    if (lambo::input_gate::guest_input_suppressed() || state != g_start_state) {
+        g_eligible_ticks = 0;
+        return;
+    }
+    if (g_eligible_ticks != UINT64_MAX) ++g_eligible_ticks;
+}
+
+} // namespace
+
+namespace lambo::replay_runtime {
+
+bool initialize_from_environment() {
+    const char* replay_path = std::getenv("LAMBO_INPUT_REPLAY");
+    const char* record_path = std::getenv("LAMBO_INPUT_RECORD");
+    const bool wants_replay = replay_path != nullptr && replay_path[0] != '\0';
+    const bool wants_record = record_path != nullptr && record_path[0] != '\0';
+
+    if (wants_replay && wants_record) {
+        set_error("LAMBO_INPUT_REPLAY and LAMBO_INPUT_RECORD are mutually exclusive",
+                  "invalid_configuration");
+        return false;
+    }
+    if (!wants_replay && !wants_record) return true;
+
+    long long start_state = 8;
+    long long start_delay = 0;
+    if (!parse_integer_env("LAMBO_INPUT_START_STATE", 8, INT16_MIN, INT16_MAX, start_state) ||
+        !parse_integer_env("LAMBO_INPUT_START_DELAY", 0, 0, LLONG_MAX, start_delay)) {
+        return false;
+    }
+    g_start_state = static_cast<int>(start_state);
+    g_start_delay = static_cast<std::uint64_t>(start_delay);
+    bool exit_on_end = true;
+    if (!parse_bool_env("LAMBO_INPUT_EXIT_ON_END", true, exit_on_end)) return false;
+    g_exit_on_end.store(exit_on_end, std::memory_order_relaxed);
+
+    if (wants_replay) {
+        replay::LoadResult loaded = replay::load_trace(std::filesystem::path(replay_path));
+        if (!loaded) {
+            set_error(loaded.error, "invalid_trace");
+            return false;
+        }
+        g_trace.emplace(std::move(*loaded.trace));
+        LAMBO_LOG_INFO("replay", "armed %llu game frame(s) from %s; start_state=%d delay=%llu\n",
+            static_cast<unsigned long long>(g_trace->total_frames()), replay_path,
+            g_start_state, static_cast<unsigned long long>(g_start_delay));
+    } else {
+        g_recorder = std::make_unique<replay::Recorder>(std::filesystem::path(record_path));
+        if (!g_recorder->ready()) {
+            set_error(g_recorder->error(), "record_open_failed");
+            g_recorder.reset();
+            return false;
+        }
+        g_recording.store(true, std::memory_order_release);
+        LAMBO_LOG_INFO("replay", "recording armed for %s; start_state=%d delay=%llu\n",
+            record_path, g_start_state, static_cast<unsigned long long>(g_start_delay));
+    }
+
+    g_configured.store(true, std::memory_order_release);
+    return true;
+}
+
+std::string last_error() {
+    std::lock_guard lock(g_error_mutex);
+    return g_error;
+}
+
+bool playback_owns_input() {
+    return g_owns_input.load(std::memory_order_acquire);
+}
+
+bool playback_frame(replay::InputFrame& output) {
+    if (!playback_owns_input()) return false;
+    {
+        std::lock_guard lock(g_input_mutex);
+        output = g_playback_input;
+    }
+    // Refresh at the controller-read seam as well as the dispatcher tick. This closes the
+    // one-frame ownership handoff race with the SDL input publisher.
+    {
+        std::lock_guard analog_lock(g_analog_mutex);
+        publish_analog_unlocked(output);
+    }
+    return true;
+}
+
+void publish_physical_analog(bool throttle_analog, float throttle,
+                             bool brake_analog, float brake) {
+    std::lock_guard analog_lock(g_analog_mutex);
+    if (g_owns_input.load(std::memory_order_acquire) ||
+        g_block_physical_analog.load(std::memory_order_acquire)) return;
+    lambo::analog_throttle::publish(0, throttle_analog, throttle);
+    lambo::analog_brake::publish(0, brake_analog, brake);
+}
+
+Status status() {
+    Status output;
+    output.configured = g_configured.load(std::memory_order_acquire);
+    output.recording = g_recording.load(std::memory_order_acquire);
+    output.active = g_active.load(std::memory_order_acquire);
+    output.complete = g_complete.load(std::memory_order_acquire);
+    output.failed = g_failed.load(std::memory_order_acquire);
+    output.exit_on_end = g_exit_on_end.load(std::memory_order_acquire);
+    if (g_trace) {
+        output.total_frames = g_trace->total_frames();
+    } else {
+        std::lock_guard lock(g_recorder_mutex);
+        output.total_frames = g_recorder ? g_recorder->total_frames() : 0;
+    }
+    output.frames_consumed = g_frames_consumed.load(std::memory_order_acquire);
+    output.guest_frames_verified =
+        g_guest_frames_verified.load(std::memory_order_acquire);
+    output.dispatcher_ticks = g_dispatcher_ticks.load(std::memory_order_acquire);
+    return output;
+}
+
+bool should_exit() {
+    if (g_failed.load(std::memory_order_acquire)) return true;
+    return g_complete.load(std::memory_order_acquire) &&
+           g_exit_on_end.load(std::memory_order_acquire);
+}
+
+std::string terminal_reason() {
+    std::lock_guard lock(g_error_mutex);
+    if (!g_terminal_reason.empty()) return g_terminal_reason;
+    if (g_complete.load(std::memory_order_acquire)) return "replay_complete";
+    return {};
+}
+
+void finalize() {
+    std::lock_guard lock(g_recorder_mutex);
+    if (g_finalized) return;
+    g_finalized = true;
+    if (g_recorder == nullptr) return;
+
+    if (!g_recorder->finalize()) {
+        set_error(g_recorder->error(), "record_finalize_failed");
+        return;
+    }
+    LAMBO_LOG_INFO("replay", "recording finalized: %llu game frame(s)\n",
+        static_cast<unsigned long long>(g_recorder->total_frames()));
+}
+
+} // namespace lambo::replay_runtime
+
+extern "C" void lambo_replay_state_loaded() {
+    g_load_generation.fetch_add(1, std::memory_order_acq_rel);
+}
+
+extern "C" void lambo_replay_dispatch_begin(std::uint8_t* rdram) {
+    using namespace lambo::replay_runtime;
+    if (!g_configured.load(std::memory_order_acquire)) return;
+
+    g_dispatcher_ticks.fetch_add(1, std::memory_order_relaxed);
+    if (g_failed.load(std::memory_order_acquire)) return;
+
+    const std::uint64_t load_generation =
+        g_load_generation.load(std::memory_order_acquire);
+    const bool state_was_loaded = load_generation != g_seen_load_generation;
+    const bool input_session_active =
+        g_owns_input.load(std::memory_order_acquire) ||
+        (g_recording.load(std::memory_order_acquire) &&
+         g_active.load(std::memory_order_acquire));
+    if (state_was_loaded && input_session_active) {
+        g_frame_staged = false;
+        g_frame_in_dispatch = false;
+        g_frame_verified = false;
+        if (g_trace) {
+            install_neutral_playback_frame(rdram);
+            set_error("a save-state was loaded after replay playback started",
+                      "state_loaded_during_replay");
+        } else {
+            release_recording_frame();
+            set_error("a save-state was loaded after input recording started",
+                      "state_loaded_during_recording");
+        }
+        return;
+    }
+    g_seen_load_generation = load_generation;
+
+    if (g_complete.load(std::memory_order_acquire)) {
+        // exit_on_end=0 deliberately leaves the game running. The normal pad
+        // decoder executes between dispatcher calls, so reassert neutral input
+        // on every later update rather than letting its final sample leak in.
+        if (g_trace) neutralize_guest_for_dispatch(rdram);
+        return;
+    }
+
+    const bool input_suppressed = lambo::input_gate::guest_input_suppressed();
+    const int state = static_cast<std::int16_t>(MEM_H(0, kGameStateAddress));
+    if (g_trace && !g_active.load(std::memory_order_acquire)) {
+        // Playback frames are staged at the controller-decode seam later in
+        // the outer loop. If a load lands directly on start_state (or the game
+        // was already there), make this one bootstrap update explicitly
+        // neutral instead of consuming stale input from the loaded RAM.
+        if (state_was_loaded && !input_suppressed && state == g_start_state) {
+            g_block_physical_analog.store(true, std::memory_order_release);
+            g_bootstrap_neutral_in_dispatch = true;
+            neutralize_guest_for_dispatch(rdram);
+        }
+        return;
+    }
+
+    if (g_trace && input_suppressed) {
+        // Once active, the overlay pauses movie consumption. This update is
+        // neutral; the staged frame is re-applied after the overlay closes.
+        g_input_was_suppressed = true;
+        neutralize_guest_for_dispatch(rdram);
+        return;
+    }
+
+    if (g_trace && g_input_was_suppressed) {
+        // Suppression can end after the last controller decode. Keep that
+        // transition update neutral, discard only the staging claim (not the
+        // trace cursor), and let the following decoder install the same frame
+        // through the stock held/pressed synthesis path.
+        g_input_was_suppressed = false;
+        g_frame_staged = false;
+        neutralize_guest_for_dispatch(rdram);
+        return;
+    }
+
+    if (!g_active.load(std::memory_order_acquire)) return;
+    if (!g_frame_staged) {
+        if (g_trace) install_neutral_playback_frame(rdram);
+        else release_recording_frame();
+        set_error("an active input session reached the dispatcher without a staged frame",
+                  "replay_clock_error");
+        return;
+    }
+    if (g_frame_in_dispatch) {
+        if (g_trace) install_neutral_playback_frame(rdram);
+        else release_recording_frame();
+        set_error("dispatcher re-entered before the previous input frame completed",
+                  "replay_clock_error");
+        return;
+    }
+
+    lambo::replay::InputFrame expected;
+    if (g_trace) {
+        std::lock_guard lock(g_input_mutex);
+        expected = g_playback_input;
+    } else {
+        expected = g_record_input;
+    }
+    if (!effective_input_matches(expected, read_guest_input(rdram))) {
+        g_frame_staged = false;
+        if (g_trace) install_neutral_playback_frame(rdram);
+        else release_recording_frame();
+        set_error("staged input changed before the game dispatcher consumed it",
+                  "replay_input_overwritten");
+        return;
+    }
+    g_frame_verified = true;
+    g_frame_in_dispatch = true;
+}
+
+extern "C" void lambo_replay_dispatch_end(std::uint8_t* rdram) {
+    if (!g_configured.load(std::memory_order_acquire)) return;
+
+    if (g_bootstrap_neutral_in_dispatch) {
+        g_bootstrap_neutral_in_dispatch = false;
+        release_recording_frame();
+    }
+    update_start_eligibility(rdram);
+    if (g_failed.load(std::memory_order_acquire) || !g_frame_in_dispatch) return;
+
+    g_frame_in_dispatch = false;
+    if (!g_frame_verified) {
+        if (!g_trace) release_recording_frame();
+        set_error("dispatcher completed an unverified input frame", "replay_clock_error");
+        return;
+    }
+    g_frame_verified = false;
+
+    g_frame_staged = false;
+    if (g_trace) {
+        const std::uint64_t consumed = g_cursor + 1;
+        g_frames_consumed.store(consumed, std::memory_order_release);
+        g_guest_frames_verified.store(consumed, std::memory_order_release);
+        if (consumed >= g_trace->total_frames()) {
+            g_complete.store(true, std::memory_order_release);
+            install_neutral_playback_frame();
+            LAMBO_LOG_INFO("replay", "playback complete after %llu game frame(s)\n",
+                static_cast<unsigned long long>(consumed));
+        }
+        return;
+    }
+
+    (void)recorder_observe_and_publish(g_record_input);
+    release_recording_frame();
+}
+
+extern "C" void lambo_replay_input_tick(std::uint8_t* rdram) {
+    using namespace lambo::replay_runtime;
+    if (!g_configured.load(std::memory_order_acquire) ||
+        g_failed.load(std::memory_order_acquire)) return;
+
+    if (g_trace && g_complete.load(std::memory_order_acquire)) {
+        install_neutral_playback_frame(rdram);
+        return;
+    }
+
+    if (g_trace && lambo::input_gate::guest_input_suppressed()) {
+        if (playback_owns_input()) {
+            g_input_was_suppressed = true;
+            neutralize_guest_for_dispatch(rdram);
+        }
+        return;
+    }
+
+    // If an unsuppressed controller decode occurs before the next dispatcher,
+    // it is itself the safe re-staging seam; no extra neutral transition update
+    // is needed.
+    g_input_was_suppressed = false;
+
+    if (!g_active.load(std::memory_order_acquire)) {
+        if (g_eligible_ticks <= g_start_delay) return;
+
+        g_active.store(true, std::memory_order_release);
+        const int state = static_cast<std::int16_t>(MEM_H(0, kGameStateAddress));
+        if (g_trace) {
+            g_cursor = 0;
+            LAMBO_LOG_INFO("replay", "playback started at game state %d\n", state);
+        } else {
+            LAMBO_LOG_INFO("replay", "recording started at game state %d\n", state);
+        }
+    }
+
+    if (g_frame_staged) {
+        // A controller decode happened without an intervening dispatcher.
+        // Preserve the pending frame instead of advancing the trace/recording.
+        if (g_trace) {
+            install_playback_frame(rdram, g_cursor);
+        } else {
+            write_guest_input(rdram, g_record_input);
+            std::lock_guard analog_lock(g_analog_mutex);
+            publish_analog_unlocked(g_record_input);
+        }
+        return;
+    }
+
+    if (g_trace) {
+        g_cursor = g_frames_consumed.load(std::memory_order_acquire);
+        install_playback_frame(rdram, g_cursor, !playback_owns_input());
+    } else {
+        stage_recording_frame(rdram);
+    }
+    g_frame_staged = true;
+}

--- a/src/lambo_replay_runtime.cpp
+++ b/src/lambo_replay_runtime.cpp
@@ -9,10 +9,12 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <utility>
 
 #include "lambo_analog_brake.h"
 #include "lambo_analog_throttle.h"
 #include "lambo_input_gate.h"
+#include "lambo_input_quantize.h"
 #include "lambo_log.h"
 #include "recomp.h"
 
@@ -23,53 +25,70 @@ constexpr gpr kPortZeroPadAddress = (gpr)(int32_t)0x800A39E0u;
 constexpr gpr kPortZeroHeldAddress = (gpr)(int32_t)0x800A39F8u;
 constexpr gpr kPortZeroPressedAddress = (gpr)(int32_t)0x800A3A00u;
 
-std::optional<lambo::replay::Trace> g_trace;
-std::unique_ptr<lambo::replay::Recorder> g_recorder;
+struct RuntimeState {
+    std::mutex mutex;
+    std::optional<lambo::replay::Trace> trace;
+    std::unique_ptr<lambo::replay::Recorder> recorder;
+    lambo::replay::InputFrame playback_input{};
+    lambo::replay::InputFrame record_input{};
+    std::string error;
+    std::string terminal_reason;
 
-std::atomic<bool> g_configured{false};
-std::atomic<bool> g_recording{false};
-std::atomic<bool> g_active{false};
-std::atomic<bool> g_owns_input{false};
-std::atomic<bool> g_complete{false};
-std::atomic<bool> g_failed{false};
-std::atomic<bool> g_exit_on_end{true};
-std::atomic<bool> g_block_physical_analog{false};
-std::atomic<std::uint64_t> g_frames_consumed{0};
-std::atomic<std::uint64_t> g_guest_frames_verified{0};
-std::atomic<std::uint64_t> g_dispatcher_ticks{0};
-std::atomic<std::uint64_t> g_load_generation{0};
+    bool configured{};
+    bool recording{};
+    bool active{};
+    bool owns_input{};
+    bool complete{};
+    bool failed{};
+    bool exit_on_end{true};
+    bool block_physical_analog{};
+    bool finalized{};
 
-std::mutex g_input_mutex;
-lambo::replay::InputFrame g_playback_input{};
-lambo::replay::InputFrame g_record_input{};
-std::mutex g_analog_mutex;
+    std::uint64_t frames_consumed{};
+    std::uint64_t guest_frames_verified{};
+    std::uint64_t dispatcher_ticks{};
+    std::uint64_t load_generation{};
 
-std::mutex g_error_mutex;
-std::string g_error;
-std::string g_terminal_reason;
+    int start_state{8};
+    std::uint64_t start_delay{};
+    std::uint64_t eligible_ticks{};
+    std::uint64_t cursor{};
+    std::uint64_t seen_load_generation{};
+    bool frame_staged{};
+    bool frame_in_dispatch{};
+    bool frame_verified{};
+    bool bootstrap_neutral_in_dispatch{};
+    bool input_was_suppressed{};
+};
 
-std::mutex g_recorder_mutex;
-bool g_finalized = false;
+RuntimeState g_state;
 
-// The fields below are owned by the game-dispatch thread.
-int g_start_state = 8;
-std::uint64_t g_start_delay = 0;
-std::uint64_t g_eligible_ticks = 0;
-std::uint64_t g_cursor = 0;
-std::uint64_t g_seen_load_generation = 0;
-bool g_frame_staged = false;
-bool g_frame_in_dispatch = false;
-bool g_frame_verified = false;
-bool g_bootstrap_neutral_in_dispatch = false;
-bool g_input_was_suppressed = false;
+// A single atomic is reserved for the exceptional path because a guest hook
+// must never let a C++ exception escape into recompiled code.
+std::atomic<bool> g_hook_exception{false};
+
+void set_error_locked(std::string message, std::string reason) {
+    g_state.error = std::move(message);
+    g_state.terminal_reason = std::move(reason);
+    g_state.failed = true;
+}
 
 void set_error(std::string message, std::string reason) {
-    {
-        std::lock_guard lock(g_error_mutex);
-        g_error = std::move(message);
-        g_terminal_reason = std::move(reason);
+    std::lock_guard lock(g_state.mutex);
+    set_error_locked(std::move(message), std::move(reason));
+}
+
+void mark_hook_exception() noexcept {
+    g_hook_exception.store(true, std::memory_order_release);
+}
+
+template <typename Function>
+void invoke_guest_hook(Function&& function) noexcept {
+    try {
+        std::forward<Function>(function)();
+    } catch (...) {
+        mark_hook_exception();
     }
-    g_failed.store(true, std::memory_order_release);
 }
 
 bool parse_integer_env(const char* name, long long default_value,
@@ -115,19 +134,12 @@ bool parse_bool_env(const char* name, bool default_value, bool& output) {
     return false;
 }
 
-void publish_analog_unlocked(const lambo::replay::InputFrame& input) {
+void publish_analog(const lambo::replay::InputFrame& input) {
     constexpr float kU16Max = 65535.0f;
     lambo::analog_throttle::publish(0, input.throttle_analog,
-        static_cast<float>(input.throttle) / kU16Max);
+                                    static_cast<float>(input.throttle) / kU16Max);
     lambo::analog_brake::publish(0, input.brake_analog,
-        static_cast<float>(input.brake) / kU16Max);
-}
-
-std::uint16_t normalized_u16(float value) {
-    constexpr float kU16Max = 65535.0f;
-    if (value <= 0.0f) return 0;
-    if (value >= 1.0f) return UINT16_MAX;
-    return static_cast<std::uint16_t>(value * kU16Max + 0.5f);
+                                 static_cast<float>(input.brake) / kU16Max);
 }
 
 lambo::replay::InputFrame read_guest_input(std::uint8_t* rdram) {
@@ -137,10 +149,10 @@ lambo::replay::InputFrame read_guest_input(std::uint8_t* rdram) {
     input.stick_y = static_cast<std::int8_t>(MEM_B(3, kPortZeroPadAddress));
     float analog = 0.0f;
     input.throttle_analog = lambo::analog_throttle::sample(0, analog);
-    input.throttle = normalized_u16(analog);
+    input.throttle = lambo::input::quantize_normalized(analog);
     analog = 0.0f;
     input.brake_analog = lambo::analog_brake::sample(0, analog);
-    input.brake = normalized_u16(analog);
+    input.brake = lambo::input::quantize_normalized(analog);
     return input;
 }
 
@@ -161,9 +173,6 @@ void write_guest_input(std::uint8_t* rdram, const lambo::replay::InputFrame& inp
 
 bool effective_input_matches(const lambo::replay::InputFrame& expected,
                              const lambo::replay::InputFrame& observed) {
-    // In aggregate-controller mode the stock decoder may fold stick directions
-    // into the raw button halfword after our staging hook. Accept only that
-    // measured transform; all other fields must remain exact.
     const bool buttons_match = observed.buttons == expected.buttons ||
         observed.buttons == button_mask_with_stick(expected);
     return buttons_match &&
@@ -175,86 +184,244 @@ bool effective_input_matches(const lambo::replay::InputFrame& expected,
            (!expected.brake_analog || expected.brake == observed.brake);
 }
 
-void install_playback_frame(std::uint8_t* rdram, std::uint64_t frame,
-                            bool acquire_ownership = false) {
-    const lambo::replay::InputFrame input = g_trace->frame_at(frame);
-    {
-        std::lock_guard lock(g_input_mutex);
-        g_playback_input = input;
-    }
-    std::lock_guard analog_lock(g_analog_mutex);
-    if (acquire_ownership) {
-        g_owns_input.store(true, std::memory_order_release);
-    }
-    publish_analog_unlocked(input);
-    write_guest_input(rdram, input);
-}
-
-void install_neutral_playback_frame(std::uint8_t* rdram = nullptr) {
+void install_neutral_playback_frame_locked(std::uint8_t* rdram = nullptr) {
     const lambo::replay::InputFrame neutral{};
-    {
-        std::lock_guard lock(g_input_mutex);
-        g_playback_input = neutral;
-    }
-    std::lock_guard analog_lock(g_analog_mutex);
-    publish_analog_unlocked(neutral);
+    g_state.playback_input = neutral;
+    publish_analog(neutral);
     if (rdram != nullptr) write_guest_input(rdram, neutral);
 }
 
-void neutralize_guest_for_dispatch(std::uint8_t* rdram) {
-    const lambo::replay::InputFrame neutral{};
-    {
-        std::lock_guard analog_lock(g_analog_mutex);
-        publish_analog_unlocked(neutral);
+bool install_playback_frame_locked(std::uint8_t* rdram, std::uint64_t frame,
+                                   bool acquire_ownership = false) {
+    lambo::replay::InputFrame input{};
+    if (!g_state.trace->frame_at(frame, input)) {
+        install_neutral_playback_frame_locked(rdram);
+        set_error_locked("replay frame " + std::to_string(frame) +
+                             " is outside the loaded trace",
+                         "replay_frame_out_of_range");
+        return false;
     }
+    g_state.playback_input = input;
+    if (acquire_ownership) g_state.owns_input = true;
+    publish_analog(input);
+    write_guest_input(rdram, input);
+    return true;
+}
+
+void neutralize_guest_for_dispatch_locked(std::uint8_t* rdram) {
+    const lambo::replay::InputFrame neutral{};
+    publish_analog(neutral);
     write_guest_input(rdram, neutral);
     MEM_H(0, kPortZeroHeldAddress) = 0;
     MEM_H(0, kPortZeroPressedAddress) = 0;
 }
 
-bool recorder_observe_and_publish(const lambo::replay::InputFrame& input) {
-    std::lock_guard lock(g_recorder_mutex);
-    if (g_recorder == nullptr || g_finalized) return false;
-    if (!g_recorder->observe(input)) {
-        set_error(g_recorder->error(), "record_failed");
+void release_recording_frame_locked() {
+    g_state.block_physical_analog = false;
+}
+
+void stage_recording_frame_locked(std::uint8_t* rdram) {
+    g_state.record_input = read_guest_input(rdram);
+    g_state.block_physical_analog = true;
+    g_state.frame_staged = true;
+}
+
+bool recorder_observe_locked(const lambo::replay::InputFrame& input) {
+    if (g_state.recorder == nullptr || g_state.finalized) {
+        set_error_locked("recording is no longer accepting input", "record_failed");
         return false;
     }
-    // Finalization takes the same mutex. Publish every observable counter
-    // before releasing it so an immediate-exit thread cannot serialize N
-    // frames but snapshot N-1 consumed/verified frames in the result.
-    const std::uint64_t count = g_recorder->total_frames();
-    g_frames_consumed.store(count, std::memory_order_release);
-    g_guest_frames_verified.store(count, std::memory_order_release);
+    if (!g_state.recorder->observe(input)) {
+        set_error_locked(g_state.recorder->error(), "record_failed");
+        return false;
+    }
+    const std::uint64_t count = g_state.recorder->total_frames();
+    g_state.frames_consumed = count;
+    g_state.guest_frames_verified = count;
     return true;
 }
 
-void stage_recording_frame(std::uint8_t* rdram) {
-    // Freeze the final pedal values atomically with the sample. The dispatcher
-    // consumes them later than the controller decoder; without this ownership
-    // window, a main-thread publication could make the trace disagree with the
-    // physics update it claims to represent.
-    {
-        std::lock_guard analog_lock(g_analog_mutex);
-        g_record_input = read_guest_input(rdram);
-        g_block_physical_analog.store(true, std::memory_order_release);
-    }
-    g_frame_staged = true;
-}
-
-void release_recording_frame() {
-    std::lock_guard analog_lock(g_analog_mutex);
-    g_block_physical_analog.store(false, std::memory_order_release);
-}
-
-void update_start_eligibility(std::uint8_t* rdram) {
-    if (g_active.load(std::memory_order_acquire)) return;
-
+void update_start_eligibility_locked(std::uint8_t* rdram) {
+    if (g_state.active) return;
     const int state = static_cast<std::int16_t>(MEM_H(0, kGameStateAddress));
-    if (lambo::input_gate::guest_input_suppressed() || state != g_start_state) {
-        g_eligible_ticks = 0;
+    if (lambo::input_gate::guest_input_suppressed() || state != g_state.start_state) {
+        g_state.eligible_ticks = 0;
         return;
     }
-    if (g_eligible_ticks != UINT64_MAX) ++g_eligible_ticks;
+    if (g_state.eligible_ticks != UINT64_MAX) ++g_state.eligible_ticks;
+    (void)rdram;
+}
+
+void dispatch_begin_impl(std::uint8_t* rdram) {
+    std::lock_guard lock(g_state.mutex);
+    if (!g_state.configured) return;
+
+    ++g_state.dispatcher_ticks;
+    if (g_state.failed) return;
+
+    const bool state_was_loaded = g_state.load_generation != g_state.seen_load_generation;
+    const bool input_session_active = g_state.owns_input ||
+        (g_state.recording && g_state.active);
+    if (state_was_loaded && input_session_active) {
+        g_state.frame_staged = false;
+        g_state.frame_in_dispatch = false;
+        g_state.frame_verified = false;
+        if (g_state.trace) {
+            install_neutral_playback_frame_locked(rdram);
+            set_error_locked("a save-state was loaded after replay playback started",
+                             "state_loaded_during_replay");
+        } else {
+            release_recording_frame_locked();
+            set_error_locked("a save-state was loaded after input recording started",
+                             "state_loaded_during_recording");
+        }
+        return;
+    }
+    g_state.seen_load_generation = g_state.load_generation;
+
+    if (g_state.complete) {
+        if (g_state.trace) neutralize_guest_for_dispatch_locked(rdram);
+        return;
+    }
+
+    const bool input_suppressed = lambo::input_gate::guest_input_suppressed();
+    const int state = static_cast<std::int16_t>(MEM_H(0, kGameStateAddress));
+    if (g_state.trace && !g_state.active) {
+        if (state_was_loaded && !input_suppressed && state == g_state.start_state) {
+            g_state.block_physical_analog = true;
+            g_state.bootstrap_neutral_in_dispatch = true;
+            neutralize_guest_for_dispatch_locked(rdram);
+        }
+        return;
+    }
+
+    if (g_state.trace && input_suppressed) {
+        g_state.input_was_suppressed = true;
+        neutralize_guest_for_dispatch_locked(rdram);
+        return;
+    }
+
+    if (g_state.trace && g_state.input_was_suppressed) {
+        g_state.input_was_suppressed = false;
+        g_state.frame_staged = false;
+        neutralize_guest_for_dispatch_locked(rdram);
+        return;
+    }
+
+    if (!g_state.active) return;
+    if (!g_state.frame_staged) {
+        if (g_state.trace) install_neutral_playback_frame_locked(rdram);
+        else release_recording_frame_locked();
+        set_error_locked("an active input session reached the dispatcher without a staged frame",
+                         "replay_clock_error");
+        return;
+    }
+    if (g_state.frame_in_dispatch) {
+        if (g_state.trace) install_neutral_playback_frame_locked(rdram);
+        else release_recording_frame_locked();
+        set_error_locked("dispatcher re-entered before the previous input frame completed",
+                         "replay_clock_error");
+        return;
+    }
+
+    const lambo::replay::InputFrame expected = g_state.trace
+        ? g_state.playback_input : g_state.record_input;
+    if (!effective_input_matches(expected, read_guest_input(rdram))) {
+        g_state.frame_staged = false;
+        if (g_state.trace) install_neutral_playback_frame_locked(rdram);
+        else release_recording_frame_locked();
+        set_error_locked("staged input changed before the game dispatcher consumed it",
+                         "replay_input_overwritten");
+        return;
+    }
+    g_state.frame_verified = true;
+    g_state.frame_in_dispatch = true;
+}
+
+void dispatch_end_impl(std::uint8_t* rdram) {
+    std::lock_guard lock(g_state.mutex);
+    if (!g_state.configured) return;
+
+    if (g_state.bootstrap_neutral_in_dispatch) {
+        g_state.bootstrap_neutral_in_dispatch = false;
+        release_recording_frame_locked();
+    }
+    update_start_eligibility_locked(rdram);
+    if (g_state.failed || !g_state.frame_in_dispatch) return;
+
+    g_state.frame_in_dispatch = false;
+    if (!g_state.frame_verified) {
+        if (!g_state.trace) release_recording_frame_locked();
+        set_error_locked("dispatcher completed an unverified input frame",
+                         "replay_clock_error");
+        return;
+    }
+    g_state.frame_verified = false;
+    g_state.frame_staged = false;
+
+    if (g_state.trace) {
+        const std::uint64_t consumed = g_state.cursor + 1;
+        g_state.frames_consumed = consumed;
+        g_state.guest_frames_verified = consumed;
+        if (consumed >= g_state.trace->total_frames()) {
+            g_state.complete = true;
+            install_neutral_playback_frame_locked();
+            LAMBO_LOG_INFO("replay", "playback complete after %llu game frame(s)\n",
+                           static_cast<unsigned long long>(consumed));
+        }
+        return;
+    }
+
+    (void)recorder_observe_locked(g_state.record_input);
+    release_recording_frame_locked();
+}
+
+void input_tick_impl(std::uint8_t* rdram) {
+    std::lock_guard lock(g_state.mutex);
+    if (!g_state.configured || g_state.failed) return;
+
+    if (g_state.trace && g_state.complete) {
+        install_neutral_playback_frame_locked(rdram);
+        return;
+    }
+
+    if (g_state.trace && lambo::input_gate::guest_input_suppressed()) {
+        if (g_state.owns_input) {
+            g_state.input_was_suppressed = true;
+            neutralize_guest_for_dispatch_locked(rdram);
+        }
+        return;
+    }
+    g_state.input_was_suppressed = false;
+
+    if (!g_state.active) {
+        if (g_state.eligible_ticks <= g_state.start_delay) return;
+        g_state.active = true;
+        const int state = static_cast<std::int16_t>(MEM_H(0, kGameStateAddress));
+        LAMBO_LOG_INFO("replay", "%s started at game state %d\n",
+                       g_state.trace ? "playback" : "recording", state);
+        if (g_state.trace) g_state.cursor = 0;
+    }
+
+    if (g_state.frame_staged) {
+        if (g_state.trace) {
+            (void)install_playback_frame_locked(rdram, g_state.cursor);
+        } else {
+            write_guest_input(rdram, g_state.record_input);
+            publish_analog(g_state.record_input);
+        }
+        return;
+    }
+
+    if (g_state.trace) {
+        g_state.cursor = g_state.frames_consumed;
+        if (!install_playback_frame_locked(rdram, g_state.cursor, !g_state.owns_input)) {
+            return;
+        }
+        g_state.frame_staged = true;
+    } else {
+        stage_recording_frame_locked(rdram);
+    }
 }
 
 } // namespace
@@ -262,341 +429,168 @@ void update_start_eligibility(std::uint8_t* rdram) {
 namespace lambo::replay_runtime {
 
 bool initialize_from_environment() {
-    const char* replay_path = std::getenv("LAMBO_INPUT_REPLAY");
-    const char* record_path = std::getenv("LAMBO_INPUT_RECORD");
-    const bool wants_replay = replay_path != nullptr && replay_path[0] != '\0';
-    const bool wants_record = record_path != nullptr && record_path[0] != '\0';
-
-    if (wants_replay && wants_record) {
-        set_error("LAMBO_INPUT_REPLAY and LAMBO_INPUT_RECORD are mutually exclusive",
-                  "invalid_configuration");
-        return false;
-    }
-    if (!wants_replay && !wants_record) return true;
-
-    long long start_state = 8;
-    long long start_delay = 0;
-    if (!parse_integer_env("LAMBO_INPUT_START_STATE", 8, INT16_MIN, INT16_MAX, start_state) ||
-        !parse_integer_env("LAMBO_INPUT_START_DELAY", 0, 0, LLONG_MAX, start_delay)) {
-        return false;
-    }
-    g_start_state = static_cast<int>(start_state);
-    g_start_delay = static_cast<std::uint64_t>(start_delay);
-    bool exit_on_end = true;
-    if (!parse_bool_env("LAMBO_INPUT_EXIT_ON_END", true, exit_on_end)) return false;
-    g_exit_on_end.store(exit_on_end, std::memory_order_relaxed);
-
-    if (wants_replay) {
-        replay::LoadResult loaded = replay::load_trace(std::filesystem::path(replay_path));
-        if (!loaded) {
-            set_error(loaded.error, "invalid_trace");
+    try {
+        const char* replay_path = std::getenv("LAMBO_INPUT_REPLAY");
+        const char* record_path = std::getenv("LAMBO_INPUT_RECORD");
+        const bool wants_replay = replay_path != nullptr && replay_path[0] != '\0';
+        const bool wants_record = record_path != nullptr && record_path[0] != '\0';
+        if (wants_replay && wants_record) {
+            set_error("LAMBO_INPUT_REPLAY and LAMBO_INPUT_RECORD are mutually exclusive",
+                      "invalid_configuration");
             return false;
         }
-        g_trace.emplace(std::move(*loaded.trace));
-        LAMBO_LOG_INFO("replay", "armed %llu game frame(s) from %s; start_state=%d delay=%llu\n",
-            static_cast<unsigned long long>(g_trace->total_frames()), replay_path,
-            g_start_state, static_cast<unsigned long long>(g_start_delay));
-    } else {
-        g_recorder = std::make_unique<replay::Recorder>(std::filesystem::path(record_path));
-        if (!g_recorder->ready()) {
-            set_error(g_recorder->error(), "record_open_failed");
-            g_recorder.reset();
+        if (!wants_replay && !wants_record) return true;
+
+        long long start_state = 8;
+        long long start_delay = 0;
+        if (!parse_integer_env("LAMBO_INPUT_START_STATE", 8, INT16_MIN, INT16_MAX,
+                               start_state) ||
+            !parse_integer_env("LAMBO_INPUT_START_DELAY", 0, 0, LLONG_MAX, start_delay)) {
             return false;
         }
-        g_recording.store(true, std::memory_order_release);
-        LAMBO_LOG_INFO("replay", "recording armed for %s; start_state=%d delay=%llu\n",
-            record_path, g_start_state, static_cast<unsigned long long>(g_start_delay));
-    }
+        bool exit_on_end = true;
+        if (!parse_bool_env("LAMBO_INPUT_EXIT_ON_END", true, exit_on_end)) return false;
 
-    g_configured.store(true, std::memory_order_release);
-    return true;
+        std::optional<replay::Trace> trace;
+        std::unique_ptr<replay::Recorder> recorder;
+        if (wants_replay) {
+            replay::LoadResult loaded = replay::load_trace(std::filesystem::path(replay_path));
+            if (!loaded) {
+                set_error(loaded.error, "invalid_trace");
+                return false;
+            }
+            trace.emplace(std::move(*loaded.trace));
+        } else {
+            recorder = std::make_unique<replay::Recorder>(std::filesystem::path(record_path));
+            if (!recorder->ready()) {
+                set_error(recorder->error(), "record_open_failed");
+                return false;
+            }
+        }
+
+        std::lock_guard lock(g_state.mutex);
+        g_state.start_state = static_cast<int>(start_state);
+        g_state.start_delay = static_cast<std::uint64_t>(start_delay);
+        g_state.exit_on_end = exit_on_end;
+        g_state.trace = std::move(trace);
+        g_state.recorder = std::move(recorder);
+        g_state.recording = wants_record;
+        g_state.configured = true;
+        if (g_state.trace) {
+            LAMBO_LOG_INFO("replay", "armed %llu game frame(s) from %s; start_state=%d delay=%llu\n",
+                           static_cast<unsigned long long>(g_state.trace->total_frames()),
+                           replay_path, g_state.start_state,
+                           static_cast<unsigned long long>(g_state.start_delay));
+        } else {
+            LAMBO_LOG_INFO("replay", "recording armed for %s; start_state=%d delay=%llu\n",
+                           record_path, g_state.start_state,
+                           static_cast<unsigned long long>(g_state.start_delay));
+        }
+        return true;
+    } catch (...) {
+        set_error("unexpected exception while initializing replay", "invalid_configuration");
+        return false;
+    }
 }
 
 std::string last_error() {
-    std::lock_guard lock(g_error_mutex);
-    return g_error;
+    if (g_hook_exception.load(std::memory_order_acquire)) {
+        return "replay runtime exception was contained at the guest hook boundary";
+    }
+    std::lock_guard lock(g_state.mutex);
+    return g_state.error;
 }
 
 bool playback_owns_input() {
-    return g_owns_input.load(std::memory_order_acquire);
+    std::lock_guard lock(g_state.mutex);
+    return g_state.owns_input;
 }
 
 bool playback_frame(replay::InputFrame& output) {
-    if (!playback_owns_input()) return false;
-    {
-        std::lock_guard lock(g_input_mutex);
-        output = g_playback_input;
-    }
-    // Refresh at the controller-read seam as well as the dispatcher tick. This closes the
-    // one-frame ownership handoff race with the SDL input publisher.
-    {
-        std::lock_guard analog_lock(g_analog_mutex);
-        publish_analog_unlocked(output);
-    }
+    std::lock_guard lock(g_state.mutex);
+    if (!g_state.owns_input) return false;
+    output = g_state.playback_input;
+    publish_analog(output);
     return true;
 }
 
 void publish_physical_analog(bool throttle_analog, float throttle,
                              bool brake_analog, float brake) {
-    std::lock_guard analog_lock(g_analog_mutex);
-    if (g_owns_input.load(std::memory_order_acquire) ||
-        g_block_physical_analog.load(std::memory_order_acquire)) return;
+    std::lock_guard lock(g_state.mutex);
+    if (g_state.owns_input || g_state.block_physical_analog) return;
     lambo::analog_throttle::publish(0, throttle_analog, throttle);
     lambo::analog_brake::publish(0, brake_analog, brake);
 }
 
 Status status() {
+    std::lock_guard lock(g_state.mutex);
     Status output;
-    output.configured = g_configured.load(std::memory_order_acquire);
-    output.recording = g_recording.load(std::memory_order_acquire);
-    output.active = g_active.load(std::memory_order_acquire);
-    output.complete = g_complete.load(std::memory_order_acquire);
-    output.failed = g_failed.load(std::memory_order_acquire);
-    output.exit_on_end = g_exit_on_end.load(std::memory_order_acquire);
-    if (g_trace) {
-        output.total_frames = g_trace->total_frames();
-    } else {
-        std::lock_guard lock(g_recorder_mutex);
-        output.total_frames = g_recorder ? g_recorder->total_frames() : 0;
-    }
-    output.frames_consumed = g_frames_consumed.load(std::memory_order_acquire);
-    output.guest_frames_verified =
-        g_guest_frames_verified.load(std::memory_order_acquire);
-    output.dispatcher_ticks = g_dispatcher_ticks.load(std::memory_order_acquire);
+    output.configured = g_state.configured;
+    output.recording = g_state.recording;
+    output.active = g_state.active;
+    output.complete = g_state.complete;
+    output.failed = g_state.failed || g_hook_exception.load(std::memory_order_acquire);
+    output.exit_on_end = g_state.exit_on_end;
+    output.total_frames = g_state.trace
+        ? g_state.trace->total_frames()
+        : (g_state.recorder ? g_state.recorder->total_frames() : 0);
+    output.frames_consumed = g_state.frames_consumed;
+    output.guest_frames_verified = g_state.guest_frames_verified;
+    output.dispatcher_ticks = g_state.dispatcher_ticks;
     return output;
 }
 
 bool should_exit() {
-    if (g_failed.load(std::memory_order_acquire)) return true;
-    return g_complete.load(std::memory_order_acquire) &&
-           g_exit_on_end.load(std::memory_order_acquire);
+    if (g_hook_exception.load(std::memory_order_acquire)) return true;
+    std::lock_guard lock(g_state.mutex);
+    return g_state.failed || (g_state.complete && g_state.exit_on_end);
 }
 
 std::string terminal_reason() {
-    std::lock_guard lock(g_error_mutex);
-    if (!g_terminal_reason.empty()) return g_terminal_reason;
-    if (g_complete.load(std::memory_order_acquire)) return "replay_complete";
+    if (g_hook_exception.load(std::memory_order_acquire)) {
+        return "replay_runtime_exception";
+    }
+    std::lock_guard lock(g_state.mutex);
+    if (!g_state.terminal_reason.empty()) return g_state.terminal_reason;
+    if (g_state.complete) return "replay_complete";
     return {};
 }
 
 void finalize() {
-    std::lock_guard lock(g_recorder_mutex);
-    if (g_finalized) return;
-    g_finalized = true;
-    if (g_recorder == nullptr) return;
-
-    if (!g_recorder->finalize()) {
-        set_error(g_recorder->error(), "record_finalize_failed");
-        return;
+    std::lock_guard lock(g_state.mutex);
+    if (g_state.finalized) return;
+    g_state.finalized = true;
+    if (g_state.recorder == nullptr) return;
+    try {
+        if (!g_state.recorder->finalize()) {
+            set_error_locked(g_state.recorder->error(), "record_finalize_failed");
+            return;
+        }
+        LAMBO_LOG_INFO("replay", "recording finalized: %llu game frame(s)\n",
+                       static_cast<unsigned long long>(g_state.recorder->total_frames()));
+    } catch (...) {
+        set_error_locked("unexpected exception while finalizing recording",
+                         "record_finalize_failed");
     }
-    LAMBO_LOG_INFO("replay", "recording finalized: %llu game frame(s)\n",
-        static_cast<unsigned long long>(g_recorder->total_frames()));
 }
 
 } // namespace lambo::replay_runtime
 
-extern "C" void lambo_replay_state_loaded() {
-    g_load_generation.fetch_add(1, std::memory_order_acq_rel);
+extern "C" void lambo_replay_state_loaded() noexcept {
+    invoke_guest_hook([] {
+        std::lock_guard lock(g_state.mutex);
+        ++g_state.load_generation;
+    });
 }
 
-extern "C" void lambo_replay_dispatch_begin(std::uint8_t* rdram) {
-    using namespace lambo::replay_runtime;
-    if (!g_configured.load(std::memory_order_acquire)) return;
-
-    g_dispatcher_ticks.fetch_add(1, std::memory_order_relaxed);
-    if (g_failed.load(std::memory_order_acquire)) return;
-
-    const std::uint64_t load_generation =
-        g_load_generation.load(std::memory_order_acquire);
-    const bool state_was_loaded = load_generation != g_seen_load_generation;
-    const bool input_session_active =
-        g_owns_input.load(std::memory_order_acquire) ||
-        (g_recording.load(std::memory_order_acquire) &&
-         g_active.load(std::memory_order_acquire));
-    if (state_was_loaded && input_session_active) {
-        g_frame_staged = false;
-        g_frame_in_dispatch = false;
-        g_frame_verified = false;
-        if (g_trace) {
-            install_neutral_playback_frame(rdram);
-            set_error("a save-state was loaded after replay playback started",
-                      "state_loaded_during_replay");
-        } else {
-            release_recording_frame();
-            set_error("a save-state was loaded after input recording started",
-                      "state_loaded_during_recording");
-        }
-        return;
-    }
-    g_seen_load_generation = load_generation;
-
-    if (g_complete.load(std::memory_order_acquire)) {
-        // exit_on_end=0 deliberately leaves the game running. The normal pad
-        // decoder executes between dispatcher calls, so reassert neutral input
-        // on every later update rather than letting its final sample leak in.
-        if (g_trace) neutralize_guest_for_dispatch(rdram);
-        return;
-    }
-
-    const bool input_suppressed = lambo::input_gate::guest_input_suppressed();
-    const int state = static_cast<std::int16_t>(MEM_H(0, kGameStateAddress));
-    if (g_trace && !g_active.load(std::memory_order_acquire)) {
-        // Playback frames are staged at the controller-decode seam later in
-        // the outer loop. If a load lands directly on start_state (or the game
-        // was already there), make this one bootstrap update explicitly
-        // neutral instead of consuming stale input from the loaded RAM.
-        if (state_was_loaded && !input_suppressed && state == g_start_state) {
-            g_block_physical_analog.store(true, std::memory_order_release);
-            g_bootstrap_neutral_in_dispatch = true;
-            neutralize_guest_for_dispatch(rdram);
-        }
-        return;
-    }
-
-    if (g_trace && input_suppressed) {
-        // Once active, the overlay pauses movie consumption. This update is
-        // neutral; the staged frame is re-applied after the overlay closes.
-        g_input_was_suppressed = true;
-        neutralize_guest_for_dispatch(rdram);
-        return;
-    }
-
-    if (g_trace && g_input_was_suppressed) {
-        // Suppression can end after the last controller decode. Keep that
-        // transition update neutral, discard only the staging claim (not the
-        // trace cursor), and let the following decoder install the same frame
-        // through the stock held/pressed synthesis path.
-        g_input_was_suppressed = false;
-        g_frame_staged = false;
-        neutralize_guest_for_dispatch(rdram);
-        return;
-    }
-
-    if (!g_active.load(std::memory_order_acquire)) return;
-    if (!g_frame_staged) {
-        if (g_trace) install_neutral_playback_frame(rdram);
-        else release_recording_frame();
-        set_error("an active input session reached the dispatcher without a staged frame",
-                  "replay_clock_error");
-        return;
-    }
-    if (g_frame_in_dispatch) {
-        if (g_trace) install_neutral_playback_frame(rdram);
-        else release_recording_frame();
-        set_error("dispatcher re-entered before the previous input frame completed",
-                  "replay_clock_error");
-        return;
-    }
-
-    lambo::replay::InputFrame expected;
-    if (g_trace) {
-        std::lock_guard lock(g_input_mutex);
-        expected = g_playback_input;
-    } else {
-        expected = g_record_input;
-    }
-    if (!effective_input_matches(expected, read_guest_input(rdram))) {
-        g_frame_staged = false;
-        if (g_trace) install_neutral_playback_frame(rdram);
-        else release_recording_frame();
-        set_error("staged input changed before the game dispatcher consumed it",
-                  "replay_input_overwritten");
-        return;
-    }
-    g_frame_verified = true;
-    g_frame_in_dispatch = true;
+extern "C" void lambo_replay_dispatch_begin(std::uint8_t* rdram) noexcept {
+    invoke_guest_hook([rdram] { dispatch_begin_impl(rdram); });
 }
 
-extern "C" void lambo_replay_dispatch_end(std::uint8_t* rdram) {
-    if (!g_configured.load(std::memory_order_acquire)) return;
-
-    if (g_bootstrap_neutral_in_dispatch) {
-        g_bootstrap_neutral_in_dispatch = false;
-        release_recording_frame();
-    }
-    update_start_eligibility(rdram);
-    if (g_failed.load(std::memory_order_acquire) || !g_frame_in_dispatch) return;
-
-    g_frame_in_dispatch = false;
-    if (!g_frame_verified) {
-        if (!g_trace) release_recording_frame();
-        set_error("dispatcher completed an unverified input frame", "replay_clock_error");
-        return;
-    }
-    g_frame_verified = false;
-
-    g_frame_staged = false;
-    if (g_trace) {
-        const std::uint64_t consumed = g_cursor + 1;
-        g_frames_consumed.store(consumed, std::memory_order_release);
-        g_guest_frames_verified.store(consumed, std::memory_order_release);
-        if (consumed >= g_trace->total_frames()) {
-            g_complete.store(true, std::memory_order_release);
-            install_neutral_playback_frame();
-            LAMBO_LOG_INFO("replay", "playback complete after %llu game frame(s)\n",
-                static_cast<unsigned long long>(consumed));
-        }
-        return;
-    }
-
-    (void)recorder_observe_and_publish(g_record_input);
-    release_recording_frame();
+extern "C" void lambo_replay_dispatch_end(std::uint8_t* rdram) noexcept {
+    invoke_guest_hook([rdram] { dispatch_end_impl(rdram); });
 }
 
-extern "C" void lambo_replay_input_tick(std::uint8_t* rdram) {
-    using namespace lambo::replay_runtime;
-    if (!g_configured.load(std::memory_order_acquire) ||
-        g_failed.load(std::memory_order_acquire)) return;
-
-    if (g_trace && g_complete.load(std::memory_order_acquire)) {
-        install_neutral_playback_frame(rdram);
-        return;
-    }
-
-    if (g_trace && lambo::input_gate::guest_input_suppressed()) {
-        if (playback_owns_input()) {
-            g_input_was_suppressed = true;
-            neutralize_guest_for_dispatch(rdram);
-        }
-        return;
-    }
-
-    // If an unsuppressed controller decode occurs before the next dispatcher,
-    // it is itself the safe re-staging seam; no extra neutral transition update
-    // is needed.
-    g_input_was_suppressed = false;
-
-    if (!g_active.load(std::memory_order_acquire)) {
-        if (g_eligible_ticks <= g_start_delay) return;
-
-        g_active.store(true, std::memory_order_release);
-        const int state = static_cast<std::int16_t>(MEM_H(0, kGameStateAddress));
-        if (g_trace) {
-            g_cursor = 0;
-            LAMBO_LOG_INFO("replay", "playback started at game state %d\n", state);
-        } else {
-            LAMBO_LOG_INFO("replay", "recording started at game state %d\n", state);
-        }
-    }
-
-    if (g_frame_staged) {
-        // A controller decode happened without an intervening dispatcher.
-        // Preserve the pending frame instead of advancing the trace/recording.
-        if (g_trace) {
-            install_playback_frame(rdram, g_cursor);
-        } else {
-            write_guest_input(rdram, g_record_input);
-            std::lock_guard analog_lock(g_analog_mutex);
-            publish_analog_unlocked(g_record_input);
-        }
-        return;
-    }
-
-    if (g_trace) {
-        g_cursor = g_frames_consumed.load(std::memory_order_acquire);
-        install_playback_frame(rdram, g_cursor, !playback_owns_input());
-    } else {
-        stage_recording_frame(rdram);
-    }
-    g_frame_staged = true;
+extern "C" void lambo_replay_input_tick(std::uint8_t* rdram) noexcept {
+    invoke_guest_hook([rdram] { input_tick_impl(rdram); });
 }

--- a/src/lambo_replay_runtime.h
+++ b/src/lambo_replay_runtime.h
@@ -1,0 +1,61 @@
+#ifndef LAMBO_REPLAY_RUNTIME_H
+#define LAMBO_REPLAY_RUNTIME_H
+
+#include <cstdint>
+#include <string>
+
+#include "lambo_replay.h"
+
+namespace lambo::replay_runtime {
+
+struct Status {
+    bool configured{};
+    bool recording{};
+    bool active{};
+    bool complete{};
+    bool failed{};
+    bool exit_on_end{};
+    std::uint64_t total_frames{};
+    std::uint64_t frames_consumed{};
+    std::uint64_t guest_frames_verified{};
+    std::uint64_t dispatcher_ticks{};
+};
+
+// Parse the replay/recording environment before recomp::start creates guest
+// threads. Returns false for an invalid configuration or trace.
+bool initialize_from_environment();
+std::string last_error();
+
+// Playback owns port 0 from its first synchronized frame onward, including the
+// neutral frame after EOF. Before synchronization, normal menu/warp input works.
+bool playback_owns_input();
+bool playback_frame(replay::InputFrame& output);
+
+// Publish both physical pedal channels only if playback has not acquired them.
+// The ownership check and writes are serialized with replay activation so a
+// main-thread sample cannot overwrite frame zero after observing stale ownership.
+void publish_physical_analog(bool throttle_analog, float throttle,
+                             bool brake_analog, float brake);
+
+Status status();
+bool should_exit();
+std::string terminal_reason();
+
+// Flush an active recording. Safe to call more than once from immediate-exit
+// paths; only the first call performs work.
+void finalize();
+
+} // namespace lambo::replay_runtime
+
+// The input hook stages a frame immediately after controller decoding and
+// before the ROM derives its held/pressed masks. The dispatcher hooks verify
+// and delimit the exact subsequent game update that consumes that frame.
+extern "C" void lambo_replay_dispatch_begin(std::uint8_t* rdram);
+extern "C" void lambo_replay_dispatch_end(std::uint8_t* rdram);
+extern "C" void lambo_replay_input_tick(std::uint8_t* rdram);
+
+// A RAM restore cannot rewind host-side replay state. The save-state module
+// reports successful loads so a mid-replay restore becomes an explicit failure.
+extern "C" void lambo_replay_state_loaded();
+
+#endif

--- a/src/lambo_replay_runtime.h
+++ b/src/lambo_replay_runtime.h
@@ -42,9 +42,7 @@ void finalize();
 
 } // namespace lambo::replay_runtime
 
-// The input hook stages a frame immediately after controller decoding and
-// before the ROM derives its held/pressed masks. The dispatcher hooks verify
-// and delimit the exact subsequent game update that consumes that frame.
+// Generated guest calls require a non-throwing hook boundary.
 extern "C" void lambo_replay_dispatch_begin(std::uint8_t* rdram) noexcept;
 extern "C" void lambo_replay_dispatch_end(std::uint8_t* rdram) noexcept;
 extern "C" void lambo_replay_input_tick(std::uint8_t* rdram) noexcept;

--- a/src/lambo_replay_runtime.h
+++ b/src/lambo_replay_runtime.h
@@ -21,13 +21,10 @@ struct Status {
     std::uint64_t dispatcher_ticks{};
 };
 
-// Parse the replay/recording environment before recomp::start creates guest
-// threads. Returns false for an invalid configuration or trace.
 bool initialize_from_environment();
 std::string last_error();
 
-// Playback owns port 0 from its first synchronized frame onward, including the
-// neutral frame after EOF. Before synchronization, normal menu/warp input works.
+// Ownership is acquired only after a synchronized game-clock frame, preserving normal menu input.
 bool playback_owns_input();
 bool playback_frame(replay::InputFrame& output);
 
@@ -41,8 +38,6 @@ Status status();
 bool should_exit();
 std::string terminal_reason();
 
-// Flush an active recording. Safe to call more than once from immediate-exit
-// paths; only the first call performs work.
 void finalize();
 
 } // namespace lambo::replay_runtime
@@ -50,12 +45,12 @@ void finalize();
 // The input hook stages a frame immediately after controller decoding and
 // before the ROM derives its held/pressed masks. The dispatcher hooks verify
 // and delimit the exact subsequent game update that consumes that frame.
-extern "C" void lambo_replay_dispatch_begin(std::uint8_t* rdram);
-extern "C" void lambo_replay_dispatch_end(std::uint8_t* rdram);
-extern "C" void lambo_replay_input_tick(std::uint8_t* rdram);
+extern "C" void lambo_replay_dispatch_begin(std::uint8_t* rdram) noexcept;
+extern "C" void lambo_replay_dispatch_end(std::uint8_t* rdram) noexcept;
+extern "C" void lambo_replay_input_tick(std::uint8_t* rdram) noexcept;
 
 // A RAM restore cannot rewind host-side replay state. The save-state module
 // reports successful loads so a mid-replay restore becomes an explicit failure.
-extern "C" void lambo_replay_state_loaded();
+extern "C" void lambo_replay_state_loaded() noexcept;
 
 #endif

--- a/src/lambo_savestate.c
+++ b/src/lambo_savestate.c
@@ -68,6 +68,10 @@
 // covers them, but any thread the snapshot captured that this process lacks keeps a dangling
 // context and the scheduler would fault on it -- another reason to snapshot only settled scenes.
 extern void ultramodern_relink_thread_contexts(uint8_t* rdram);
+// Host-side replay state is deliberately not part of the RDRAM snapshot. Notify the
+// deterministic input harness so a load can arm an as-yet-unstarted replay, while a
+// mid-replay load is reported as an explicit determinism failure.
+extern void lambo_replay_state_loaded(void);
 
 #define STATE_VAR   0x800CE6ACu       // game-state halfword (see lambo_warp.c cluster map)
 #define RDRAM_SNAP_SIZE 0x800000u     // low 8 MiB = guest-addressable N64 RAM (osMemSize)
@@ -93,6 +97,15 @@ typedef struct {
 #define REQ_SAVE 0x1u
 #define REQ_LOAD 0x2u
 static _Atomic uint32_t g_req;
+static _Atomic int g_env_load_applied;
+static _Atomic int g_env_load_failed;
+
+int lambo_savestate_env_load_applied(void) {
+    return atomic_load_explicit(&g_env_load_applied, memory_order_acquire);
+}
+int lambo_savestate_env_load_failed(void) {
+    return atomic_load_explicit(&g_env_load_failed, memory_order_acquire);
+}
 
 static const char* slot_path(void) {
     const char* p = getenv("LAMBO_STATE_FILE");
@@ -147,30 +160,30 @@ static void do_save(uint8_t* rdram, const char* path) {
 // Load <path> fully into a scratch buffer and validate BEFORE overwriting any live RAM, so
 // a bad/short file aborts the load with the game untouched. Only on full success do we
 // memcpy the payload over rdram[0..8MiB).
-static void do_load(uint8_t* rdram, const char* path) {
+static int do_load(uint8_t* rdram, const char* path) {
     FILE* f = fopen(path, "rb");
     if (f == NULL) {
         LAMBO_LOG("state", "load: cannot open %s\n", path);
-        return;
+        return 0;
     }
     state_header_t h;
     if (fread(&h, 1, sizeof(h), f) != sizeof(h) ||
         memcmp(h.magic, STATE_MAGIC, 8) != 0) {
         LAMBO_LOG("state", "load: %s is not a save-state (bad magic)\n", path);
         fclose(f);
-        return;
+        return 0;
     }
     if (h.version != STATE_VERSION || h.rdram_size != RDRAM_SNAP_SIZE) {
         LAMBO_LOG("state", "load: %s version/size mismatch (v%u size %u)\n",
                 path, h.version, h.rdram_size);
         fclose(f);
-        return;
+        return 0;
     }
     uint8_t* buf = (uint8_t*)malloc(RDRAM_SNAP_SIZE);
     if (buf == NULL) {
         LAMBO_LOG("state", "load: out of memory\n");
         fclose(f);
-        return;
+        return 0;
     }
     size_t got = fread(buf, 1, RDRAM_SNAP_SIZE, f);
     fclose(f);
@@ -178,15 +191,17 @@ static void do_load(uint8_t* rdram, const char* path) {
         LAMBO_LOG("state", "load: %s truncated (%zu/%u bytes)\n",
                 path, got, RDRAM_SNAP_SIZE);
         free(buf);
-        return;
+        return 0;
     }
     memcpy(rdram, buf, RDRAM_SNAP_SIZE);
     free(buf);
     // Repair the native OSThread.context pointers the memcpy just clobbered with the save
     // process's addresses; without this the scheduler dereferences garbage on the next tick.
     ultramodern_relink_thread_contexts(rdram);
+    lambo_replay_state_loaded();
     LAMBO_LOG("state", "loaded %u bytes from %s (state=%u)\n",
             RDRAM_SNAP_SIZE, path, h.state);
+    return 1;
 }
 
 // SDL-thread entry points (edge-detected in main.cpp). Only flip the request bit; the copy
@@ -238,7 +253,11 @@ void lambo_savestate_tick(uint8_t* rdram, recomp_context* ctx) {
         if (load_ticks++ >= load_delay) {
             const char* p = env_load;
             env_load = NULL;      // fire once
-            do_load(rdram, p);
+            if (do_load(rdram, p)) {
+                atomic_store_explicit(&g_env_load_applied, 1, memory_order_release);
+            } else {
+                atomic_store_explicit(&g_env_load_failed, 1, memory_order_release);
+            }
             return;               // don't also process a same-frame save/hotkey request
         }
     }
@@ -259,6 +278,6 @@ void lambo_savestate_tick(uint8_t* rdram, recomp_context* ctx) {
     if (state < 3) return;
     uint32_t req = atomic_exchange_explicit(&g_req, 0, memory_order_relaxed);
     if (req == 0) return;
-    if (req & REQ_LOAD) do_load(rdram, slot_path());   // load wins if both somehow set
+    if (req & REQ_LOAD) (void)do_load(rdram, slot_path()); // load wins if both somehow set
     else if (req & REQ_SAVE) do_save(rdram, slot_path());
 }

--- a/src/lambo_warp.c
+++ b/src/lambo_warp.c
@@ -60,6 +60,35 @@ static const char* const lambo_scene_table[6] = {
 // 16-23 car, 24-27 players. Published by the SDL main thread / env parse,
 // exchanged to 0 by the game-thread tick.
 static _Atomic uint32_t g_warp_request;
+static _Atomic int g_warp_applied;
+static _Atomic int g_warp_failed;
+static _Atomic int g_warp_circuit;
+static _Atomic int g_warp_laps;
+static _Atomic int g_warp_car;
+static _Atomic int g_warp_players;
+static _Atomic int g_warp_mode;
+
+int lambo_warp_env_applied(void) {
+    return atomic_load_explicit(&g_warp_applied, memory_order_acquire);
+}
+int lambo_warp_env_failed(void) {
+    return atomic_load_explicit(&g_warp_failed, memory_order_acquire);
+}
+int lambo_warp_env_circuit(void) {
+    return atomic_load_explicit(&g_warp_circuit, memory_order_relaxed);
+}
+int lambo_warp_env_laps(void) {
+    return atomic_load_explicit(&g_warp_laps, memory_order_relaxed);
+}
+int lambo_warp_env_car(void) {
+    return atomic_load_explicit(&g_warp_car, memory_order_relaxed);
+}
+int lambo_warp_env_players(void) {
+    return atomic_load_explicit(&g_warp_players, memory_order_relaxed);
+}
+int lambo_warp_env_mode(void) {
+    return atomic_load_explicit(&g_warp_mode, memory_order_relaxed);
+}
 
 static uint32_t pack_request(int circuit0, int laps, int car, int players) {
     return 0x80000000u | (uint32_t)(circuit0 & 0xFF) | ((uint32_t)(laps & 0xFF) << 8)
@@ -87,6 +116,7 @@ static void parse_env_request(void) {
         if (p != NULL) p++;
     }
     if (v[0] < 1 || v[0] > 6) {
+        atomic_store_explicit(&g_warp_failed, 1, memory_order_release);
         LAMBO_LOG("warp", "LAMBO_WARP=%s invalid: circuit must be 1-6\n", env);
         return;
     }
@@ -137,6 +167,9 @@ void lambo_warp_tick(uint8_t* rdram, recomp_context* ctx) {
     // for testing the non-arcade HUD variants (issue #42); defaults to single race.
     int mode = MODE_SINGLE_RACE;
     { const char* m = getenv("LAMBO_WARP_MODE"); if (m != NULL) mode = atoi(m); }
+    // Report the exact signed halfword written to guest RAM, even for direct
+    // environment use outside the stricter scenario runner.
+    mode = (int)(int16_t)mode;
     MEM_H(0, (gpr)(int32_t)WARP_PLAYERS)    = (int16_t)players;
     MEM_H(0, (gpr)(int32_t)WARP_TRACK_FLAG) = 1;
     MEM_H(0, (gpr)(int32_t)WARP_MODE)       = (int16_t)mode;
@@ -148,6 +181,13 @@ void lambo_warp_tick(uint8_t* rdram, recomp_context* ctx) {
     func_800676B4(rdram, ctx);
     func_80008ECC(rdram, ctx);
     MEM_H(0, (gpr)(int32_t)WARP_STATE) = 7;
+
+    atomic_store_explicit(&g_warp_circuit, circuit0 + 1, memory_order_relaxed);
+    atomic_store_explicit(&g_warp_laps, laps, memory_order_relaxed);
+    atomic_store_explicit(&g_warp_car, car, memory_order_relaxed);
+    atomic_store_explicit(&g_warp_players, players, memory_order_relaxed);
+    atomic_store_explicit(&g_warp_mode, mode, memory_order_relaxed);
+    atomic_store_explicit(&g_warp_applied, 1, memory_order_release);
 
     LAMBO_LOG("warp", "%s: single race, %d lap(s), car %d, %d player(s) (from state %d)\n",
             lambo_scene_table[circuit0], laps, car, players, state);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,9 +19,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "librecomp/game.hpp"
@@ -53,6 +55,7 @@
 #include "lambo_input_gate.h"
 #include "lambo_analog_throttle.h"
 #include "lambo_analog_brake.h"
+#include "lambo_replay_runtime.h"
 #include "lambo_startup.h"
 #include "controls/lambo_controls_sdl.h"
 #include "ui/lambo_ui.h"
@@ -79,7 +82,14 @@ static std::atomic<bool> g_first_vi{false};
 // smoke test assert the init cascade reaches the title state machine rather than just
 // "didn't crash". See state_probe(). (0 = never read; the cold-boot seed is state 1.)
 static std::atomic<int>  g_max_state{0};
+static std::atomic<int>  g_current_state{0};
+static std::atomic<int>  g_current_menu_screen{-1};
+static std::atomic<int>  g_loaded_circuit{0};
 static std::atomic<int>  g_swaps{0};
+static std::atomic<int>  g_player_vehicle{-1};
+static std::atomic<int>  g_player_speed{0};
+static std::atomic<int>  g_max_abs_player_speed{0};
+static std::atomic<bool> g_termination_started{false};
 
 // LAMBO_CRASH_TEST: when set, the test thread's 2 s sleep must outlast
 // boot_summary_and_exit() so its deliberate crash fires. Disable the VI cap.
@@ -112,6 +122,137 @@ static void thread_create_cb(uint8_t*, recomp_context*) {
     if (n <= 12) LAMBO_LOG("probe", "game thread #%d started (osCreateThread)\n", n);
 }
 
+extern "C" int lambo_warp_env_applied(void);
+extern "C" int lambo_warp_env_failed(void);
+extern "C" int lambo_warp_env_circuit(void);
+extern "C" int lambo_warp_env_laps(void);
+extern "C" int lambo_warp_env_car(void);
+extern "C" int lambo_warp_env_players(void);
+extern "C" int lambo_warp_env_mode(void);
+extern "C" int lambo_savestate_env_load_applied(void);
+extern "C" int lambo_savestate_env_load_failed(void);
+
+// Scenario runners need a machine-readable outcome rather than having to infer success from
+// human-oriented log prose. The artifact is opt-in and atomically published so a killed or
+// crashed process can never leave a plausible-looking partial result.
+static void write_harness_result(const char* reason, int exit_code) {
+    const char* value = std::getenv("LAMBO_HARNESS_RESULT");
+    if (value == nullptr || value[0] == '\0') return;
+
+    const lambo::replay_runtime::Status replay = lambo::replay_runtime::status();
+    auto environment_requested = [](const char* name) {
+        const char* configured = std::getenv(name);
+        return configured != nullptr && configured[0] != '\0';
+    };
+    const bool warp_requested = environment_requested("LAMBO_WARP");
+    const bool state_load_requested = environment_requested("LAMBO_STATE_LOAD");
+    const std::filesystem::path output(value);
+    std::error_code error;
+    if (!output.parent_path().empty()) {
+        std::filesystem::create_directories(output.parent_path(), error);
+        if (error) {
+            LAMBO_LOG_ERROR("harness", "cannot create result directory for %s: %s\n",
+                            value, error.message().c_str());
+            return;
+        }
+    }
+    std::filesystem::path temporary = output;
+    temporary += ".tmp";
+    std::ofstream stream(temporary, std::ios::binary | std::ios::trunc);
+    if (!stream) {
+        LAMBO_LOG_ERROR("harness", "cannot write result file %s\n", value);
+        return;
+    }
+    stream << "{\n"
+           << "  \"schema\": 1,\n"
+           << "  \"outcome\": \"" << (exit_code == 0 ? "passed" : "failed") << "\",\n"
+           << "  \"reason\": \"" << reason << "\",\n"
+           << "  \"exit_code\": " << exit_code << ",\n"
+           << "  \"vis\": " << g_vis.load() << ",\n"
+           << "  \"swaps\": " << g_swaps.load() << ",\n"
+           << "  \"max_state\": " << g_max_state.load() << ",\n"
+           << "  \"final_state\": " << g_current_state.load() << ",\n"
+           << "  \"menu_screen\": " << g_current_menu_screen.load() << ",\n"
+           << "  \"loaded_circuit\": " << g_loaded_circuit.load() << ",\n"
+           << "  \"player_vehicle\": " << g_player_vehicle.load() << ",\n"
+           << "  \"player_speed\": " << g_player_speed.load() << ",\n"
+           << "  \"max_abs_player_speed\": " << g_max_abs_player_speed.load() << ",\n"
+           << "  \"warp\": {\n"
+           << "    \"requested\": " << (warp_requested ? "true" : "false") << ",\n"
+           << "    \"applied\": " << (lambo_warp_env_applied() ? "true" : "false") << ",\n"
+           << "    \"failed\": " << (lambo_warp_env_failed() ? "true" : "false") << ",\n"
+           << "    \"circuit\": " << lambo_warp_env_circuit() << ",\n"
+           << "    \"laps\": " << lambo_warp_env_laps() << ",\n"
+           << "    \"car\": " << lambo_warp_env_car() << ",\n"
+           << "    \"players\": " << lambo_warp_env_players() << ",\n"
+           << "    \"mode\": " << lambo_warp_env_mode() << "\n"
+           << "  },\n"
+           << "  \"state_load\": {\n"
+           << "    \"requested\": " << (state_load_requested ? "true" : "false") << ",\n"
+           << "    \"applied\": "
+           << (lambo_savestate_env_load_applied() ? "true" : "false") << ",\n"
+           << "    \"failed\": "
+           << (lambo_savestate_env_load_failed() ? "true" : "false") << "\n"
+           << "  },\n"
+           << "  \"replay\": {\n"
+           << "    \"configured\": " << (replay.configured ? "true" : "false") << ",\n"
+           << "    \"recording\": " << (replay.recording ? "true" : "false") << ",\n"
+           << "    \"active\": " << (replay.active ? "true" : "false") << ",\n"
+           << "    \"complete\": " << (replay.complete ? "true" : "false") << ",\n"
+           << "    \"failed\": " << (replay.failed ? "true" : "false") << ",\n"
+           << "    \"total_frames\": " << replay.total_frames << ",\n"
+           << "    \"frames_consumed\": " << replay.frames_consumed << ",\n"
+           << "    \"guest_frames_verified\": " << replay.guest_frames_verified << ",\n"
+           << "    \"dispatcher_ticks\": " << replay.dispatcher_ticks << "\n"
+           << "  }\n"
+           << "}\n";
+    stream.close();
+    if (!stream) {
+        LAMBO_LOG_ERROR("harness", "failed while writing result file %s\n", value);
+        return;
+    }
+
+    std::filesystem::rename(temporary, output, error);
+    if (error) {
+        // Windows does not replace an existing destination. Preserve the first rename's
+        // failure semantics, then replace only this explicitly requested harness artifact.
+        error.clear();
+        std::filesystem::remove(output, error);
+        error.clear();
+        std::filesystem::rename(temporary, output, error);
+    }
+    if (error) {
+        LAMBO_LOG_ERROR("harness", "cannot publish result file %s: %s\n",
+                        value, error.message().c_str());
+    }
+}
+
+struct HarnessOutcome {
+    std::string reason;
+    int exit_code;
+};
+
+// VI EOF/max-vis, the watchdog, and a UI close can converge on the immediate
+// exit paths from different native threads. Let exactly one thread publish the
+// result and shut down shared logging/storage; the winner's _Exit terminates
+// any losing waiter a few instructions later.
+static void claim_immediate_exit() {
+    if (!g_termination_started.exchange(true, std::memory_order_acq_rel)) return;
+    for (;;) std::this_thread::yield();
+}
+
+static HarnessOutcome finalize_harness_outcome(const char* reason, int exit_code) {
+    lambo::replay_runtime::finalize();
+    const lambo::replay_runtime::Status replay = lambo::replay_runtime::status();
+    std::string effective_reason = reason;
+    if (replay.failed) {
+        exit_code = 2;
+        const std::string terminal = lambo::replay_runtime::terminal_reason();
+        effective_reason = terminal.empty() ? "replay_failed" : terminal;
+    }
+    return {std::move(effective_reason), exit_code};
+}
+
 // Print the one-line boot summary the runtime guard (tests/pivot/test_boot_smoke.py) parses,
 // then terminate the process immediately. We _Exit instead of returning through
 // recomp::start()'s teardown on purpose: that teardown joins the helper threads and munmaps
@@ -121,16 +262,36 @@ static void thread_create_cb(uint8_t*, recomp_context*) {
 // quitting anyway, so skip the unwind and let process exit tear the game threads down.
     // (Graceful game-thread shutdown is RT64-integration work, #58.)
 [[noreturn]] static void boot_summary_and_exit() {
+    claim_immediate_exit();
     LAMBO_LOG("probe", "boot summary; threads=%d vis=%d first_vi=%d max_state=%d swaps=%d\n",
                  g_threads.load(), g_vis.load(), (int)g_first_vi.load(), g_max_state.load(),
                  g_swaps.load());
+    const HarnessOutcome outcome = finalize_harness_outcome(
+        "max_vis", g_first_vi.load() ? 0 : 2);
+    write_harness_result(outcome.reason.c_str(), outcome.exit_code);
     (void)lambo_pak_storage_flush();
     lambo_log_shutdown();
     std::fflush(nullptr);
-    std::_Exit(g_first_vi.load() ? 0 : 2);
+    std::_Exit(outcome.exit_code);
+}
+
+[[noreturn]] static void harness_summary_and_exit(const char* reason, int exit_code) {
+    claim_immediate_exit();
+    const HarnessOutcome outcome = finalize_harness_outcome(reason, exit_code);
+    LAMBO_LOG("harness", "scenario finished; reason=%s status=%d\n",
+              outcome.reason.c_str(), outcome.exit_code);
+    LAMBO_LOG("probe", "boot summary; threads=%d vis=%d first_vi=%d max_state=%d swaps=%d\n",
+              g_threads.load(), g_vis.load(), (int)g_first_vi.load(), g_max_state.load(),
+              g_swaps.load());
+    write_harness_result(outcome.reason.c_str(), outcome.exit_code);
+    (void)lambo_pak_storage_flush();
+    lambo_log_shutdown();
+    std::fflush(nullptr);
+    std::_Exit(outcome.exit_code);
 }
 
 [[noreturn]] static void application_exit_success() {
+    claim_immediate_exit();
     LAMBO_LOG("probe", "application exit requested; status=success\n");
     // update_gfx_stub runs on librecomp's primary thread, while RT64 invokes the
     // UI render hooks on its presentation thread. Calling ui::shutdown() here
@@ -138,10 +299,12 @@ static void thread_create_cb(uint8_t*, recomp_context*) {
     // down RmlUi while a draw hook can still be using it. This path deliberately
     // terminates the process below, so there is no cleanup benefit that can
     // justify touching either subsystem first.
+    const HarnessOutcome outcome = finalize_harness_outcome("runtime_exit", 0);
+    write_harness_result(outcome.reason.c_str(), outcome.exit_code);
     (void)lambo_pak_storage_flush();
     lambo_log_shutdown();
     std::fflush(nullptr);
-    std::_Exit(0);
+    std::_Exit(outcome.exit_code);
 }
 
 // Set by headless::create_render_context (stub_renderer.cpp) so this retrace hook can reach RDRAM.
@@ -224,7 +387,43 @@ static void state_probe() {
         return (a & 2u) ? (w & 0xFFFF) : ((w >> 16) & 0xFFFF);
     };
     int state = (int)h(0x800CE6AC);
+    // The dispatcher range-checks state-1 < 0x10, so its measured domain is
+    // states 1..16 (plus the cold seed 0). The native VI callback races guest
+    // writes; ignore values outside that domain so a torn sample cannot satisfy
+    // an "at least state N" oracle.
+    if (state < 0 || state > 16) return;
+    g_current_state.store(state, std::memory_order_relaxed);
     if (state > g_max_state.load()) g_max_state.store(state);
+    if (state == 8) {
+        // This is the loader's live zero-based circuit, not the menu cursor
+        // written by the warp hook. Keeping it separately lets a scenario
+        // detect a loader regression that selects the wrong track.
+        const int circuit0 = static_cast<int16_t>(h(0x800CE794u));
+        if (circuit0 >= 0 && circuit0 < 6) {
+            g_loaded_circuit.store(circuit0 + 1, std::memory_order_relaxed);
+        }
+        // Vehicle records and these fields are runtime-verified (see the historical
+        // car-differences instrumentation): +0x0E is the one-based player channel and
+        // +0x90 is the signed speedometer value. Report channel 1 without assuming a
+        // stable vehicle-slot assignment across race modes.
+        constexpr uint32_t kVehicleBase = 0x800B69A8u;
+        constexpr uint32_t kVehicleStride = 0x10Cu;
+        for (int vehicle = 0; vehicle < 6; ++vehicle) {
+            const uint32_t base = kVehicleBase + static_cast<uint32_t>(vehicle) * kVehicleStride;
+            if (static_cast<int16_t>(h(base + 0x0Eu)) != 1) continue;
+            const int speed = static_cast<int32_t>(
+                *(const uint32_t*)(g_lambo_rdram + (base + 0x90u - 0x80000000u)));
+            g_player_vehicle.store(vehicle, std::memory_order_relaxed);
+            g_player_speed.store(speed, std::memory_order_relaxed);
+            const int magnitude = speed == std::numeric_limits<int>::min()
+                ? std::numeric_limits<int>::max() : std::abs(speed);
+            int previous = g_max_abs_player_speed.load(std::memory_order_relaxed);
+            while (magnitude > previous &&
+                   !g_max_abs_player_speed.compare_exchange_weak(
+                       previous, magnitude, std::memory_order_relaxed)) {}
+            break;
+        }
+    }
     static int s_last = -1;
     if (state != s_last) {
         LAMBO_LOG("state", "vi=%d  state=%d (was %d)\n", g_vis.load(), state, s_last);
@@ -246,6 +445,7 @@ static void menu_probe() {
     };
     int scr = (int)(int16_t)h(0x80098562);
     int sub = (int)(int16_t)h(0x80098560);
+    g_current_menu_screen.store(scr, std::memory_order_relaxed);
     static int s_scr = -9999, s_sub = -9999;
     if (scr != s_scr || sub != s_sub) {
         LAMBO_LOG("menu", "vi=%d  screen=%d sub=%d (was %d/%d)\n",
@@ -286,6 +486,12 @@ static void vi_cb() {
     pace_probe(n);
     if ((n % 50) == 0) lambo_thread_trace_dump(n); // THROWAWAY: per-thread recv/send snapshot to find the frozen thread
     if (!g_first_vi.exchange(true)) LAMBO_LOG("probe", "FIRST VI retrace\n");
+    if (lambo::replay_runtime::should_exit()) {
+        const lambo::replay_runtime::Status replay = lambo::replay_runtime::status();
+        const std::string reason = lambo::replay_runtime::terminal_reason();
+        harness_summary_and_exit(reason.empty() ? "replay_failed" : reason.c_str(),
+                                 replay.failed ? 3 : 0);
+    }
     if (n == kQuitAfterVis) {
         LAMBO_LOG("probe", "reached %d VIs; quitting\n", n);
         boot_summary_and_exit();
@@ -663,10 +869,10 @@ static void input_sample() {
     lambo::input_gate::publish_physical_snapshot(gated_snap);
     const float throttle = lambo::input_gate::guest_input_suppressed()
         ? 0.0f : physical_throttle;
-    lambo::analog_throttle::publish(0, analog_mode, throttle);
     const float brake = lambo::input_gate::guest_input_suppressed()
         ? 0.0f : physical_brake;
-    lambo::analog_brake::publish(0, brake_analog_mode, brake);
+    lambo::replay_runtime::publish_physical_analog(
+        analog_mode, throttle, brake_analog_mode, brake);
 }
 
 static void input_poll_stub() {}
@@ -686,6 +892,33 @@ static bool input_get_input(int controller_num, uint16_t* buttons, float* x, flo
     int8_t   sy = (int8_t)((snap >> 24) & 0xFF);
     if (!suppressed && sx == 0) sx = g_held_sx;                  // env stick fills in when live stick idle
     if (!suppressed && sy == 0) sy = g_held_sy;
+
+    // Record/replay uses mapped N64 controls rather than SDL device events. This callback
+    // mirrors the current movie frame into the normal controller response, while the
+    // authoritative injection/recording seam is the game dispatcher in lambo_replay_runtime.
+    auto normalized_u16 = [](float value) -> uint16_t {
+        if (!std::isfinite(value) || value <= 0.0f) return 0;
+        if (value >= 1.0f) return UINT16_MAX;
+        return static_cast<uint16_t>(std::lround(value * static_cast<float>(UINT16_MAX)));
+    };
+    lambo::replay::InputFrame effective{};
+    effective.buttons = b;
+    effective.stick_x = sx;
+    effective.stick_y = sy;
+    float analog_value = 0.0f;
+    effective.throttle_analog = lambo::analog_throttle::sample(0, analog_value);
+    effective.throttle = normalized_u16(analog_value);
+    analog_value = 0.0f;
+    effective.brake_analog = lambo::analog_brake::sample(0, analog_value);
+    effective.brake = normalized_u16(analog_value);
+
+    lambo::replay::InputFrame replay_frame{};
+    if (lambo::replay_runtime::playback_frame(replay_frame)) {
+        effective = replay_frame;
+    }
+    b = effective.buttons;
+    sx = effective.stick_x;
+    sy = effective.stick_y;
     if (buttons) *buttons = b;
     // ultramodern does stick_x = (int8_t)(127 * x), so divide by 127 (NOT N64_STICK_MAX) to
     // preserve our authentic +-80 range through that re-scale instead of re-expanding to +-127.
@@ -926,6 +1159,17 @@ static int application_main(int argc, char** argv) {
     }
     LAMBO_LOG("probe", "ROM validated; rom_hash matches\n");
 
+    if (!lambo::replay_runtime::initialize_from_environment()) {
+        const std::string error = lambo::replay_runtime::last_error();
+        LAMBO_LOG_ERROR("replay", "cannot initialize input record/replay: %s\n", error.c_str());
+        lambo::replay_runtime::finalize();
+        const std::string reason = lambo::replay_runtime::terminal_reason();
+        write_harness_result(reason.empty() ? "invalid_configuration" : reason.c_str(), 2);
+        (void)lambo_pak_storage_flush();
+        lambo_log_shutdown();
+        return 2;
+    }
+
     lambo::StartupMode startup_mode = lambo::startup_mode_from_environment();
     if (startup_mode == lambo::StartupMode::Automatic && lambo::config::show_launcher()) {
         startup_mode = lambo::StartupMode::InteractiveLauncher;
@@ -956,7 +1200,7 @@ static int application_main(int argc, char** argv) {
                          wd_sec, g_threads.load(), g_vis.load(), (int)g_first_vi.load());
             // Exit deterministically (same as the VI-cap path) rather than ultramodern::quit(),
             // whose teardown munmaps RDRAM out from under the live game threads (SIGSEGV race).
-            boot_summary_and_exit();
+            harness_summary_and_exit("watchdog", 2);
         });
         watchdog.detach();
     }
@@ -1049,7 +1293,7 @@ static int application_main(int argc, char** argv) {
     recomp::start(cfg);
     // Reached only via the watchdog quit path (a boot stall before the VI cap): the VI-cap
     // path exits from vi_cb via boot_summary_and_exit() and never returns here.
-    boot_summary_and_exit();
+    harness_summary_and_exit("runtime_return", g_first_vi.load() ? 0 : 2);
 }
 
 #if defined(_WIN32)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,13 +14,14 @@
 #include <chrono>
 #include <cctype>
 #include <cmath>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
-#include <fstream>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <utility>
@@ -55,6 +56,7 @@
 #include "lambo_input_gate.h"
 #include "lambo_analog_throttle.h"
 #include "lambo_analog_brake.h"
+#include "lambo_harness_report.h"
 #include "lambo_replay_runtime.h"
 #include "lambo_startup.h"
 #include "controls/lambo_controls_sdl.h"
@@ -74,22 +76,9 @@ create_render_context(uint8_t* rdram, ultramodern::renderer::WindowHandle window
 int run_lighting_selftest();
 }
 
-// --- probe instrumentation ---------------------------------------------------
-static std::atomic<int>  g_threads{0};
-static std::atomic<int>  g_vis{0};
-static std::atomic<bool> g_first_vi{false};
-// Highest stage3 state-machine value (D_800CE6AC) observed during the run. Lets the boot
-// smoke test assert the init cascade reaches the title state machine rather than just
-// "didn't crash". See state_probe(). (0 = never read; the cold-boot seed is state 1.)
-static std::atomic<int>  g_max_state{0};
-static std::atomic<int>  g_current_state{0};
-static std::atomic<int>  g_current_menu_screen{-1};
-static std::atomic<int>  g_loaded_circuit{0};
-static std::atomic<int>  g_swaps{0};
-static std::atomic<int>  g_player_vehicle{-1};
-static std::atomic<int>  g_player_speed{0};
-static std::atomic<int>  g_max_abs_player_speed{0};
-static std::atomic<bool> g_termination_started{false};
+static std::mutex g_termination_mutex;
+static std::condition_variable g_termination_latch;
+static bool g_termination_claimed = false;
 
 // LAMBO_CRASH_TEST: when set, the test thread's 2 s sleep must outlast
 // boot_summary_and_exit() so its deliberate crash fires. Disable the VI cap.
@@ -118,139 +107,20 @@ static void on_init_cb(uint8_t*, recomp_context*) {
 }
 
 static void thread_create_cb(uint8_t*, recomp_context*) {
-    int n = ++g_threads;
-    if (n <= 12) LAMBO_LOG("probe", "game thread #%d started (osCreateThread)\n", n);
+    lambo::harness::note_thread_created();
 }
-
-extern "C" int lambo_warp_env_applied(void);
-extern "C" int lambo_warp_env_failed(void);
-extern "C" int lambo_warp_env_circuit(void);
-extern "C" int lambo_warp_env_laps(void);
-extern "C" int lambo_warp_env_car(void);
-extern "C" int lambo_warp_env_players(void);
-extern "C" int lambo_warp_env_mode(void);
-extern "C" int lambo_savestate_env_load_applied(void);
-extern "C" int lambo_savestate_env_load_failed(void);
-
-// Scenario runners need a machine-readable outcome rather than having to infer success from
-// human-oriented log prose. The artifact is opt-in and atomically published so a killed or
-// crashed process can never leave a plausible-looking partial result.
-static void write_harness_result(const char* reason, int exit_code) {
-    const char* value = std::getenv("LAMBO_HARNESS_RESULT");
-    if (value == nullptr || value[0] == '\0') return;
-
-    const lambo::replay_runtime::Status replay = lambo::replay_runtime::status();
-    auto environment_requested = [](const char* name) {
-        const char* configured = std::getenv(name);
-        return configured != nullptr && configured[0] != '\0';
-    };
-    const bool warp_requested = environment_requested("LAMBO_WARP");
-    const bool state_load_requested = environment_requested("LAMBO_STATE_LOAD");
-    const std::filesystem::path output(value);
-    std::error_code error;
-    if (!output.parent_path().empty()) {
-        std::filesystem::create_directories(output.parent_path(), error);
-        if (error) {
-            LAMBO_LOG_ERROR("harness", "cannot create result directory for %s: %s\n",
-                            value, error.message().c_str());
-            return;
-        }
-    }
-    std::filesystem::path temporary = output;
-    temporary += ".tmp";
-    std::ofstream stream(temporary, std::ios::binary | std::ios::trunc);
-    if (!stream) {
-        LAMBO_LOG_ERROR("harness", "cannot write result file %s\n", value);
-        return;
-    }
-    stream << "{\n"
-           << "  \"schema\": 1,\n"
-           << "  \"outcome\": \"" << (exit_code == 0 ? "passed" : "failed") << "\",\n"
-           << "  \"reason\": \"" << reason << "\",\n"
-           << "  \"exit_code\": " << exit_code << ",\n"
-           << "  \"vis\": " << g_vis.load() << ",\n"
-           << "  \"swaps\": " << g_swaps.load() << ",\n"
-           << "  \"max_state\": " << g_max_state.load() << ",\n"
-           << "  \"final_state\": " << g_current_state.load() << ",\n"
-           << "  \"menu_screen\": " << g_current_menu_screen.load() << ",\n"
-           << "  \"loaded_circuit\": " << g_loaded_circuit.load() << ",\n"
-           << "  \"player_vehicle\": " << g_player_vehicle.load() << ",\n"
-           << "  \"player_speed\": " << g_player_speed.load() << ",\n"
-           << "  \"max_abs_player_speed\": " << g_max_abs_player_speed.load() << ",\n"
-           << "  \"warp\": {\n"
-           << "    \"requested\": " << (warp_requested ? "true" : "false") << ",\n"
-           << "    \"applied\": " << (lambo_warp_env_applied() ? "true" : "false") << ",\n"
-           << "    \"failed\": " << (lambo_warp_env_failed() ? "true" : "false") << ",\n"
-           << "    \"circuit\": " << lambo_warp_env_circuit() << ",\n"
-           << "    \"laps\": " << lambo_warp_env_laps() << ",\n"
-           << "    \"car\": " << lambo_warp_env_car() << ",\n"
-           << "    \"players\": " << lambo_warp_env_players() << ",\n"
-           << "    \"mode\": " << lambo_warp_env_mode() << "\n"
-           << "  },\n"
-           << "  \"state_load\": {\n"
-           << "    \"requested\": " << (state_load_requested ? "true" : "false") << ",\n"
-           << "    \"applied\": "
-           << (lambo_savestate_env_load_applied() ? "true" : "false") << ",\n"
-           << "    \"failed\": "
-           << (lambo_savestate_env_load_failed() ? "true" : "false") << "\n"
-           << "  },\n"
-           << "  \"replay\": {\n"
-           << "    \"configured\": " << (replay.configured ? "true" : "false") << ",\n"
-           << "    \"recording\": " << (replay.recording ? "true" : "false") << ",\n"
-           << "    \"active\": " << (replay.active ? "true" : "false") << ",\n"
-           << "    \"complete\": " << (replay.complete ? "true" : "false") << ",\n"
-           << "    \"failed\": " << (replay.failed ? "true" : "false") << ",\n"
-           << "    \"total_frames\": " << replay.total_frames << ",\n"
-           << "    \"frames_consumed\": " << replay.frames_consumed << ",\n"
-           << "    \"guest_frames_verified\": " << replay.guest_frames_verified << ",\n"
-           << "    \"dispatcher_ticks\": " << replay.dispatcher_ticks << "\n"
-           << "  }\n"
-           << "}\n";
-    stream.close();
-    if (!stream) {
-        LAMBO_LOG_ERROR("harness", "failed while writing result file %s\n", value);
-        return;
-    }
-
-    std::filesystem::rename(temporary, output, error);
-    if (error) {
-        // Windows does not replace an existing destination. Preserve the first rename's
-        // failure semantics, then replace only this explicitly requested harness artifact.
-        error.clear();
-        std::filesystem::remove(output, error);
-        error.clear();
-        std::filesystem::rename(temporary, output, error);
-    }
-    if (error) {
-        LAMBO_LOG_ERROR("harness", "cannot publish result file %s: %s\n",
-                        value, error.message().c_str());
-    }
-}
-
-struct HarnessOutcome {
-    std::string reason;
-    int exit_code;
-};
 
 // VI EOF/max-vis, the watchdog, and a UI close can converge on the immediate
 // exit paths from different native threads. Let exactly one thread publish the
 // result and shut down shared logging/storage; the winner's _Exit terminates
 // any losing waiter a few instructions later.
 static void claim_immediate_exit() {
-    if (!g_termination_started.exchange(true, std::memory_order_acq_rel)) return;
-    for (;;) std::this_thread::yield();
-}
-
-static HarnessOutcome finalize_harness_outcome(const char* reason, int exit_code) {
-    lambo::replay_runtime::finalize();
-    const lambo::replay_runtime::Status replay = lambo::replay_runtime::status();
-    std::string effective_reason = reason;
-    if (replay.failed) {
-        exit_code = 2;
-        const std::string terminal = lambo::replay_runtime::terminal_reason();
-        effective_reason = terminal.empty() ? "replay_failed" : terminal;
+    std::unique_lock lock(g_termination_mutex);
+    if (!g_termination_claimed) {
+        g_termination_claimed = true;
+        return;
     }
-    return {std::move(effective_reason), exit_code};
+    g_termination_latch.wait(lock, [] { return false; });
 }
 
 // Print the one-line boot summary the runtime guard (tests/pivot/test_boot_smoke.py) parses,
@@ -263,12 +133,11 @@ static HarnessOutcome finalize_harness_outcome(const char* reason, int exit_code
     // (Graceful game-thread shutdown is RT64-integration work, #58.)
 [[noreturn]] static void boot_summary_and_exit() {
     claim_immediate_exit();
-    LAMBO_LOG("probe", "boot summary; threads=%d vis=%d first_vi=%d max_state=%d swaps=%d\n",
-                 g_threads.load(), g_vis.load(), (int)g_first_vi.load(), g_max_state.load(),
-                 g_swaps.load());
-    const HarnessOutcome outcome = finalize_harness_outcome(
-        "max_vis", g_first_vi.load() ? 0 : 2);
-    write_harness_result(outcome.reason.c_str(), outcome.exit_code);
+    lambo::harness::log_boot_summary();
+    const lambo::harness::Snapshot metrics = lambo::harness::snapshot();
+    const lambo::harness::Outcome outcome = lambo::harness::finalize_outcome(
+        "max_vis", metrics.first_vi ? 0 : 2);
+    lambo::harness::write_result(outcome);
     (void)lambo_pak_storage_flush();
     lambo_log_shutdown();
     std::fflush(nullptr);
@@ -277,13 +146,11 @@ static HarnessOutcome finalize_harness_outcome(const char* reason, int exit_code
 
 [[noreturn]] static void harness_summary_and_exit(const char* reason, int exit_code) {
     claim_immediate_exit();
-    const HarnessOutcome outcome = finalize_harness_outcome(reason, exit_code);
+    const lambo::harness::Outcome outcome = lambo::harness::finalize_outcome(reason, exit_code);
     LAMBO_LOG("harness", "scenario finished; reason=%s status=%d\n",
               outcome.reason.c_str(), outcome.exit_code);
-    LAMBO_LOG("probe", "boot summary; threads=%d vis=%d first_vi=%d max_state=%d swaps=%d\n",
-              g_threads.load(), g_vis.load(), (int)g_first_vi.load(), g_max_state.load(),
-              g_swaps.load());
-    write_harness_result(outcome.reason.c_str(), outcome.exit_code);
+    lambo::harness::log_boot_summary();
+    lambo::harness::write_result(outcome);
     (void)lambo_pak_storage_flush();
     lambo_log_shutdown();
     std::fflush(nullptr);
@@ -299,11 +166,12 @@ static HarnessOutcome finalize_harness_outcome(const char* reason, int exit_code
     // down RmlUi while a draw hook can still be using it. This path deliberately
     // terminates the process below, so there is no cleanup benefit that can
     // justify touching either subsystem first.
-    const HarnessOutcome outcome = finalize_harness_outcome("runtime_exit", 0);
-    write_harness_result(outcome.reason.c_str(), outcome.exit_code);
+    const lambo::harness::Outcome outcome = lambo::harness::finalize_outcome("runtime_exit", 0);
+    lambo::harness::write_result(outcome);
     (void)lambo_pak_storage_flush();
     lambo_log_shutdown();
     std::fflush(nullptr);
+    if (outcome.exit_code == 0) std::_Exit(0);
     std::_Exit(outcome.exit_code);
 }
 
@@ -363,129 +231,11 @@ static void promote_vi_context() {
     }
 }
 
-// Stage3 state-machine progression tracker (PERMANENT harness instrumentation, not a
-// throwaway diagnostic). The ROM's per-frame dispatcher (func_800028D0) walks a state
-// register at D_800CE6AC and advances copyright(2)->...->title(6)->demo-race(8). We sample
-// it each VI, record the max reached (g_max_state, asserted by the boot smoke test) and log
-// each transition, so a run reports "stuck vs progressing" instead of just "didn't crash".
-//
-// Addressing (measured 2026-06-28, ares-cross-checked): the register lives at its LITERAL
-// address 0x800CE6AC (NOT the -0xC00 boot shift -- that applies to IPL3-loaded code, not this
-// BSS global; 0x800CDAAC stays 0). ultramodern stores RDRAM so a native u32 load yields the
-// N64 word, but a halfword needs the MEM_H XOR-2 swizzle -- hence the (a&2) extract below,
-// which matches recomp.h's MEM_H exactly. The progression is 0->1->2->3->4->5->6 then (as of
-// 2026-06-28) STUCK at 6 (ares walks 0..6->7->8). The 6->7 advance lives in func_80038D6C
-// (state-6 worker, guest 0x8003816C): the hold counter 0x800985AC expires and the fade
-// D_800A2D08 reaches 0 -- the SAME gate values ares has at state 7 -- yet a hardware watchpoint
-// confirms `state = 7` is never written. Mechanism not yet isolated (the recomp body is
-// auto-generated computed-goto C; -O2 + multithread make gdb line-tracing unreliable). #53.
-static void state_probe() {
-    uint8_t* rdram = g_lambo_rdram;
-    if (rdram == nullptr) return;
-    auto h = [&](uint32_t a) -> uint32_t { // N64 big-endian halfword at literal addr (MEM_H)
-        uint32_t w = *(uint32_t*)(rdram + ((a & ~3u) - 0x80000000u));
-        return (a & 2u) ? (w & 0xFFFF) : ((w >> 16) & 0xFFFF);
-    };
-    int state = (int)h(0x800CE6AC);
-    // The dispatcher range-checks state-1 < 0x10, so its measured domain is
-    // states 1..16 (plus the cold seed 0). The native VI callback races guest
-    // writes; ignore values outside that domain so a torn sample cannot satisfy
-    // an "at least state N" oracle.
-    if (state < 0 || state > 16) return;
-    g_current_state.store(state, std::memory_order_relaxed);
-    if (state > g_max_state.load()) g_max_state.store(state);
-    if (state == 8) {
-        // This is the loader's live zero-based circuit, not the menu cursor
-        // written by the warp hook. Keeping it separately lets a scenario
-        // detect a loader regression that selects the wrong track.
-        const int circuit0 = static_cast<int16_t>(h(0x800CE794u));
-        if (circuit0 >= 0 && circuit0 < 6) {
-            g_loaded_circuit.store(circuit0 + 1, std::memory_order_relaxed);
-        }
-        // Vehicle records and these fields are runtime-verified (see the historical
-        // car-differences instrumentation): +0x0E is the one-based player channel and
-        // +0x90 is the signed speedometer value. Report channel 1 without assuming a
-        // stable vehicle-slot assignment across race modes.
-        constexpr uint32_t kVehicleBase = 0x800B69A8u;
-        constexpr uint32_t kVehicleStride = 0x10Cu;
-        for (int vehicle = 0; vehicle < 6; ++vehicle) {
-            const uint32_t base = kVehicleBase + static_cast<uint32_t>(vehicle) * kVehicleStride;
-            if (static_cast<int16_t>(h(base + 0x0Eu)) != 1) continue;
-            const int speed = static_cast<int32_t>(
-                *(const uint32_t*)(g_lambo_rdram + (base + 0x90u - 0x80000000u)));
-            g_player_vehicle.store(vehicle, std::memory_order_relaxed);
-            g_player_speed.store(speed, std::memory_order_relaxed);
-            const int magnitude = speed == std::numeric_limits<int>::min()
-                ? std::numeric_limits<int>::max() : std::abs(speed);
-            int previous = g_max_abs_player_speed.load(std::memory_order_relaxed);
-            while (magnitude > previous &&
-                   !g_max_abs_player_speed.compare_exchange_weak(
-                       previous, magnitude, std::memory_order_relaxed)) {}
-            break;
-        }
-    }
-    static int s_last = -1;
-    if (state != s_last) {
-        LAMBO_LOG("state", "vi=%d  state=%d (was %d)\n", g_vis.load(), state, s_last);
-        s_last = state;
-    }
-}
-
-// Menu-screen probe (PERMANENT harness instrumentation, same class as state_probe): samples the
-// menu overlay's current-screen id D_80098562 (set by the "request menu screen" API func_800383A8,
-// docs/notes/menu.md) plus its neighbour D_80098560 each VI and logs transitions -- the menu chain
-// (players/mode/series/car/name/pak-message, #69) all runs under top-level state 6, so state_probe
-// alone cannot show menu navigation.
-static void menu_probe() {
-    uint8_t* rdram = g_lambo_rdram;
-    if (rdram == nullptr) return;
-    auto h = [&](uint32_t a) -> uint32_t { // N64 big-endian halfword at literal addr (MEM_H)
-        uint32_t w = *(uint32_t*)(rdram + ((a & ~3u) - 0x80000000u));
-        return (a & 2u) ? (w & 0xFFFF) : ((w >> 16) & 0xFFFF);
-    };
-    int scr = (int)(int16_t)h(0x80098562);
-    int sub = (int)(int16_t)h(0x80098560);
-    g_current_menu_screen.store(scr, std::memory_order_relaxed);
-    static int s_scr = -9999, s_sub = -9999;
-    if (scr != s_scr || sub != s_sub) {
-        LAMBO_LOG("menu", "vi=%d  screen=%d sub=%d (was %d/%d)\n",
-                     g_vis.load(), scr, sub, s_scr, s_sub);
-        s_scr = scr; s_sub = sub;
-    }
-}
-
-// Frame-pace probe (PERMANENT harness instrumentation, same class as state_probe): counts game
-// framebuffer swaps by sampling __osViNext->buffer (ctx at *(0x8008D1A4), buffer field +0x4) once
-// per VI. The scheduler gate admits at most one swap per retrace, so per-VI sampling cannot miss
-// one. Real hardware runs this game at ~30fps = 0.5 swaps/VI (ares state-8 dwell 3094 VIs, W102);
-// ~1.0 swaps/VI means the port is running the game 2x fast (#58 pacing).
-static void pace_probe(int vi_n) {
-    uint8_t* rdram = g_lambo_rdram;
-    if (rdram == nullptr) return;
-    auto gw = [&](uint32_t a) -> uint32_t { return *(uint32_t*)(rdram + (a - 0x80000000u)); };
-    uint32_t next = gw(0x8008D1A4); // __osViNext
-    if (next < 0x80000000u || next >= 0x80800000u) return;
-    uint32_t buf = gw(next + 0x4);
-    static uint32_t s_last_buf = 0;
-    if (buf != s_last_buf) { s_last_buf = buf; g_swaps.fetch_add(1); }
-    if ((vi_n % 600) == 0) {
-        static int s_prev_total = 0;
-        int total = g_swaps.load();
-        LAMBO_LOG("pace", "vi=%d swaps_last_600vi=%d (~%.1f fps)\n",
-                     vi_n, total - s_prev_total, (total - s_prev_total) / 10.0);
-        s_prev_total = total;
-    }
-}
-
 extern "C" void lambo_thread_trace_dump(int vi); // THROWAWAY diag (mesgqueue.cpp), gated by LAMBO_THREAD_TRACE
 static void vi_cb() {
     promote_vi_context();
-    state_probe();
-    menu_probe();
-    int n = ++g_vis;
-    pace_probe(n);
+    const int n = lambo::harness::sample_vi();
     if ((n % 50) == 0) lambo_thread_trace_dump(n); // THROWAWAY: per-thread recv/send snapshot to find the frozen thread
-    if (!g_first_vi.exchange(true)) LAMBO_LOG("probe", "FIRST VI retrace\n");
     if (lambo::replay_runtime::should_exit()) {
         const lambo::replay_runtime::Status replay = lambo::replay_runtime::status();
         const std::string reason = lambo::replay_runtime::terminal_reason();
@@ -883,7 +633,7 @@ static bool input_get_input(int controller_num, uint16_t* buttons, float* x, flo
     uint16_t b = suppressed ? 0 : (uint16_t)(snap & 0xFFFF);
     if (!suppressed) b |= g_held_buttons;                       // env mask is a guest input source
     if (!suppressed && g_pulse_period > 0) {                    // scripted pulse (harness knob)
-        int vi = g_vis.load(std::memory_order_relaxed);
+        const int vi = lambo::harness::vis_count();
         if (vi >= g_pulse_start && ((vi - g_pulse_start) % g_pulse_period) < g_pulse_duty
             && (g_pulse_count == 0 || (vi - g_pulse_start) / g_pulse_period < g_pulse_count))
             b |= g_pulse_buttons;
@@ -893,32 +643,12 @@ static bool input_get_input(int controller_num, uint16_t* buttons, float* x, flo
     if (!suppressed && sx == 0) sx = g_held_sx;                  // env stick fills in when live stick idle
     if (!suppressed && sy == 0) sy = g_held_sy;
 
-    // Record/replay uses mapped N64 controls rather than SDL device events. This callback
-    // mirrors the current movie frame into the normal controller response, while the
-    // authoritative injection/recording seam is the game dispatcher in lambo_replay_runtime.
-    auto normalized_u16 = [](float value) -> uint16_t {
-        if (!std::isfinite(value) || value <= 0.0f) return 0;
-        if (value >= 1.0f) return UINT16_MAX;
-        return static_cast<uint16_t>(std::lround(value * static_cast<float>(UINT16_MAX)));
-    };
-    lambo::replay::InputFrame effective{};
-    effective.buttons = b;
-    effective.stick_x = sx;
-    effective.stick_y = sy;
-    float analog_value = 0.0f;
-    effective.throttle_analog = lambo::analog_throttle::sample(0, analog_value);
-    effective.throttle = normalized_u16(analog_value);
-    analog_value = 0.0f;
-    effective.brake_analog = lambo::analog_brake::sample(0, analog_value);
-    effective.brake = normalized_u16(analog_value);
-
     lambo::replay::InputFrame replay_frame{};
     if (lambo::replay_runtime::playback_frame(replay_frame)) {
-        effective = replay_frame;
+        b = replay_frame.buttons;
+        sx = replay_frame.stick_x;
+        sy = replay_frame.stick_y;
     }
-    b = effective.buttons;
-    sx = effective.stick_x;
-    sy = effective.stick_y;
     if (buttons) *buttons = b;
     // ultramodern does stick_x = (int8_t)(127 * x), so divide by 127 (NOT N64_STICK_MAX) to
     // preserve our authentic +-80 range through that re-scale instead of re-expanding to +-127.
@@ -1164,7 +894,9 @@ static int application_main(int argc, char** argv) {
         LAMBO_LOG_ERROR("replay", "cannot initialize input record/replay: %s\n", error.c_str());
         lambo::replay_runtime::finalize();
         const std::string reason = lambo::replay_runtime::terminal_reason();
-        write_harness_result(reason.empty() ? "invalid_configuration" : reason.c_str(), 2);
+        const lambo::harness::Outcome outcome = lambo::harness::finalize_outcome(
+            reason.empty() ? "invalid_configuration" : reason.c_str(), 2);
+        lambo::harness::write_result(outcome);
         (void)lambo_pak_storage_flush();
         lambo_log_shutdown();
         return 2;
@@ -1196,8 +928,9 @@ static int application_main(int argc, char** argv) {
             if (startup_controller.state() == lambo::StartupState::Exiting) return;
             std::this_thread::sleep_for(std::chrono::seconds(wd_sec));
             if (startup_controller.state() == lambo::StartupState::Exiting) return;
+            const lambo::harness::Snapshot metrics = lambo::harness::snapshot();
             LAMBO_LOG("probe", "WATCHDOG %ds: threads=%d vis=%d first_vi=%d\n",
-                         wd_sec, g_threads.load(), g_vis.load(), (int)g_first_vi.load());
+                      wd_sec, metrics.threads, metrics.vis, static_cast<int>(metrics.first_vi));
             // Exit deterministically (same as the VI-cap path) rather than ultramodern::quit(),
             // whose teardown munmaps RDRAM out from under the live game threads (SIGSEGV race).
             harness_summary_and_exit("watchdog", 2);
@@ -1293,7 +1026,7 @@ static int application_main(int argc, char** argv) {
     recomp::start(cfg);
     // Reached only via the watchdog quit path (a boot stall before the VI cap): the VI-cap
     // path exits from vi_cb via boot_summary_and_exit() and never returns here.
-    harness_summary_and_exit("runtime_return", g_first_vi.load() ? 0 : 2);
+    harness_summary_and_exit("runtime_return", lambo::harness::snapshot().first_vi ? 0 : 2);
 }
 
 #if defined(_WIN32)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,10 +110,7 @@ static void thread_create_cb(uint8_t*, recomp_context*) {
     lambo::harness::note_thread_created();
 }
 
-// VI EOF/max-vis, the watchdog, and a UI close can converge on the immediate
-// exit paths from different native threads. Let exactly one thread publish the
-// result and shut down shared logging/storage; the winner's _Exit terminates
-// any losing waiter a few instructions later.
+// Multiple native threads can request finalization; serialize the publisher.
 static void claim_immediate_exit() {
     std::unique_lock lock(g_termination_mutex);
     if (!g_termination_claimed) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,12 +14,12 @@
 #include <chrono>
 #include <cctype>
 #include <cmath>
-#include <condition_variable>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <latch>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -77,7 +77,7 @@ int run_lighting_selftest();
 }
 
 static std::mutex g_termination_mutex;
-static std::condition_variable g_termination_latch;
+static std::latch g_termination_latch{1};
 static bool g_termination_claimed = false;
 
 // LAMBO_CRASH_TEST: when set, the test thread's 2 s sleep must outlast
@@ -117,7 +117,8 @@ static void claim_immediate_exit() {
         g_termination_claimed = true;
         return;
     }
-    g_termination_latch.wait(lock, [] { return false; });
+    lock.unlock();
+    g_termination_latch.wait();
 }
 
 // Print the one-line boot summary the runtime guard (tests/pivot/test_boot_smoke.py) parses,

--- a/src/stub_renderer.cpp
+++ b/src/stub_renderer.cpp
@@ -1277,20 +1277,23 @@ static bool write_bmp(const char* path, const Framebuffer& fb) {
     *(uint16_t*)(hdr + 26) = 1;       // planes
     *(uint16_t*)(hdr + 28) = 24;      // bpp
     *(uint32_t*)(hdr + 34) = img_size;
-    std::fwrite(hdr, 1, 54, f);
+    bool ok = std::fwrite(hdr, 1, 54, f) == 54;
     std::unique_ptr<uint8_t[]> row = std::make_unique<uint8_t[]>(row_bytes + pad);
     for (int i = 0; i < pad; ++i) row[row_bytes + i] = 0;
-    for (int y = fb.H - 1; y >= 0; --y) {          // bottom-up
+    for (int y = fb.H - 1; ok && y >= 0; --y) {    // bottom-up
         for (int x = 0; x < fb.W; ++x) {
             int idx = y * fb.W + x;
             row[x * 3 + 0] = fb.rgb[idx * 3 + 2];  // B
             row[x * 3 + 1] = fb.rgb[idx * 3 + 1];  // G
             row[x * 3 + 2] = fb.rgb[idx * 3 + 0];  // R
         }
-        std::fwrite(row.get(), 1, row_bytes + pad, f);
+        ok = std::fwrite(row.get(), 1, row_bytes + pad, f) ==
+             static_cast<std::size_t>(row_bytes + pad);
     }
-    std::fclose(f);
-    return true;
+    ok = ok && std::fflush(f) == 0;
+    if (std::fclose(f) != 0) ok = false;
+    if (!ok) std::remove(path);
+    return ok;
 }
 
 struct RenderStats {

--- a/tests/test_game_scenario.py
+++ b/tests/test_game_scenario.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPOSITORY = Path(__file__).resolve().parents[1]
+RUNNER = REPOSITORY / "tools" / "run_game_scenario.py"
+
+FAKE_GAME = r'''#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+import time
+
+if sys.argv[1:] != ["--console", "--verbose"]:
+    print("runner omitted diagnostic CLI flags", file=sys.stderr)
+    raise SystemExit(9)
+
+interesting = {
+    key: value for key, value in os.environ.items()
+    if key.startswith("LAMBO_")
+}
+print(json.dumps(interesting, sort_keys=True))
+
+mode = os.environ.get("FAKE_GAME_MODE", "success")
+if mode == "timeout":
+    time.sleep(10)
+if mode == "missing":
+    raise SystemExit(0)
+
+result_path = pathlib.Path(os.environ["LAMBO_HARNESS_RESULT"])
+if mode == "invalid":
+    result_path.write_text("{ definitely not JSON", encoding="utf-8")
+    raise SystemExit(0)
+
+capture = os.environ.get("LAMBO_DL_RENDER_OUT")
+if capture and mode != "no_capture":
+    capture_path = pathlib.Path(capture)
+    capture_path.parent.mkdir(parents=True, exist_ok=True)
+    header = bytearray(54)
+    header[0:2] = b"BM"
+    header[2:6] = (70).to_bytes(4, "little")
+    header[10:14] = (54).to_bytes(4, "little")
+    header[14:18] = (40).to_bytes(4, "little")
+    header[18:22] = (2).to_bytes(4, "little", signed=True)
+    header[22:26] = (2).to_bytes(4, "little", signed=True)
+    header[26:28] = (1).to_bytes(2, "little")
+    header[28:30] = (24).to_bytes(2, "little")
+    header[34:38] = (16).to_bytes(4, "little")
+    bmp = bytes(header) + bytes(16)
+    if mode == "corrupt_capture":
+        bmp = bmp[:-3]
+    capture_path.write_bytes(bmp)
+    if "LAMBO_DL_RENDER_EVERY" in os.environ:
+        pathlib.Path(str(capture_path) + ".20.bmp").write_bytes(bmp)
+
+warp_text = os.environ.get("LAMBO_WARP")
+warp_values = [0, 0, 0, 0]
+if warp_text:
+    parsed = [int(part) for part in warp_text.split(":")]
+    parsed.extend((3, 0, 1)[len(parsed) - 1:])
+    warp_values = parsed
+replay_requested = "LAMBO_INPUT_REPLAY" in os.environ
+state_load_requested = "LAMBO_STATE_LOAD" in os.environ
+result = {
+    "schema": 1,
+    "outcome": "passed",
+    "reason": "replay_complete",
+    "exit_code": 0,
+    "vis": 240,
+    "swaps": 37,
+    "max_state": 8,
+    "final_state": 8,
+    "menu_screen": -1,
+    "loaded_circuit": warp_values[0] if warp_text else 1,
+    "player_vehicle": 0,
+    "player_speed": -42,
+    "max_abs_player_speed": 73,
+    "warp": {
+        "requested": warp_text is not None,
+        "applied": warp_text is not None,
+        "failed": False,
+        "circuit": warp_values[0],
+        "laps": warp_values[1],
+        "car": warp_values[2],
+        "players": warp_values[3],
+        "mode": int(os.environ.get("LAMBO_WARP_MODE", "2")) if warp_text else 0,
+    },
+    "state_load": {
+        "requested": state_load_requested,
+        "applied": state_load_requested,
+        "failed": False,
+    },
+    "replay": {
+        "configured": replay_requested,
+        "recording": False,
+        "active": replay_requested,
+        "complete": replay_requested,
+        "failed": False,
+        "total_frames": 180 if replay_requested else 0,
+        "frames_consumed": 180 if replay_requested else 0,
+        "guest_frames_verified": 180 if replay_requested else 0,
+        "dispatcher_ticks": 182,
+    },
+}
+if mode == "incomplete":
+    result["reason"] = "max_vis"
+    result["replay"]["active"] = True
+    result["replay"]["complete"] = False
+    result["replay"]["frames_consumed"] = 0
+    result["replay"]["guest_frames_verified"] = 0
+if mode == "partial":
+    result["reason"] = "max_vis"
+    result["replay"]["active"] = True
+    result["replay"]["complete"] = False
+    result["replay"]["frames_consumed"] = 1
+    result["replay"]["guest_frames_verified"] = 1
+if mode == "warp_not_applied":
+    result["warp"]["applied"] = False
+if mode == "warp_wrong_track":
+    result["loaded_circuit"] = 6 if warp_values[0] != 6 else 5
+if mode == "state_load_failed":
+    result["state_load"]["applied"] = False
+    result["state_load"]["failed"] = True
+if mode == "replay_not_started":
+    result["replay"]["active"] = False
+if mode == "guest_unverified":
+    result["replay"]["guest_frames_verified"] = 179
+result_path.write_text(json.dumps(result), encoding="utf-8")
+'''
+
+
+class GameScenarioRunnerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.scenario_directory = self.root / "nested" / "scenarios"
+        self.scenario_directory.mkdir(parents=True)
+        self.fake_game = self.root / "fake_game.py"
+        self.fake_game.write_text(FAKE_GAME, encoding="utf-8")
+        self.artifacts = self.root / "artifacts"
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write_scenario(self, scenario: dict, name: str = "scenario.json") -> Path:
+        path = self.scenario_directory / name
+        path.write_text(json.dumps(scenario), encoding="utf-8")
+        return path
+
+    def run_scenario(
+        self,
+        scenario: dict,
+        *,
+        mode: str = "success",
+        timeout: float | None = None,
+        inherited: dict[str, str] | None = None,
+    ) -> tuple[subprocess.CompletedProcess[str], Path]:
+        scenario_path = self.write_scenario(scenario)
+        environment = os.environ.copy()
+        environment["FAKE_GAME_MODE"] = mode
+        if inherited:
+            environment.update(inherited)
+        command = [
+            sys.executable,
+            str(RUNNER),
+            str(scenario_path),
+            "--exe",
+            str(self.fake_game),
+            "--artifacts-dir",
+            str(self.artifacts),
+        ]
+        if timeout is not None:
+            command.extend(("--timeout", str(timeout)))
+        completed = subprocess.run(
+            command,
+            cwd=self.root,
+            env=environment,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+        artifact_directories = list(self.artifacts.iterdir())
+        self.assertEqual(len(artifact_directories), 1, completed.stdout + completed.stderr)
+        return completed, artifact_directories[0]
+
+    def test_success_isolated_environment_and_relative_paths(self) -> None:
+        replay = self.scenario_directory / "data" / "lap.jsonl"
+        replay.parent.mkdir()
+        replay.write_text('{"schema":1}\n', encoding="utf-8")
+        scenario = {
+            "schema": 1,
+            "name": "complete lap",
+            "warp": "2:3:0:1",
+            "warp_mode": 0,
+            "input": {
+                "replay": "data/lap.jsonl",
+                "start_state": 8,
+                "start_delay": 3,
+                "exit_on_end": True,
+            },
+            "max_vis": 500,
+            "capture": {"path": "captures/finish.bmp", "state": 8, "every": 20},
+            "expect": {
+                "max_state_at_least": 8,
+                "replay_complete": True,
+                "min_swaps": 30,
+                "min_abs_player_speed": 50,
+                "capture": True,
+            },
+        }
+        inherited = {
+            "LAMBO_MODERN_INPUT": "ffff:80:80",
+            "LAMBO_INPUT_PULSE": "1000:1:1",
+            "LAMBO_ANALOG_THROTTLE": "1",
+            "LAMBO_INPUT_REPLAY": "wrong-replay",
+            "LAMBO_STATE_SAVE": "wrong-state",
+            "LAMBO_DL_RENDER_OUT": "wrong-capture",
+            "LAMBO_WARP_MODE": "99",
+            "LAMBO_DRAW_DISTANCE": "999999",
+            "LAMBO_ASSET_DIR": str(self.root / "custom-assets"),
+        }
+
+        completed, artifact = self.run_scenario(scenario, inherited=inherited)
+
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertIn("PASS complete lap", completed.stdout)
+        self.assertIn(f"artifacts={artifact.resolve()}", completed.stdout)
+        environment = json.loads((artifact / "stdout.log").read_text(encoding="utf-8"))
+        staged_replay = artifact / "fixtures" / "input-replay.jsonl"
+        self.assertEqual(Path(environment["LAMBO_INPUT_REPLAY"]), staged_replay.resolve())
+        self.assertEqual(staged_replay.read_bytes(), replay.read_bytes())
+        self.assertEqual(
+            Path(environment["LAMBO_DL_RENDER_OUT"]),
+            (artifact / "capture" / "captures" / "finish.bmp").resolve(),
+        )
+        self.assertEqual(environment["LAMBO_INPUT_START_STATE"], "8")
+        self.assertEqual(environment["LAMBO_INPUT_START_DELAY"], "3")
+        self.assertEqual(environment["LAMBO_INPUT_EXIT_ON_END"], "1")
+        self.assertEqual(environment["LAMBO_MODERN_MAX_VIS"], "500")
+        self.assertEqual(environment["LAMBO_HEADLESS"], "1")
+        self.assertEqual(environment["LAMBO_WARP_MODE"], "0")
+        self.assertNotIn("LAMBO_MODERN_INPUT", environment)
+        self.assertNotIn("LAMBO_INPUT_PULSE", environment)
+        self.assertNotIn("LAMBO_ANALOG_THROTTLE", environment)
+        self.assertNotIn("LAMBO_STATE_SAVE", environment)
+        self.assertNotIn("LAMBO_DRAW_DISTANCE", environment)
+        self.assertEqual(environment["LAMBO_ASSET_DIR"], inherited["LAMBO_ASSET_DIR"])
+        self.assertEqual(Path(environment["LAMBO_GRAPHICS_CONFIG"]).parent, artifact.resolve())
+        self.assertEqual(Path(environment["LAMBO_CONTROLLER_PAK_FILE"]).parent, artifact.resolve())
+        self.assertEqual(Path(environment["LAMBO_HARNESS_RESULT"]).parent, artifact.resolve())
+        self.assertTrue((artifact / "capture" / "captures" / "finish.bmp").is_file())
+        self.assertTrue(
+            (artifact / "capture" / "captures" / "finish.bmp.20.bmp").is_file()
+        )
+        self.assertTrue((artifact / "scenario.json").is_file())
+        resolved = json.loads((artifact / "scenario-resolved.json").read_text(encoding="utf-8"))
+        self.assertEqual(resolved["input"]["replay"], "fixtures/input-replay.jsonl")
+        fixture_manifest = json.loads(
+            (artifact / "fixtures-manifest.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(fixture_manifest["fixtures"][0]["role"], "input-replay")
+        self.assertEqual(fixture_manifest["fixtures"][0]["bytes"], replay.stat().st_size)
+        self.assertEqual(len(fixture_manifest["fixtures"][0]["sha256"]), 64)
+        self.assertTrue((artifact / "harness-environment.json").is_file())
+        recorded_environment = json.loads(
+            (artifact / "harness-environment.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(
+            recorded_environment["LAMBO_ASSET_DIR"], inherited["LAMBO_ASSET_DIR"]
+        )
+        runner_result = json.loads((artifact / "runner-result.json").read_text(encoding="utf-8"))
+        self.assertEqual(runner_result["outcome"], "passed")
+        self.assertEqual(runner_result["failures"], [])
+        self.assertEqual(runner_result["native_result"]["max_state"], 8)
+
+    def test_oracle_failure_is_nonzero_and_preserves_result(self) -> None:
+        scenario = {
+            "schema": 1,
+            "name": "too shallow",
+            "max_vis": 300,
+            "expect": {
+                "max_state_at_least": 9,
+                "min_swaps": 40,
+                "min_abs_player_speed": 80,
+            },
+        }
+
+        completed, artifact = self.run_scenario(scenario)
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("FAIL too shallow", completed.stdout)
+        self.assertIn("max_state 8 < 9", completed.stdout)
+        self.assertIn("swaps 37 < 40", completed.stdout)
+        self.assertIn("max_abs_player_speed 73 < 80", completed.stdout)
+        self.assertTrue((artifact / "harness-result.json").is_file())
+        self.assertTrue((artifact / "stdout.log").is_file())
+        runner_result = json.loads((artifact / "runner-result.json").read_text(encoding="utf-8"))
+        self.assertEqual(runner_result["outcome"], "failed")
+        self.assertIn("max_state 8 < 9", runner_result["failures"])
+
+    def test_replay_completion_is_required_by_default(self) -> None:
+        replay = self.scenario_directory / "lap.jsonl"
+        replay.write_text('{"schema":1}\n', encoding="utf-8")
+        scenario = {
+            "schema": 1,
+            "name": "unfinished lap",
+            "input": {"replay": "lap.jsonl"},
+        }
+
+        completed, _ = self.run_scenario(scenario, mode="incomplete")
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("replay_complete was false, expected true", completed.stdout)
+
+    def test_non_exiting_replay_must_still_consume_a_frame(self) -> None:
+        replay = self.scenario_directory / "lap.jsonl"
+        replay.write_text('{"schema":1}\n', encoding="utf-8")
+        scenario = {
+            "schema": 1,
+            "name": "zero progress",
+            "input": {"replay": "lap.jsonl", "exit_on_end": False},
+        }
+
+        completed, _ = self.run_scenario(scenario, mode="incomplete")
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("native replay did not consume any frames", completed.stdout)
+
+    def test_partial_replay_requires_an_explicit_expectation(self) -> None:
+        replay = self.scenario_directory / "lap.jsonl"
+        replay.write_text('{"schema":1}\n', encoding="utf-8")
+        scenario = {
+            "schema": 1,
+            "name": "partial progress",
+            "input": {"replay": "lap.jsonl", "exit_on_end": False},
+        }
+
+        completed, _ = self.run_scenario(scenario, mode="partial")
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("replay_complete was false, expected true", completed.stdout)
+
+        self.artifacts = self.root / "artifacts-explicit-partial"
+        scenario["expect"] = {"replay_complete": False}
+        completed, _ = self.run_scenario(scenario, mode="partial")
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+
+    def test_missing_and_invalid_native_results_fail_cleanly(self) -> None:
+        scenario = {"schema": 1, "name": "bad native result", "max_vis": 20}
+        for mode, expected in (
+            ("missing", "native result file is missing"),
+            ("invalid", "native result JSON is invalid"),
+        ):
+            with self.subTest(mode=mode):
+                # Each subtest needs its own artifact parent because run_scenario
+                # deliberately asserts that one unique run directory was made.
+                self.artifacts = self.root / f"artifacts-{mode}"
+                completed, artifact = self.run_scenario(scenario, mode=mode)
+                self.assertNotEqual(completed.returncode, 0)
+                self.assertIn(expected, completed.stdout)
+                self.assertTrue((artifact / "stdout.log").is_file())
+                runner_result = json.loads(
+                    (artifact / "runner-result.json").read_text(encoding="utf-8")
+                )
+                self.assertEqual(runner_result["outcome"], "failed")
+                self.assertIsNone(runner_result["native_result"])
+
+    def test_timeout_kills_the_process_and_preserves_logs(self) -> None:
+        scenario = {"schema": 1, "name": "hung game", "max_vis": 20}
+
+        completed, artifact = self.run_scenario(scenario, mode="timeout", timeout=0.2)
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("timed out after 0.2s", completed.stdout)
+        self.assertTrue((artifact / "stdout.log").is_file())
+        runner_result = json.loads((artifact / "runner-result.json").read_text(encoding="utf-8"))
+        self.assertTrue(runner_result["timed_out"])
+
+    def test_stale_capture_cannot_satisfy_capture_oracle(self) -> None:
+        capture = self.scenario_directory / "captures" / "frame.bmp"
+        capture.parent.mkdir()
+        capture.write_bytes(b"old capture")
+        numbered = Path(str(capture) + ".12.bmp")
+        numbered.write_bytes(b"old numbered capture")
+        scenario = {
+            "schema": 1,
+            "name": "fresh capture required",
+            "capture": {"path": "captures/frame.bmp", "state": 8, "every": 12},
+            "expect": {"capture": True},
+        }
+
+        completed, artifact = self.run_scenario(scenario, mode="no_capture")
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("capture was not written", completed.stdout)
+        self.assertEqual(capture.read_bytes(), b"old capture")
+        self.assertEqual(numbered.read_bytes(), b"old numbered capture")
+        self.assertFalse((artifact / "capture" / "captures" / "frame.bmp").exists())
+
+    def test_truncated_bmp_cannot_satisfy_capture_oracle(self) -> None:
+        scenario = {
+            "schema": 1,
+            "name": "complete capture required",
+            "capture": {"path": "frame.bmp", "state": 8},
+            "expect": {"capture": True},
+        }
+
+        completed, artifact = self.run_scenario(scenario, mode="corrupt_capture")
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("complete renderer BMP", completed.stdout)
+        self.assertTrue((artifact / "capture" / "frame.bmp").is_file())
+
+    def test_native_bootstrap_and_replay_claims_are_verified(self) -> None:
+        replay = self.scenario_directory / "lap.jsonl"
+        replay.write_text('{"schema":1}\n', encoding="utf-8")
+        cases = (
+            (
+                "warp_not_applied",
+                {"schema": 1, "name": "warp claim", "warp": 1,
+                 "input": {"replay": "lap.jsonl"}},
+                "native warp was requested but never applied",
+            ),
+            (
+                "warp_wrong_track",
+                {"schema": 1, "name": "track claim", "warp": 1,
+                 "input": {"replay": "lap.jsonl"}},
+                "loaded_circuit 6 != requested 1",
+            ),
+            (
+                "replay_not_started",
+                {"schema": 1, "name": "start claim", "warp": 1,
+                 "input": {"replay": "lap.jsonl"}},
+                "native replay never became active",
+            ),
+            (
+                "guest_unverified",
+                {"schema": 1, "name": "guest claim", "warp": 1,
+                 "input": {"replay": "lap.jsonl"}},
+                "guest input verification covered 179/180 consumed frames",
+            ),
+        )
+        for index, (mode, scenario, expected) in enumerate(cases):
+            with self.subTest(mode=mode):
+                self.artifacts = self.root / f"artifacts-claim-{index}"
+                completed, _ = self.run_scenario(scenario, mode=mode)
+                self.assertNotEqual(completed.returncode, 0)
+                self.assertIn(expected, completed.stdout)
+
+    def test_failed_state_load_is_not_mistaken_for_race_state(self) -> None:
+        state = self.scenario_directory / "grid.lstate"
+        replay = self.scenario_directory / "lap.jsonl"
+        state.write_bytes(b"state")
+        replay.write_text('{"schema":1}\n', encoding="utf-8")
+        scenario = {
+            "schema": 1,
+            "name": "state claim",
+            "state_load": "grid.lstate",
+            "input": {"replay": "lap.jsonl"},
+        }
+
+        completed, _ = self.run_scenario(scenario, mode="state_load_failed")
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("native state load reported failure", completed.stdout)
+        self.assertIn("native state load was requested but never applied", completed.stdout)
+
+    def test_warp_and_state_load_are_rejected_as_ambiguous(self) -> None:
+        state = self.scenario_directory / "grid.lstate"
+        state.write_bytes(b"state")
+        scenario_path = self.write_scenario(
+            {"schema": 1, "name": "ambiguous", "warp": 1, "state_load": "grid.lstate"}
+        )
+        completed = subprocess.run(
+            [sys.executable, str(RUNNER), str(scenario_path), "--exe", str(self.fake_game)],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("alternative bootstraps", completed.stderr)
+
+    def test_unknown_scenario_field_is_rejected(self) -> None:
+        scenario_path = self.write_scenario(
+            {"schema": 1, "name": "typo", "expect": {"min_swap": 1}}
+        )
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER),
+                str(scenario_path),
+                "--exe",
+                str(self.fake_game),
+                "--artifacts-dir",
+                str(self.artifacts),
+            ],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("scenario.expect has unknown field(s): min_swap", completed.stderr)
+        self.assertFalse(self.artifacts.exists())
+
+    def test_unverified_warp_mode_is_rejected(self) -> None:
+        scenario_path = self.write_scenario(
+            {"schema": 1, "name": "bad mode", "warp": 1, "warp_mode": 99}
+        )
+        completed = subprocess.run(
+            [sys.executable, str(RUNNER), str(scenario_path), "--exe", str(self.fake_game)],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("0 (time trial) or 2 (single race)", completed.stderr)
+
+    def test_unverified_warp_car_is_rejected(self) -> None:
+        scenario_path = self.write_scenario(
+            {"schema": 1, "name": "bad car", "warp": "1:3:1:1"}
+        )
+        completed = subprocess.run(
+            [sys.executable, str(RUNNER), str(scenario_path), "--exe", str(self.fake_game)],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("runtime-verified car 0", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_game_scenario.py
+++ b/tests/test_game_scenario.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 from __future__ import annotations
 
 import json
@@ -7,553 +5,143 @@ import os
 import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 
 
-REPOSITORY = Path(__file__).resolve().parents[1]
-RUNNER = REPOSITORY / "tools" / "run_game_scenario.py"
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "tools" / "run_game_scenario.py"
 
-FAKE_GAME = r'''#!/usr/bin/env python3
-import json
-import os
-import pathlib
-import sys
-import time
-
-if sys.argv[1:] != ["--console", "--verbose"]:
-    print("runner omitted diagnostic CLI flags", file=sys.stderr)
-    raise SystemExit(9)
-
-interesting = {
-    key: value for key, value in os.environ.items()
-    if key.startswith("LAMBO_")
-}
-print(json.dumps(interesting, sort_keys=True))
-
-mode = os.environ.get("FAKE_GAME_MODE", "success")
-if mode == "timeout":
-    time.sleep(10)
-if mode == "missing":
+FAKE_GAME = textwrap.dedent(
+    r'''
+    import json, os, sys, time
+    from pathlib import Path
+    mode = os.environ.get("FAKE_GAME_MODE", "success")
+    if mode == "timeout":
+        time.sleep(30)
+        raise SystemExit(0)
+    result_path = os.environ["LAMBO_HARNESS_RESULT"]
+    print(json.dumps({k: v for k, v in os.environ.items() if k.startswith("LAMBO_")}))
+    if mode == "missing":
+        raise SystemExit(0)
+    if mode == "invalid":
+        open(result_path, "w", encoding="utf-8").write("{")
+        raise SystemExit(0)
+    warp = os.environ.get("LAMBO_WARP")
+    warp_values = [int(part) for part in warp.split(":")] if warp else [0, 0, 0, 0]
+    warp_values += [3, 0, 1][:4-len(warp_values)]
+    replay = bool(os.environ.get("LAMBO_INPUT_REPLAY"))
+    complete = replay and mode != "partial" and mode != "incomplete"
+    result = {
+        "schema": 1, "outcome": "passed", "reason": "fake", "exit_code": 0,
+        "vis": 40, "swaps": 50, "max_state": 8, "final_state": 8,
+        "menu_screen": 0, "loaded_circuit": warp_values[0],
+        "player_vehicle": 0, "player_speed": 70, "max_abs_player_speed": 70,
+        "warp": {"requested": bool(warp), "applied": bool(warp), "failed": False,
+                  "circuit": warp_values[0], "laps": warp_values[1],
+                  "car": warp_values[2], "players": warp_values[3],
+                  "mode": int(os.environ.get("LAMBO_WARP_MODE", "2"))},
+        "state_load": {"requested": bool(os.environ.get("LAMBO_STATE_LOAD")),
+                       "applied": bool(os.environ.get("LAMBO_STATE_LOAD")), "failed": False},
+        "replay": {"configured": replay, "recording": False, "active": replay,
+                    "complete": complete, "failed": False, "total_frames": 3 if replay else 0,
+                    "frames_consumed": 3 if complete else (1 if replay else 0),
+                    "guest_frames_verified": 3 if complete else (1 if replay else 0),
+                    "dispatcher_ticks": 4},
+    }
+    capture = os.environ.get("LAMBO_DL_RENDER_OUT")
+    if capture and mode != "no_capture":
+        Path(capture).parent.mkdir(parents=True, exist_ok=True)
+        Path(capture).write_bytes(b"fake capture")
+    Path(result_path).write_text(json.dumps(result), encoding="utf-8")
     raise SystemExit(0)
-
-result_path = pathlib.Path(os.environ["LAMBO_HARNESS_RESULT"])
-if mode == "invalid":
-    result_path.write_text("{ definitely not JSON", encoding="utf-8")
-    raise SystemExit(0)
-
-capture = os.environ.get("LAMBO_DL_RENDER_OUT")
-if capture and mode != "no_capture":
-    capture_path = pathlib.Path(capture)
-    capture_path.parent.mkdir(parents=True, exist_ok=True)
-    header = bytearray(54)
-    header[0:2] = b"BM"
-    header[2:6] = (70).to_bytes(4, "little")
-    header[10:14] = (54).to_bytes(4, "little")
-    header[14:18] = (40).to_bytes(4, "little")
-    header[18:22] = (2).to_bytes(4, "little", signed=True)
-    header[22:26] = (2).to_bytes(4, "little", signed=True)
-    header[26:28] = (1).to_bytes(2, "little")
-    header[28:30] = (24).to_bytes(2, "little")
-    header[34:38] = (16).to_bytes(4, "little")
-    bmp = bytes(header) + bytes(16)
-    if mode == "corrupt_capture":
-        bmp = bmp[:-3]
-    capture_path.write_bytes(bmp)
-    if "LAMBO_DL_RENDER_EVERY" in os.environ:
-        pathlib.Path(str(capture_path) + ".20.bmp").write_bytes(bmp)
-
-warp_text = os.environ.get("LAMBO_WARP")
-warp_values = [0, 0, 0, 0]
-if warp_text:
-    parsed = [int(part) for part in warp_text.split(":")]
-    parsed.extend((3, 0, 1)[len(parsed) - 1:])
-    warp_values = parsed
-replay_requested = "LAMBO_INPUT_REPLAY" in os.environ
-state_load_requested = "LAMBO_STATE_LOAD" in os.environ
-result = {
-    "schema": 1,
-    "outcome": "passed",
-    "reason": "replay_complete",
-    "exit_code": 0,
-    "vis": 240,
-    "swaps": 37,
-    "max_state": 8,
-    "final_state": 8,
-    "menu_screen": -1,
-    "loaded_circuit": warp_values[0] if warp_text else 1,
-    "player_vehicle": 0,
-    "player_speed": -42,
-    "max_abs_player_speed": 73,
-    "warp": {
-        "requested": warp_text is not None,
-        "applied": warp_text is not None,
-        "failed": False,
-        "circuit": warp_values[0],
-        "laps": warp_values[1],
-        "car": warp_values[2],
-        "players": warp_values[3],
-        "mode": int(os.environ.get("LAMBO_WARP_MODE", "2")) if warp_text else 0,
-    },
-    "state_load": {
-        "requested": state_load_requested,
-        "applied": state_load_requested,
-        "failed": False,
-    },
-    "replay": {
-        "configured": replay_requested,
-        "recording": False,
-        "active": replay_requested,
-        "complete": replay_requested,
-        "failed": False,
-        "total_frames": 180 if replay_requested else 0,
-        "frames_consumed": 180 if replay_requested else 0,
-        "guest_frames_verified": 180 if replay_requested else 0,
-        "dispatcher_ticks": 182,
-    },
-}
-if mode == "incomplete":
-    result["reason"] = "max_vis"
-    result["replay"]["active"] = True
-    result["replay"]["complete"] = False
-    result["replay"]["frames_consumed"] = 0
-    result["replay"]["guest_frames_verified"] = 0
-if mode == "partial":
-    result["reason"] = "max_vis"
-    result["replay"]["active"] = True
-    result["replay"]["complete"] = False
-    result["replay"]["frames_consumed"] = 1
-    result["replay"]["guest_frames_verified"] = 1
-if mode == "warp_not_applied":
-    result["warp"]["applied"] = False
-if mode == "warp_wrong_track":
-    result["loaded_circuit"] = 6 if warp_values[0] != 6 else 5
-if mode == "state_load_failed":
-    result["state_load"]["applied"] = False
-    result["state_load"]["failed"] = True
-if mode == "replay_not_started":
-    result["replay"]["active"] = False
-if mode == "guest_unverified":
-    result["replay"]["guest_frames_verified"] = 179
-result_path.write_text(json.dumps(result), encoding="utf-8")
-'''
+    '''
+)
 
 
-class GameScenarioRunnerTests(unittest.TestCase):
+class ScenarioRunnerTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.temporary = tempfile.TemporaryDirectory()
-        self.root = Path(self.temporary.name)
-        self.scenario_directory = self.root / "nested" / "scenarios"
-        self.scenario_directory.mkdir(parents=True)
-        self.fake_game = self.root / "fake_game.py"
-        self.fake_game.write_text(FAKE_GAME, encoding="utf-8")
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.scenario_dir = self.root / "scenarios"
+        self.scenario_dir.mkdir()
+        self.fake = self.root / "fake_game.py"
+        self.fake.write_text(FAKE_GAME, encoding="utf-8")
         self.artifacts = self.root / "artifacts"
 
     def tearDown(self) -> None:
-        self.temporary.cleanup()
+        self.temp.cleanup()
 
-    def write_scenario(self, scenario: dict, name: str = "scenario.json") -> Path:
-        path = self.scenario_directory / name
-        path.write_text(json.dumps(scenario), encoding="utf-8")
-        return path
-
-    def run_scenario(
-        self,
-        scenario: dict,
-        *,
-        mode: str = "success",
-        timeout: float | None = None,
-        inherited: dict[str, str] | None = None,
-    ) -> tuple[subprocess.CompletedProcess[str], Path]:
-        scenario_path = self.write_scenario(scenario)
+    def run_scenario(self, document: dict, mode: str = "success", timeout: float | None = None):
+        scenario = self.scenario_dir / "scenario.json"
+        scenario.write_text(json.dumps(document), encoding="utf-8")
         environment = os.environ.copy()
         environment["FAKE_GAME_MODE"] = mode
-        if inherited:
-            environment.update(inherited)
-        command = [
-            sys.executable,
-            str(RUNNER),
-            str(scenario_path),
-            "--exe",
-            str(self.fake_game),
-            "--artifacts-dir",
-            str(self.artifacts),
-        ]
+        environment["LAMBO_MODERN_INPUT"] = "stale-input"
+        command = [sys.executable, str(RUNNER), str(scenario), "--exe", str(self.fake),
+                   "--artifacts-dir", str(self.artifacts)]
         if timeout is not None:
-            command.extend(("--timeout", str(timeout)))
-        completed = subprocess.run(
-            command,
-            cwd=self.root,
-            env=environment,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=10,
-        )
-        artifact_directories = list(self.artifacts.iterdir())
-        self.assertEqual(len(artifact_directories), 1, completed.stdout + completed.stderr)
-        return completed, artifact_directories[0]
+            command += ["--timeout", str(timeout)]
+        completed = subprocess.run(command, cwd=self.root, env=environment,
+                                   capture_output=True, text=True, timeout=10)
+        directories = list(self.artifacts.iterdir()) if self.artifacts.exists() else []
+        self.assertEqual(len(directories), 1, completed.stdout + completed.stderr)
+        return completed, directories[0]
 
-    def test_success_isolated_environment_and_relative_paths(self) -> None:
-        replay = self.scenario_directory / "data" / "lap.jsonl"
-        replay.parent.mkdir()
-        replay.write_text('{"schema":1}\n', encoding="utf-8")
-        scenario = {
-            "schema": 1,
-            "name": "complete lap",
-            "warp": "2:3:0:1",
-            "warp_mode": 0,
-            "input": {
-                "replay": "data/lap.jsonl",
-                "start_state": 8,
-                "start_delay": 3,
-                "exit_on_end": True,
-            },
-            "max_vis": 500,
-            "capture": {"path": "captures/finish.bmp", "state": 8, "every": 20},
-            "expect": {
-                "max_state_at_least": 8,
-                "replay_complete": True,
-                "min_swaps": 30,
-                "min_abs_player_speed": 50,
-                "capture": True,
-            },
-        }
-        inherited = {
-            "LAMBO_MODERN_INPUT": "ffff:80:80",
-            "LAMBO_INPUT_PULSE": "1000:1:1",
-            "LAMBO_ANALOG_THROTTLE": "1",
-            "LAMBO_INPUT_REPLAY": "wrong-replay",
-            "LAMBO_STATE_SAVE": "wrong-state",
-            "LAMBO_DL_RENDER_OUT": "wrong-capture",
-            "LAMBO_WARP_MODE": "99",
-            "LAMBO_DRAW_DISTANCE": "999999",
-            "LAMBO_ASSET_DIR": str(self.root / "custom-assets"),
-        }
-
-        completed, artifact = self.run_scenario(scenario, inherited=inherited)
-
-        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
-        self.assertIn("PASS complete lap", completed.stdout)
-        self.assertIn(f"artifacts={artifact.resolve()}", completed.stdout)
-        environment = json.loads((artifact / "stdout.log").read_text(encoding="utf-8"))
-        staged_replay = artifact / "fixtures" / "input-replay.jsonl"
-        self.assertEqual(Path(environment["LAMBO_INPUT_REPLAY"]), staged_replay.resolve())
-        self.assertEqual(staged_replay.read_bytes(), replay.read_bytes())
-        self.assertEqual(
-            Path(environment["LAMBO_DL_RENDER_OUT"]),
-            (artifact / "capture" / "captures" / "finish.bmp").resolve(),
-        )
-        self.assertEqual(environment["LAMBO_INPUT_START_STATE"], "8")
-        self.assertEqual(environment["LAMBO_INPUT_START_DELAY"], "3")
-        self.assertEqual(environment["LAMBO_INPUT_EXIT_ON_END"], "1")
-        self.assertEqual(environment["LAMBO_MODERN_MAX_VIS"], "500")
-        self.assertEqual(environment["LAMBO_HEADLESS"], "1")
-        self.assertEqual(environment["LAMBO_WARP_MODE"], "0")
-        self.assertNotIn("LAMBO_MODERN_INPUT", environment)
-        self.assertNotIn("LAMBO_INPUT_PULSE", environment)
-        self.assertNotIn("LAMBO_ANALOG_THROTTLE", environment)
-        self.assertNotIn("LAMBO_STATE_SAVE", environment)
-        self.assertNotIn("LAMBO_DRAW_DISTANCE", environment)
-        self.assertEqual(environment["LAMBO_ASSET_DIR"], inherited["LAMBO_ASSET_DIR"])
-        self.assertEqual(Path(environment["LAMBO_GRAPHICS_CONFIG"]).parent, artifact.resolve())
-        self.assertEqual(Path(environment["LAMBO_CONTROLLER_PAK_FILE"]).parent, artifact.resolve())
-        self.assertEqual(Path(environment["LAMBO_HARNESS_RESULT"]).parent, artifact.resolve())
-        self.assertTrue((artifact / "capture" / "captures" / "finish.bmp").is_file())
-        self.assertTrue(
-            (artifact / "capture" / "captures" / "finish.bmp.20.bmp").is_file()
-        )
-        self.assertTrue((artifact / "scenario.json").is_file())
-        resolved = json.loads((artifact / "scenario-resolved.json").read_text(encoding="utf-8"))
-        self.assertEqual(resolved["input"]["replay"], "fixtures/input-replay.jsonl")
-        fixture_manifest = json.loads(
-            (artifact / "fixtures-manifest.json").read_text(encoding="utf-8")
-        )
-        self.assertEqual(fixture_manifest["fixtures"][0]["role"], "input-replay")
-        self.assertEqual(fixture_manifest["fixtures"][0]["bytes"], replay.stat().st_size)
-        self.assertEqual(len(fixture_manifest["fixtures"][0]["sha256"]), 64)
-        self.assertTrue((artifact / "harness-environment.json").is_file())
-        recorded_environment = json.loads(
-            (artifact / "harness-environment.json").read_text(encoding="utf-8")
-        )
-        self.assertEqual(
-            recorded_environment["LAMBO_ASSET_DIR"], inherited["LAMBO_ASSET_DIR"]
-        )
-        runner_result = json.loads((artifact / "runner-result.json").read_text(encoding="utf-8"))
-        self.assertEqual(runner_result["outcome"], "passed")
-        self.assertEqual(runner_result["failures"], [])
-        self.assertEqual(runner_result["native_result"]["max_state"], 8)
-
-    def test_oracle_failure_is_nonzero_and_preserves_result(self) -> None:
-        scenario = {
-            "schema": 1,
-            "name": "too shallow",
-            "max_vis": 300,
-            "expect": {
-                "max_state_at_least": 9,
-                "min_swaps": 40,
-                "min_abs_player_speed": 80,
-            },
-        }
-
+    def test_success_stages_fixture_and_isolates_environment(self) -> None:
+        replay = self.scenario_dir / "lap.jsonl"
+        replay.write_text("trace", encoding="utf-8")
+        scenario = {"schema": 1, "name": "success", "warp": "2:3:0:1", "warp_mode": 0,
+                    "input": {"replay": "lap.jsonl"}, "capture": {"path": "frame.bmp"},
+                    "expect": {"max_state_at_least": 8, "replay_complete": True,
+                               "min_swaps": 10, "capture": True}}
         completed, artifact = self.run_scenario(scenario)
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertIn("PASS success", completed.stdout)
+        self.assertEqual((artifact / "fixtures" / "input-replay.jsonl").read_text(), "trace")
+        environment = json.loads((artifact / "harness-environment.json").read_text())
+        self.assertNotIn("LAMBO_MODERN_INPUT", environment)
+        self.assertTrue((artifact / "capture" / "frame.bmp").is_file())
+        self.assertEqual(json.loads((artifact / "runner-result.json").read_text())["failures"], [])
 
-        self.assertNotEqual(completed.returncode, 0)
-        self.assertIn("FAIL too shallow", completed.stdout)
-        self.assertIn("max_state 8 < 9", completed.stdout)
-        self.assertIn("swaps 37 < 40", completed.stdout)
-        self.assertIn("max_abs_player_speed 73 < 80", completed.stdout)
-        self.assertTrue((artifact / "harness-result.json").is_file())
-        self.assertTrue((artifact / "stdout.log").is_file())
-        runner_result = json.loads((artifact / "runner-result.json").read_text(encoding="utf-8"))
-        self.assertEqual(runner_result["outcome"], "failed")
-        self.assertIn("max_state 8 < 9", runner_result["failures"])
-
-    def test_replay_completion_is_required_by_default(self) -> None:
-        replay = self.scenario_directory / "lap.jsonl"
-        replay.write_text('{"schema":1}\n', encoding="utf-8")
-        scenario = {
-            "schema": 1,
-            "name": "unfinished lap",
-            "input": {"replay": "lap.jsonl"},
-        }
-
+    def test_incomplete_replay_fails_unless_explicitly_expected(self) -> None:
+        (self.scenario_dir / "lap.jsonl").write_text("trace", encoding="utf-8")
+        scenario = {"schema": 1, "name": "partial", "input": {"replay": "lap.jsonl"}}
         completed, _ = self.run_scenario(scenario, mode="incomplete")
-
         self.assertNotEqual(completed.returncode, 0)
-        self.assertIn("replay_complete was false, expected true", completed.stdout)
-
-    def test_non_exiting_replay_must_still_consume_a_frame(self) -> None:
-        replay = self.scenario_directory / "lap.jsonl"
-        replay.write_text('{"schema":1}\n', encoding="utf-8")
-        scenario = {
-            "schema": 1,
-            "name": "zero progress",
-            "input": {"replay": "lap.jsonl", "exit_on_end": False},
-        }
-
-        completed, _ = self.run_scenario(scenario, mode="incomplete")
-
-        self.assertNotEqual(completed.returncode, 0)
-        self.assertIn("native replay did not consume any frames", completed.stdout)
-
-    def test_partial_replay_requires_an_explicit_expectation(self) -> None:
-        replay = self.scenario_directory / "lap.jsonl"
-        replay.write_text('{"schema":1}\n', encoding="utf-8")
-        scenario = {
-            "schema": 1,
-            "name": "partial progress",
-            "input": {"replay": "lap.jsonl", "exit_on_end": False},
-        }
-
-        completed, _ = self.run_scenario(scenario, mode="partial")
-        self.assertNotEqual(completed.returncode, 0)
-        self.assertIn("replay_complete was false, expected true", completed.stdout)
-
-        self.artifacts = self.root / "artifacts-explicit-partial"
+        self.assertIn("replay_complete was False, expected True", completed.stdout)
+        self.artifacts = self.root / "artifacts-explicit"
         scenario["expect"] = {"replay_complete": False}
         completed, _ = self.run_scenario(scenario, mode="partial")
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
 
-    def test_missing_and_invalid_native_results_fail_cleanly(self) -> None:
-        scenario = {"schema": 1, "name": "bad native result", "max_vis": 20}
-        for mode, expected in (
-            ("missing", "native result file is missing"),
-            ("invalid", "native result JSON is invalid"),
-        ):
-            with self.subTest(mode=mode):
-                # Each subtest needs its own artifact parent because run_scenario
-                # deliberately asserts that one unique run directory was made.
-                self.artifacts = self.root / f"artifacts-{mode}"
-                completed, artifact = self.run_scenario(scenario, mode=mode)
-                self.assertNotEqual(completed.returncode, 0)
-                self.assertIn(expected, completed.stdout)
-                self.assertTrue((artifact / "stdout.log").is_file())
-                runner_result = json.loads(
-                    (artifact / "runner-result.json").read_text(encoding="utf-8")
-                )
-                self.assertEqual(runner_result["outcome"], "failed")
-                self.assertIsNone(runner_result["native_result"])
-
-    def test_timeout_kills_the_process_and_preserves_logs(self) -> None:
-        scenario = {"schema": 1, "name": "hung game", "max_vis": 20}
-
-        completed, artifact = self.run_scenario(scenario, mode="timeout", timeout=0.2)
-
+    def test_missing_result_and_timeout_preserve_artifacts(self) -> None:
+        scenario = {"schema": 1, "name": "missing", "max_vis": 20}
+        completed, artifact = self.run_scenario(scenario, mode="missing")
         self.assertNotEqual(completed.returncode, 0)
-        self.assertIn("timed out after 0.2s", completed.stdout)
+        self.assertIn("native result is missing or invalid", completed.stdout)
         self.assertTrue((artifact / "stdout.log").is_file())
-        runner_result = json.loads((artifact / "runner-result.json").read_text(encoding="utf-8"))
-        self.assertTrue(runner_result["timed_out"])
-
-    def test_stale_capture_cannot_satisfy_capture_oracle(self) -> None:
-        capture = self.scenario_directory / "captures" / "frame.bmp"
-        capture.parent.mkdir()
-        capture.write_bytes(b"old capture")
-        numbered = Path(str(capture) + ".12.bmp")
-        numbered.write_bytes(b"old numbered capture")
-        scenario = {
-            "schema": 1,
-            "name": "fresh capture required",
-            "capture": {"path": "captures/frame.bmp", "state": 8, "every": 12},
-            "expect": {"capture": True},
-        }
-
-        completed, artifact = self.run_scenario(scenario, mode="no_capture")
-
-        self.assertNotEqual(completed.returncode, 0)
-        self.assertIn("capture was not written", completed.stdout)
-        self.assertEqual(capture.read_bytes(), b"old capture")
-        self.assertEqual(numbered.read_bytes(), b"old numbered capture")
-        self.assertFalse((artifact / "capture" / "captures" / "frame.bmp").exists())
-
-    def test_truncated_bmp_cannot_satisfy_capture_oracle(self) -> None:
-        scenario = {
-            "schema": 1,
-            "name": "complete capture required",
-            "capture": {"path": "frame.bmp", "state": 8},
-            "expect": {"capture": True},
-        }
-
-        completed, artifact = self.run_scenario(scenario, mode="corrupt_capture")
-
-        self.assertNotEqual(completed.returncode, 0)
-        self.assertIn("complete renderer BMP", completed.stdout)
-        self.assertTrue((artifact / "capture" / "frame.bmp").is_file())
-
-    def test_native_bootstrap_and_replay_claims_are_verified(self) -> None:
-        replay = self.scenario_directory / "lap.jsonl"
-        replay.write_text('{"schema":1}\n', encoding="utf-8")
-        cases = (
-            (
-                "warp_not_applied",
-                {"schema": 1, "name": "warp claim", "warp": 1,
-                 "input": {"replay": "lap.jsonl"}},
-                "native warp was requested but never applied",
-            ),
-            (
-                "warp_wrong_track",
-                {"schema": 1, "name": "track claim", "warp": 1,
-                 "input": {"replay": "lap.jsonl"}},
-                "loaded_circuit 6 != requested 1",
-            ),
-            (
-                "replay_not_started",
-                {"schema": 1, "name": "start claim", "warp": 1,
-                 "input": {"replay": "lap.jsonl"}},
-                "native replay never became active",
-            ),
-            (
-                "guest_unverified",
-                {"schema": 1, "name": "guest claim", "warp": 1,
-                 "input": {"replay": "lap.jsonl"}},
-                "guest input verification covered 179/180 consumed frames",
-            ),
+        self.artifacts = self.root / "artifacts-timeout"
+        completed, artifact = self.run_scenario(
+            {"schema": 1, "name": "timeout", "max_vis": 20}, mode="timeout", timeout=0.1
         )
-        for index, (mode, scenario, expected) in enumerate(cases):
-            with self.subTest(mode=mode):
-                self.artifacts = self.root / f"artifacts-claim-{index}"
-                completed, _ = self.run_scenario(scenario, mode=mode)
-                self.assertNotEqual(completed.returncode, 0)
-                self.assertIn(expected, completed.stdout)
-
-    def test_failed_state_load_is_not_mistaken_for_race_state(self) -> None:
-        state = self.scenario_directory / "grid.lstate"
-        replay = self.scenario_directory / "lap.jsonl"
-        state.write_bytes(b"state")
-        replay.write_text('{"schema":1}\n', encoding="utf-8")
-        scenario = {
-            "schema": 1,
-            "name": "state claim",
-            "state_load": "grid.lstate",
-            "input": {"replay": "lap.jsonl"},
-        }
-
-        completed, _ = self.run_scenario(scenario, mode="state_load_failed")
-
         self.assertNotEqual(completed.returncode, 0)
-        self.assertIn("native state load reported failure", completed.stdout)
-        self.assertIn("native state load was requested but never applied", completed.stdout)
+        self.assertIn("timed out after 0.1s", completed.stdout)
+        self.assertTrue(json.loads((artifact / "runner-result.json").read_text())["timed_out"])
 
-    def test_warp_and_state_load_are_rejected_as_ambiguous(self) -> None:
-        state = self.scenario_directory / "grid.lstate"
+    def test_schema_errors_are_reported_before_starting_game(self) -> None:
+        state = self.scenario_dir / "state.lstate"
         state.write_bytes(b"state")
-        scenario_path = self.write_scenario(
-            {"schema": 1, "name": "ambiguous", "warp": 1, "state_load": "grid.lstate"}
-        )
+        scenario = {"schema": 1, "name": "ambiguous", "warp": 1, "state_load": "state"}
+        path = self.scenario_dir / "bad.json"
+        path.write_text(json.dumps(scenario), encoding="utf-8")
         completed = subprocess.run(
-            [sys.executable, str(RUNNER), str(scenario_path), "--exe", str(self.fake_game)],
-            cwd=self.root,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=10,
+            [sys.executable, str(RUNNER), str(path), "--exe", str(self.fake)],
+            cwd=self.root, capture_output=True, text=True, timeout=10,
         )
-
         self.assertEqual(completed.returncode, 2)
         self.assertIn("alternative bootstraps", completed.stderr)
-
-    def test_unknown_scenario_field_is_rejected(self) -> None:
-        scenario_path = self.write_scenario(
-            {"schema": 1, "name": "typo", "expect": {"min_swap": 1}}
-        )
-        completed = subprocess.run(
-            [
-                sys.executable,
-                str(RUNNER),
-                str(scenario_path),
-                "--exe",
-                str(self.fake_game),
-                "--artifacts-dir",
-                str(self.artifacts),
-            ],
-            cwd=self.root,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=10,
-        )
-
-        self.assertEqual(completed.returncode, 2)
-        self.assertIn("scenario.expect has unknown field(s): min_swap", completed.stderr)
-        self.assertFalse(self.artifacts.exists())
-
-    def test_unverified_warp_mode_is_rejected(self) -> None:
-        scenario_path = self.write_scenario(
-            {"schema": 1, "name": "bad mode", "warp": 1, "warp_mode": 99}
-        )
-        completed = subprocess.run(
-            [sys.executable, str(RUNNER), str(scenario_path), "--exe", str(self.fake_game)],
-            cwd=self.root,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=10,
-        )
-
-        self.assertEqual(completed.returncode, 2)
-        self.assertIn("0 (time trial) or 2 (single race)", completed.stderr)
-
-    def test_unverified_warp_car_is_rejected(self) -> None:
-        scenario_path = self.write_scenario(
-            {"schema": 1, "name": "bad car", "warp": "1:3:1:1"}
-        )
-        completed = subprocess.run(
-            [sys.executable, str(RUNNER), str(scenario_path), "--exe", str(self.fake_game)],
-            cwd=self.root,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=10,
-        )
-
-        self.assertEqual(completed.returncode, 2)
-        self.assertIn("runtime-verified car 0", completed.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_lambo_replay.cpp
+++ b/tests/test_lambo_replay.cpp
@@ -1,0 +1,406 @@
+#include "lambo_replay.h"
+
+#include "json/json.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using json = nlohmann::json;
+using lambo::replay::InputFrame;
+
+int failures = 0;
+std::filesystem::path test_directory;
+
+void expect(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+json header() {
+    return json{{"type", "header"},
+                {"format", "lambo-input-trace"},
+                {"version", 1},
+                {"clock", "game-dispatch"},
+                {"ports", 1}};
+}
+
+json run(std::uint64_t frames = 1) {
+    return json{{"type", "run"},
+                {"frames", frames},
+                {"buttons", 0},
+                {"stick_x", 0},
+                {"stick_y", 0},
+                {"throttle_analog", false},
+                {"throttle", 0},
+                {"brake_analog", false},
+                {"brake", 0}};
+}
+
+json end(std::uint64_t frames) {
+    return json{{"type", "end"}, {"frames", frames}};
+}
+
+std::string lines(const std::vector<json>& records, bool trailing_newline = true) {
+    std::ostringstream text;
+    for (std::size_t index = 0; index < records.size(); ++index) {
+        text << records[index].dump();
+        if (trailing_newline || index + 1 < records.size()) text << '\n';
+    }
+    return text.str();
+}
+
+void write_text(const std::filesystem::path& path, const std::string& contents) {
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    output << contents;
+}
+
+std::string read_text(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    std::ostringstream contents;
+    contents << input.rdbuf();
+    return contents.str();
+}
+
+void expect_rejected(const std::string& name, const std::string& contents,
+                     const std::string& diagnostic) {
+    const auto path = test_directory / (name + ".jsonl");
+    write_text(path, contents);
+    const auto loaded = lambo::replay::load_trace(path);
+    expect(!loaded, name + " is rejected");
+    expect(!loaded.trace.has_value(), name + " does not expose a partial trace");
+    expect(loaded.error.find(diagnostic) != std::string::npos,
+           name + " reports '" + diagnostic + "' (actual: " + loaded.error + ")");
+}
+
+void test_valid_boundaries_and_lookup() {
+    json first = run(1);
+    first["buttons"] = 0;
+    first["stick_x"] = -80;
+    first["stick_y"] = 80;
+    first["throttle_analog"] = false;
+    first["throttle"] = 0;
+    first["brake_analog"] = true;
+    first["brake"] = 65535;
+
+    json second = run(2);
+    second["buttons"] = 65535;
+    second["stick_x"] = 80;
+    second["stick_y"] = -80;
+    second["throttle_analog"] = true;
+    second["throttle"] = 65535;
+    second["brake_analog"] = false;
+    second["brake"] = 0;
+
+    const auto path = test_directory / "valid-boundaries.jsonl";
+    // A complete final JSON record does not require a trailing newline.
+    write_text(path, lines({header(), first, second, end(3)}, false));
+    const auto loaded = lambo::replay::load_trace(path);
+    expect(static_cast<bool>(loaded), "valid boundary trace loads");
+    expect(loaded.error.empty(), "successful load has no error");
+    if (!loaded) return;
+
+    expect(!loaded.trace->empty(), "loaded trace is not empty");
+    expect(loaded.trace->total_frames() == 3, "run lengths produce total frame count");
+    expect(loaded.trace->frame_at(0) ==
+               InputFrame{0, -80, 80, false, 0, true, 65535},
+           "first run maps to frame zero");
+    const InputFrame expected_second{65535, 80, -80, true, 65535, false, 0};
+    expect(loaded.trace->frame_at(1) == expected_second,
+           "second run maps to its first frame");
+    expect(loaded.trace->frame_at(2) == expected_second,
+           "second run maps to its last frame");
+
+    try {
+        (void)loaded.trace->frame_at(3);
+        expect(false, "frame_at(total_frames) throws");
+    } catch (const std::out_of_range& exception) {
+        expect(std::string{exception.what()}.find("3-frame trace") != std::string::npos,
+               "out-of-range error states trace length");
+    }
+
+    const std::uint64_t maximum = std::numeric_limits<std::uint64_t>::max();
+    const auto maximum_path = test_directory / "maximum-run.jsonl";
+    write_text(maximum_path, lines({header(), run(maximum), end(maximum)}));
+    const auto maximum_loaded = lambo::replay::load_trace(maximum_path);
+    expect(static_cast<bool>(maximum_loaded), "UINT64_MAX frame run is accepted");
+    if (maximum_loaded) {
+        expect(maximum_loaded.trace->total_frames() == maximum,
+               "UINT64_MAX total is represented exactly");
+        expect(maximum_loaded.trace->frame_at(maximum - 1) == InputFrame{},
+               "last addressable frame of maximum run is available");
+    }
+}
+
+void test_invalid_headers_and_sequences() {
+    expect_rejected("empty", "", "file is empty");
+    expect_rejected("malformed-header", "{not json}\n", "invalid JSON");
+    expect_rejected("scalar-header", "42\n", "header record must be a JSON object");
+
+    json wrong = header();
+    wrong["format"] = "something-else";
+    expect_rejected("wrong-format", lines({wrong, run(), end(1)}), "lambo-input-trace");
+    wrong = header();
+    wrong["version"] = 2;
+    expect_rejected("wrong-version", lines({wrong, run(), end(1)}), "[1, 1]");
+    wrong = header();
+    wrong["version"] = 1.0;
+    expect_rejected("float-version", lines({wrong, run(), end(1)}), "unsigned integer");
+    wrong = header();
+    wrong["clock"] = "video-interface";
+    expect_rejected("wrong-clock", lines({wrong, run(), end(1)}), "game-dispatch");
+    wrong = header();
+    wrong["ports"] = 2;
+    expect_rejected("wrong-ports", lines({wrong, run(), end(1)}), "[1, 1]");
+    wrong = header();
+    wrong["extra"] = true;
+    expect_rejected("extra-header-field", lines({wrong, run(), end(1)}), "unknown field 'extra'");
+    wrong = header();
+    wrong.erase("format");
+    expect_rejected("missing-header-field", lines({wrong, run(), end(1)}), "missing field 'format'");
+
+    expect_rejected("run-first", lines({run(), end(1)}), "header record");
+    expect_rejected("end-before-run", lines({header(), end(1)}), "at least one run");
+    expect_rejected("missing-end", lines({header(), run()}), "missing end trailer");
+    expect_rejected("mismatched-end", lines({header(), run(2), end(1)}),
+                    "does not match run total 2");
+    expect_rejected("unknown-record", lines({header(), json{{"type", "metadata"}}}),
+                    "unknown record type 'metadata'");
+    expect_rejected("duplicate-header", lines({header(), run(), header(), end(1)}),
+                    "unknown record type 'header'");
+    expect_rejected("record-after-end", lines({header(), run(), end(1), run()}),
+                    "after the end trailer");
+    expect_rejected("blank-record", lines({header()}, false) + "\n\n" +
+                                        lines({run(), end(1)}),
+                    "invalid JSON");
+    expect_rejected("scalar-record", lines({header()}, false) + "\n[]\n", "JSON object");
+
+    const std::string duplicate =
+        header().dump() + "\n" +
+        "{\"type\":\"run\",\"frames\":1,\"frames\":2,\"buttons\":0,"
+        "\"stick_x\":0,\"stick_y\":0,\"throttle_analog\":false,"
+        "\"throttle\":0,\"brake_analog\":false,\"brake\":0}\n" +
+        end(2).dump() + "\n";
+    expect_rejected("duplicate-field", duplicate, "duplicate field 'frames'");
+}
+
+void test_invalid_run_fields() {
+    struct Case {
+        std::string name;
+        std::string diagnostic;
+        json record;
+    };
+    std::vector<Case> cases;
+
+    auto add = [&](std::string name, std::string field, json value,
+                   std::string diagnostic) {
+        json record = run();
+        record[std::move(field)] = std::move(value);
+        cases.push_back(Case{std::move(name), std::move(diagnostic), std::move(record)});
+    };
+
+    add("zero-frames", "frames", 0, "[1,");
+    add("negative-frames", "frames", -1, "unsigned integer");
+    add("float-frames", "frames", 1.0, "unsigned integer");
+    add("string-frames", "frames", "1", "unsigned integer");
+    add("negative-buttons", "buttons", -1, "unsigned integer");
+    add("large-buttons", "buttons", 65536, "[0, 65535]");
+    add("float-buttons", "buttons", 1.0, "unsigned integer");
+    add("low-stick-x", "stick_x", -81, "[-80, 80]");
+    add("high-stick-y", "stick_y", 81, "[-80, 80]");
+    add("float-stick", "stick_x", 1.0, "must be an integer");
+    add("numeric-throttle-flag", "throttle_analog", 1, "must be a boolean");
+    add("negative-throttle", "throttle", -1, "unsigned integer");
+    add("large-throttle", "throttle", 65536, "[0, 65535]");
+    add("string-brake-flag", "brake_analog", "false", "must be a boolean");
+    add("negative-brake", "brake", -1, "unsigned integer");
+    add("large-brake", "brake", 65536, "[0, 65535]");
+
+    json missing = run();
+    missing.erase("brake");
+    cases.push_back({"missing-run-field", "missing field 'brake'", std::move(missing)});
+    json extra = run();
+    extra["player"] = 1;
+    cases.push_back({"extra-run-field", "unknown field 'player'", std::move(extra)});
+
+    for (const Case& test : cases) {
+        expect_rejected(test.name, lines({header(), test.record, end(1)}), test.diagnostic);
+    }
+
+    const std::uint64_t maximum = std::numeric_limits<std::uint64_t>::max();
+    expect_rejected("frame-total-overflow",
+                    lines({header(), run(maximum), run(1), end(maximum)}),
+                    "overflows uint64");
+
+    json bad_end = end(1);
+    bad_end["frames"] = 1.0;
+    expect_rejected("float-end", lines({header(), run(), bad_end}), "unsigned integer");
+    bad_end = end(1);
+    bad_end["extra"] = 0;
+    expect_rejected("extra-end-field", lines({header(), run(), bad_end}),
+                    "unknown field 'extra'");
+}
+
+void test_recorder_round_trip_and_atomic_publish() {
+    const auto path = test_directory / "recorded.jsonl";
+    std::filesystem::path temporary = path;
+    temporary += ".tmp";
+    write_text(path, "old trace stays visible\n");
+
+    const InputFrame first{0x8000, -80, 80, true, 65535, false, 0};
+    const InputFrame second{0x0001, 12, -34, false, 7, true, 4096};
+    {
+        lambo::replay::Recorder recorder(path);
+        expect(recorder.ready(), "recorder opens its temporary file");
+        expect(std::filesystem::exists(temporary), "recorder uses the .tmp sibling");
+        expect(read_text(path) == "old trace stays visible\n",
+               "existing destination stays untouched while recording");
+        expect(recorder.observe(first), "recorder accepts first observation");
+        expect(recorder.observe(first), "recorder accepts identical observation");
+        expect(recorder.observe(second), "recorder accepts changed observation");
+        expect(recorder.observe(second), "recorder coalesces second observation");
+        expect(recorder.observe(second), "recorder coalesces third observation");
+        expect(recorder.total_frames() == 5, "recorder counts dispatcher observations");
+        expect(recorder.finalize(), "recorder atomically publishes on finalize");
+        expect(!recorder.ready(), "finalized recorder no longer accepts observations");
+        expect(recorder.error().empty(), "successful recorder has no error");
+        expect(recorder.finalize(), "finalize is idempotent");
+    }
+    expect(!std::filesystem::exists(temporary), "published temporary file is gone");
+    expect(read_text(path) != "old trace stays visible\n", "finalize replaces old destination");
+
+    const auto loaded = lambo::replay::load_trace(path);
+    expect(static_cast<bool>(loaded), "recorded trace loads again");
+    if (loaded) {
+        expect(loaded.trace->total_frames() == 5, "round trip preserves frame total");
+        expect(loaded.trace->frame_at(0) == first && loaded.trace->frame_at(1) == first,
+               "round trip preserves first RLE run");
+        expect(loaded.trace->frame_at(2) == second && loaded.trace->frame_at(4) == second,
+               "round trip preserves second RLE run");
+    }
+
+    std::ifstream recorded(path, std::ios::binary);
+    std::string line;
+    std::vector<std::uint64_t> run_lengths;
+    while (std::getline(recorded, line)) {
+        const json record = json::parse(line);
+        if (record.at("type") == "run") run_lengths.push_back(record.at("frames"));
+    }
+    expect(run_lengths == std::vector<std::uint64_t>{2, 3},
+           "recorder writes exactly two coalesced runs");
+}
+
+void test_recorder_failure_and_abandon_paths() {
+    const auto abandoned = test_directory / "abandoned.jsonl";
+    std::filesystem::path abandoned_temporary = abandoned;
+    abandoned_temporary += ".tmp";
+    {
+        lambo::replay::Recorder recorder(abandoned);
+        expect(recorder.ready() && recorder.observe(InputFrame{}),
+               "abandon test records a frame");
+    }
+    expect(!std::filesystem::exists(abandoned), "destructor does not publish implicitly");
+    expect(!std::filesystem::exists(abandoned_temporary),
+           "destructor removes unpublished temporary file");
+
+    const auto empty = test_directory / "empty-recording.jsonl";
+    std::filesystem::path empty_temporary = empty;
+    empty_temporary += ".tmp";
+    write_text(empty, "existing destination\n");
+    {
+        lambo::replay::Recorder recorder(empty);
+        expect(!recorder.finalize(), "zero-frame recording cannot create an invalid trace");
+        expect(recorder.error().find("no input frames") != std::string::npos,
+               "zero-frame finalize has a detailed error");
+    }
+    expect(read_text(empty) == "existing destination\n",
+           "failed empty finalize preserves existing destination");
+    expect(!std::filesystem::exists(empty_temporary),
+           "failed empty finalize removes temporary file");
+
+    const auto invalid = test_directory / "invalid-observation.jsonl";
+    std::filesystem::path invalid_temporary = invalid;
+    invalid_temporary += ".tmp";
+    lambo::replay::Recorder invalid_recorder(invalid);
+    InputFrame invalid_frame{};
+    invalid_frame.stick_x = 81;
+    expect(!invalid_recorder.observe(invalid_frame), "out-of-range observation is rejected");
+    expect(!invalid_recorder.ready(), "invalid observation fails recorder");
+    expect(invalid_recorder.error().find("stick_x") != std::string::npos,
+           "invalid observation identifies its field");
+    expect(!std::filesystem::exists(invalid_temporary),
+           "invalid observation removes temporary file");
+    expect(!invalid_recorder.finalize(), "failed recorder cannot publish");
+
+    lambo::replay::Recorder empty_path(std::filesystem::path{});
+    expect(!empty_path.ready(), "empty recorder destination is rejected");
+    expect(empty_path.error().find("empty") != std::string::npos,
+           "empty destination has a useful error");
+
+    const auto blocker = test_directory / "not-a-directory";
+    write_text(blocker, "file");
+    lambo::replay::Recorder blocked(blocker / "trace.jsonl");
+    expect(!blocked.ready(), "recorder reports an unusable parent directory");
+    expect(!blocked.error().empty(), "unusable parent directory has an error");
+
+    const auto occupied_temporary_destination = test_directory / "occupied-temp.jsonl";
+    std::filesystem::path occupied_temporary = occupied_temporary_destination;
+    occupied_temporary += ".tmp";
+    std::filesystem::create_directory(occupied_temporary);
+    {
+        lambo::replay::Recorder occupied(occupied_temporary_destination);
+        expect(!occupied.ready(), "non-file temporary path prevents recording");
+    }
+    expect(std::filesystem::is_directory(occupied_temporary),
+           "recorder does not remove a temporary path it never opened");
+
+    const auto directory_destination = test_directory / "directory-destination";
+    std::filesystem::create_directory(directory_destination);
+    std::filesystem::path publish_temporary = directory_destination;
+    publish_temporary += ".tmp";
+    lambo::replay::Recorder publish_failure(directory_destination);
+    expect(publish_failure.ready() && publish_failure.observe(InputFrame{}),
+           "publish-failure recorder reaches finalize");
+    expect(!publish_failure.finalize(), "failed atomic rename is reported");
+    expect(publish_failure.error().find("could not publish") != std::string::npos,
+           "publish failure includes operation context");
+    expect(std::filesystem::is_directory(directory_destination),
+           "publish failure preserves existing destination");
+    expect(!std::filesystem::exists(publish_temporary),
+           "publish failure removes temporary file");
+}
+
+} // namespace
+
+int main() {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    test_directory = std::filesystem::temp_directory_path() /
+                     ("lambo-replay-test-" + std::to_string(unique));
+    std::filesystem::create_directories(test_directory);
+
+    test_valid_boundaries_and_lookup();
+    test_invalid_headers_and_sequences();
+    test_invalid_run_fields();
+    test_recorder_round_trip_and_atomic_publish();
+    test_recorder_failure_and_abandon_paths();
+
+    std::error_code cleanup_error;
+    std::filesystem::remove_all(test_directory, cleanup_error);
+    if (cleanup_error) {
+        std::cerr << "FAIL: could not remove test directory: " << cleanup_error.message() << '\n';
+        ++failures;
+    }
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_lambo_replay.cpp
+++ b/tests/test_lambo_replay.cpp
@@ -1,15 +1,16 @@
 #include "lambo_replay.h"
+#include "lambo_input_quantize.h"
 
 #include "json/json.hpp"
 
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <limits>
 #include <sstream>
-#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -114,22 +115,17 @@ void test_valid_boundaries_and_lookup() {
 
     expect(!loaded.trace->empty(), "loaded trace is not empty");
     expect(loaded.trace->total_frames() == 3, "run lengths produce total frame count");
-    expect(loaded.trace->frame_at(0) ==
-               InputFrame{0, -80, 80, false, 0, true, 65535},
+    InputFrame actual{};
+    expect(loaded.trace->frame_at(0, actual) &&
+               actual == InputFrame{0, -80, 80, false, 0, true, 65535},
            "first run maps to frame zero");
     const InputFrame expected_second{65535, 80, -80, true, 65535, false, 0};
-    expect(loaded.trace->frame_at(1) == expected_second,
+    expect(loaded.trace->frame_at(1, actual) && actual == expected_second,
            "second run maps to its first frame");
-    expect(loaded.trace->frame_at(2) == expected_second,
+    expect(loaded.trace->frame_at(2, actual) && actual == expected_second,
            "second run maps to its last frame");
-
-    try {
-        (void)loaded.trace->frame_at(3);
-        expect(false, "frame_at(total_frames) throws");
-    } catch (const std::out_of_range& exception) {
-        expect(std::string{exception.what()}.find("3-frame trace") != std::string::npos,
-               "out-of-range error states trace length");
-    }
+    expect(!loaded.trace->frame_at(3, actual),
+           "frame_at(total_frames) returns false without throwing");
 
     const std::uint64_t maximum = std::numeric_limits<std::uint64_t>::max();
     const auto maximum_path = test_directory / "maximum-run.jsonl";
@@ -139,7 +135,7 @@ void test_valid_boundaries_and_lookup() {
     if (maximum_loaded) {
         expect(maximum_loaded.trace->total_frames() == maximum,
                "UINT64_MAX total is represented exactly");
-        expect(maximum_loaded.trace->frame_at(maximum - 1) == InputFrame{},
+        expect(maximum_loaded.trace->frame_at(maximum - 1, actual) && actual == InputFrame{},
                "last addressable frame of maximum run is available");
     }
 }
@@ -263,8 +259,9 @@ void test_recorder_round_trip_and_atomic_publish() {
     const InputFrame second{0x0001, 12, -34, false, 7, true, 4096};
     {
         lambo::replay::Recorder recorder(path);
-        expect(recorder.ready(), "recorder opens its temporary file");
-        expect(std::filesystem::exists(temporary), "recorder uses the .tmp sibling");
+        expect(recorder.ready(), "recorder accepts a destination before recording");
+        expect(!std::filesystem::exists(temporary),
+               "recorder does not touch disk before finalize");
         expect(read_text(path) == "old trace stays visible\n",
                "existing destination stays untouched while recording");
         expect(recorder.observe(first), "recorder accepts first observation");
@@ -285,9 +282,12 @@ void test_recorder_round_trip_and_atomic_publish() {
     expect(static_cast<bool>(loaded), "recorded trace loads again");
     if (loaded) {
         expect(loaded.trace->total_frames() == 5, "round trip preserves frame total");
-        expect(loaded.trace->frame_at(0) == first && loaded.trace->frame_at(1) == first,
+        InputFrame actual{};
+        expect(loaded.trace->frame_at(0, actual) && actual == first &&
+                   loaded.trace->frame_at(1, actual) && actual == first,
                "round trip preserves first RLE run");
-        expect(loaded.trace->frame_at(2) == second && loaded.trace->frame_at(4) == second,
+        expect(loaded.trace->frame_at(2, actual) && actual == second &&
+                   loaded.trace->frame_at(4, actual) && actual == second,
                "round trip preserves second RLE run");
     }
 
@@ -313,7 +313,7 @@ void test_recorder_failure_and_abandon_paths() {
     }
     expect(!std::filesystem::exists(abandoned), "destructor does not publish implicitly");
     expect(!std::filesystem::exists(abandoned_temporary),
-           "destructor removes unpublished temporary file");
+           "destructor leaves no unpublished temporary file");
 
     const auto empty = test_directory / "empty-recording.jsonl";
     std::filesystem::path empty_temporary = empty;
@@ -341,7 +341,7 @@ void test_recorder_failure_and_abandon_paths() {
     expect(invalid_recorder.error().find("stick_x") != std::string::npos,
            "invalid observation identifies its field");
     expect(!std::filesystem::exists(invalid_temporary),
-           "invalid observation removes temporary file");
+           "invalid observation has not created a temporary file");
     expect(!invalid_recorder.finalize(), "failed recorder cannot publish");
 
     lambo::replay::Recorder empty_path(std::filesystem::path{});
@@ -361,7 +361,9 @@ void test_recorder_failure_and_abandon_paths() {
     std::filesystem::create_directory(occupied_temporary);
     {
         lambo::replay::Recorder occupied(occupied_temporary_destination);
-        expect(!occupied.ready(), "non-file temporary path prevents recording");
+        expect(occupied.ready() && occupied.observe(InputFrame{}),
+               "recording remains in memory despite an occupied temporary path");
+        expect(!occupied.finalize(), "occupied temporary path fails only at finalize");
     }
     expect(std::filesystem::is_directory(occupied_temporary),
            "recorder does not remove a temporary path it never opened");
@@ -382,6 +384,19 @@ void test_recorder_failure_and_abandon_paths() {
            "publish failure removes temporary file");
 }
 
+void test_quantize_normalized_is_finite_and_bounded() {
+    expect(lambo::input::quantize_normalized(-1.0f) == 0,
+           "negative normalized input clamps to zero");
+    expect(lambo::input::quantize_normalized(0.5f) == 32768,
+           "midpoint normalized input rounds to the nearest u16");
+    expect(lambo::input::quantize_normalized(2.0f) == UINT16_MAX,
+           "normalized input above one clamps to UINT16_MAX");
+    expect(lambo::input::quantize_normalized(std::numeric_limits<float>::quiet_NaN()) == 0,
+           "NaN normalized input safely clamps to zero");
+    expect(lambo::input::quantize_normalized(std::numeric_limits<float>::infinity()) == 0,
+           "positive infinity normalized input safely clamps to zero");
+}
+
 } // namespace
 
 int main() {
@@ -395,6 +410,7 @@ int main() {
     test_invalid_run_fields();
     test_recorder_round_trip_and_atomic_publish();
     test_recorder_failure_and_abandon_paths();
+    test_quantize_normalized_is_finite_and_bounded();
 
     std::error_code cleanup_error;
     std::filesystem::remove_all(test_directory, cleanup_error);

--- a/tools/run_game_scenario.py
+++ b/tools/run_game_scenario.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python3
-"""Run one deterministic Lamborghini scenario and evaluate its result.
-
-The game process owns simulation and replay.  This wrapper owns isolation,
-timeouts, artifact collection, and the small set of assertions that make a run
-useful in automation.
-"""
+"""Run one game scenario without a human or a focused window."""
 
 from __future__ import annotations
 
 import argparse
-import hashlib
+import copy
 import json
-import math
 import os
-import re
 import shutil
 import signal
 import subprocess
@@ -27,271 +20,92 @@ SCHEMA_VERSION = 1
 DEFAULT_TIMEOUT_SECONDS = 90.0
 DEFAULT_MAX_VIS = 3600
 
-# These are the variables this runner may set and records in its manifest.  All
-# inherited LAMBO_* knobs are cleared except asset discovery: rendering tweaks,
-# one-off probes, and old input drivers would make a scenario non-reproducible.
-MANAGED_ENVIRONMENT = {
-    "LAMBO_ANALOG_BRAKE",
-    "LAMBO_ANALOG_BRAKE_PROBE",
-    "LAMBO_ANALOG_THROTTLE",
-    "LAMBO_ANALOG_THROTTLE_PROBE",
-    "LAMBO_CONTROLLER_PAK",
-    "LAMBO_CONTROLLER_PAK_FILE",
-    "LAMBO_CRASH_TEST",
-    "LAMBO_DL_RENDER_EVERY",
-    "LAMBO_DL_RENDER_OUT",
-    "LAMBO_DL_RENDER_STATE",
-    "LAMBO_GRAPHICS_CONFIG",
-    "LAMBO_HARNESS_RESULT",
-    "LAMBO_HEADLESS",
-    "LAMBO_INPUT_EXIT_ON_END",
-    "LAMBO_INPUT_PULSE",
-    "LAMBO_INPUT_RECORD",
-    "LAMBO_INPUT_REPLAY",
-    "LAMBO_INPUT_START_DELAY",
-    "LAMBO_INPUT_START_STATE",
-    "LAMBO_LAUNCHER",
-    "LAMBO_LIGHTING_SELFTEST",
-    "LAMBO_MODERN_INPUT",
-    "LAMBO_MODERN_MAX_VIS",
-    "LAMBO_STATE_FILE",
-    "LAMBO_STATE_LOAD",
-    "LAMBO_STATE_LOAD_DELAY",
-    "LAMBO_STATE_LOAD_STATE",
-    "LAMBO_STATE_SAVE",
-    "LAMBO_STATE_SAVE_DELAY",
-    "LAMBO_STATE_SAVE_STATE",
-    "LAMBO_WARP",
-    "LAMBO_WARP_MODE",
-}
-PRESERVED_LAMBO_ENVIRONMENT = {"LAMBO_ASSET_DIR"}
-
-TOP_LEVEL_KEYS = {
-    "schema",
-    "name",
-    "headless",
-    "warp",
-    "warp_mode",
-    "state_load",
-    "input",
-    "max_vis",
-    "timeout_seconds",
-    "capture",
-    "expect",
-}
-INPUT_KEYS = {"replay", "start_state", "start_delay", "exit_on_end"}
-CAPTURE_KEYS = {"path", "state", "every"}
-EXPECTATION_KEYS = {
-    "max_state_at_least",
-    "replay_complete",
-    "min_swaps",
-    "min_abs_player_speed",
-    "capture",
-}
-
 
 class ScenarioError(ValueError):
-    """A user-facing scenario or result validation error."""
+    pass
 
 
-def _integer(value: Any, label: str, *, minimum: int = 0) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
-        raise ScenarioError(f"{label} must be an integer >= {minimum}")
-    return value
-
-
-def _signed_integer(value: Any, label: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise ScenarioError(f"{label} must be an integer")
-    return value
-
-
-def _boolean(value: Any, label: str) -> bool:
-    if not isinstance(value, bool):
-        raise ScenarioError(f"{label} must be a boolean")
-    return value
-
-
-def _mapping(value: Any, label: str) -> dict[str, Any]:
+def _dict(value: Any, name: str) -> dict[str, Any]:
     if not isinstance(value, dict):
-        raise ScenarioError(f"{label} must be an object")
+        raise ScenarioError(f"{name} must be an object")
     return value
 
 
-def _reject_unknown_keys(value: dict[str, Any], allowed: set[str], label: str) -> None:
-    unknown = sorted(set(value) - allowed)
-    if unknown:
-        raise ScenarioError(f"{label} has unknown field(s): {', '.join(unknown)}")
-
-
-def _path(value: Any, label: str, scenario_directory: Path) -> Path:
+def _path(value: Any, name: str, base: Path) -> Path:
     if not isinstance(value, str) or not value.strip():
-        raise ScenarioError(f"{label} must be a non-empty path string")
+        raise ScenarioError(f"{name} must be a path string")
     path = Path(value).expanduser()
     if not path.is_absolute():
-        path = scenario_directory / path
+        path = base / path
     return path.resolve()
 
 
-def _capture_path(value: Any, label: str) -> Path:
-    if not isinstance(value, str) or not value.strip():
-        raise ScenarioError(f"{label} must be a non-empty relative path string")
-    path = Path(value)
-    if path.is_absolute() or path.anchor or ".." in path.parts:
-        raise ScenarioError(f"{label} must stay inside the run artifact directory")
-    return path
-
-
-def _parse_warp(value: str | int) -> tuple[str, dict[str, int]]:
-    text = str(value)
+def _warp(value: Any) -> str:
+    if isinstance(value, bool) or not isinstance(value, (str, int)):
+        raise ScenarioError("scenario.warp must be circuit[:laps[:car[:players]]]")
+    text = str(value).strip()
     parts = text.split(":")
-    if not 1 <= len(parts) <= 4 or any(not re.fullmatch(r"[0-9]+", part) for part in parts):
-        raise ScenarioError(
-            "scenario.warp must use circuit[:laps[:car[:players]]] with decimal integers"
-        )
+    if not 1 <= len(parts) <= 4 or any(not part.isdigit() for part in parts):
+        raise ScenarioError("scenario.warp must be circuit[:laps[:car[:players]]]")
     values = [int(part) for part in parts]
-    values.extend((3, 0, 1)[len(values) - 1 :])
+    values += [3, 0, 1][: 4 - len(values)]
     circuit, laps, car, players = values
-    if not 1 <= circuit <= 6:
-        raise ScenarioError("scenario.warp circuit must be in [1, 6]")
-    if not 1 <= laps <= 30:
-        raise ScenarioError("scenario.warp laps must be in [1, 30]")
+    if not 1 <= circuit <= 6 or not 1 <= laps <= 30:
+        raise ScenarioError("scenario.warp circuit must be 1-6 and laps must be 1-30")
     if car != 0:
-        raise ScenarioError(
-            "scenario.warp currently supports only runtime-verified car 0"
-        )
-    if not 1 <= players <= 4:
-        raise ScenarioError("scenario.warp players must be in [1, 4]")
-    if players >= 3 and circuit > 3:
-        raise ScenarioError("scenario.warp circuits 4-6 are unavailable with 3-4 players")
-    return text, {
-        "circuit": circuit,
-        "laps": laps,
-        "car": car,
-        "players": players,
-    }
+        raise ScenarioError("scenario.warp currently supports runtime-verified car 0")
+    if not 1 <= players <= 4 or (players >= 3 and circuit > 3):
+        raise ScenarioError("scenario.warp has an unsupported player/track combination")
+    return text
 
 
 def load_scenario(path: Path) -> dict[str, Any]:
     try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
+        scenario = _dict(json.loads(path.read_text(encoding="utf-8")), "scenario")
     except OSError as error:
         raise ScenarioError(f"cannot read scenario: {error}") from error
     except json.JSONDecodeError as error:
-        raise ScenarioError(
-            f"invalid scenario JSON at line {error.lineno}, column {error.colno}: {error.msg}"
-        ) from error
+        raise ScenarioError(f"invalid scenario JSON: {error}") from error
 
-    scenario = _mapping(raw, "scenario")
-    _reject_unknown_keys(scenario, TOP_LEVEL_KEYS, "scenario")
-    schema = scenario.get("schema")
-    if isinstance(schema, bool) or not isinstance(schema, int) or schema != SCHEMA_VERSION:
+    if scenario.get("schema") != SCHEMA_VERSION:
         raise ScenarioError(f"scenario.schema must be {SCHEMA_VERSION}")
-
     name = scenario.get("name", path.stem)
     if not isinstance(name, str) or not name.strip():
         raise ScenarioError("scenario.name must be a non-empty string")
-
-    if "headless" in scenario:
-        _boolean(scenario["headless"], "scenario.headless")
-    if "warp" in scenario and (
-        isinstance(scenario["warp"], bool)
-        or not isinstance(scenario["warp"], (str, int))
-        or not str(scenario["warp"]).strip()
-    ):
-        raise ScenarioError("scenario.warp must be a non-empty string or integer")
-    if "warp_mode" in scenario:
-        warp_mode = _integer(scenario["warp_mode"], "scenario.warp_mode")
-        if "warp" not in scenario:
-            raise ScenarioError("scenario.warp_mode requires scenario.warp")
-        if warp_mode not in {0, 2}:
-            raise ScenarioError("scenario.warp_mode must be 0 (time trial) or 2 (single race)")
-    if "warp" in scenario and "state_load" in scenario:
-        raise ScenarioError(
-            "scenario.warp and scenario.state_load are alternative bootstraps; choose one"
-        )
-
-    if "max_vis" in scenario:
-        _integer(scenario["max_vis"], "scenario.max_vis", minimum=1)
-    if "timeout_seconds" in scenario:
-        timeout = scenario["timeout_seconds"]
-        if (
-            isinstance(timeout, bool)
-            or not isinstance(timeout, (int, float))
-            or not math.isfinite(timeout)
-            or timeout <= 0
-        ):
-            raise ScenarioError("scenario.timeout_seconds must be a number > 0")
-
-    base = path.parent
-    resolved = dict(scenario)
-    resolved["name"] = name.strip()
+    scenario["name"] = name.strip()
     if "warp" in scenario:
-        resolved["warp"], resolved["_warp_expected"] = _parse_warp(scenario["warp"])
+        scenario["warp"] = _warp(scenario["warp"])
+    if "warp_mode" in scenario and scenario["warp_mode"] not in (0, 2):
+        raise ScenarioError("scenario.warp_mode must be 0 (time trial) or 2 (single race)")
+    if "warp" in scenario and "state_load" in scenario:
+        raise ScenarioError("scenario.warp and scenario.state_load are alternative bootstraps")
+
     if "state_load" in scenario:
-        resolved["state_load"] = _path(scenario["state_load"], "scenario.state_load", base)
+        scenario["state_load"] = _path(scenario["state_load"], "scenario.state_load", path.parent)
+        if not scenario["state_load"].is_file():
+            raise ScenarioError(f"state-load file does not exist: {scenario['state_load']}")
 
-    input_config = _mapping(scenario.get("input", {}), "scenario.input")
-    _reject_unknown_keys(input_config, INPUT_KEYS, "scenario.input")
-    resolved_input = dict(input_config)
-    if "replay" in input_config:
-        resolved_input["replay"] = _path(
-            input_config["replay"], "scenario.input.replay", base
-        )
-    if "start_state" in input_config:
-        _integer(input_config["start_state"], "scenario.input.start_state")
-    if "start_delay" in input_config:
-        _integer(input_config["start_delay"], "scenario.input.start_delay")
-    if "exit_on_end" in input_config:
-        _boolean(input_config["exit_on_end"], "scenario.input.exit_on_end")
-    if "replay" not in input_config and set(input_config) & {
-        "start_state",
-        "start_delay",
-        "exit_on_end",
-    }:
+    inputs = _dict(scenario.setdefault("input", {}), "scenario.input")
+    if "replay" in inputs:
+        inputs["replay"] = _path(inputs["replay"], "scenario.input.replay", path.parent)
+        if not inputs["replay"].is_file():
+            raise ScenarioError(f"replay file does not exist: {inputs['replay']}")
+    if any(key in inputs for key in ("start_state", "start_delay", "exit_on_end")) and "replay" not in inputs:
         raise ScenarioError("scenario.input start/exit fields require scenario.input.replay")
-    resolved["input"] = resolved_input
 
-    if "capture" in scenario:
-        capture = _mapping(scenario["capture"], "scenario.capture")
-        _reject_unknown_keys(capture, CAPTURE_KEYS, "scenario.capture")
-        if "path" not in capture:
-            raise ScenarioError("scenario.capture.path is required")
-        resolved_capture = dict(capture)
-        resolved_capture["path"] = _capture_path(
-            capture["path"], "scenario.capture.path"
-        )
-        if "state" in capture:
-            _integer(capture["state"], "scenario.capture.state")
-        if "every" in capture:
-            _integer(capture["every"], "scenario.capture.every", minimum=1)
-        resolved["capture"] = resolved_capture
+    capture = scenario.get("capture")
+    if capture is not None:
+        capture = _dict(capture, "scenario.capture")
+        value = capture.get("path")
+        if not isinstance(value, str) or not value.strip():
+            raise ScenarioError("scenario.capture.path must be a relative path")
+        capture_path = Path(value)
+        if capture_path.is_absolute() or ".." in capture_path.parts:
+            raise ScenarioError("scenario.capture.path must stay inside the run artifact")
+        scenario["capture"] = capture
 
-    expectations = _mapping(scenario.get("expect", {}), "scenario.expect")
-    _reject_unknown_keys(expectations, EXPECTATION_KEYS, "scenario.expect")
-    if "max_state_at_least" in expectations:
-        _integer(expectations["max_state_at_least"], "scenario.expect.max_state_at_least")
-    if "replay_complete" in expectations:
-        _boolean(expectations["replay_complete"], "scenario.expect.replay_complete")
-    if "min_swaps" in expectations:
-        _integer(expectations["min_swaps"], "scenario.expect.min_swaps")
-    if "min_abs_player_speed" in expectations:
-        _integer(
-            expectations["min_abs_player_speed"], "scenario.expect.min_abs_player_speed"
-        )
-    if "capture" in expectations:
-        _boolean(expectations["capture"], "scenario.expect.capture")
-        if expectations["capture"] and "capture" not in resolved:
-            raise ScenarioError("scenario.expect.capture requires scenario.capture")
-    resolved["expect"] = dict(expectations)
-
-    for source, label in (
-        (resolved.get("state_load"), "state-load"),
-        (resolved_input.get("replay"), "replay"),
-    ):
-        if source is not None and not source.is_file():
-            raise ScenarioError(f"{label} file does not exist: {source}")
-    return resolved
+    scenario["expect"] = _dict(scenario.get("expect", {}), "scenario.expect")
+    return scenario
 
 
 def find_executable(override: str | None, repository: Path) -> Path:
@@ -300,136 +114,89 @@ def find_executable(override: str | None, repository: Path) -> Path:
         if not candidate.is_absolute():
             candidate = Path.cwd() / candidate
         candidate = candidate.resolve()
-        if not candidate.is_file():
-            raise ScenarioError(f"executable does not exist: {candidate}")
-        return candidate
-
-    executable_names = (
-        ("lamborghini_modern.exe", "lamborghini_modern")
-        if os.name == "nt"
-        else ("lamborghini_modern", "lamborghini_modern.exe")
+        if candidate.is_file():
+            return candidate
+        raise ScenarioError(f"executable does not exist: {candidate}")
+    names = ("lamborghini_modern.exe", "lamborghini_modern") if os.name == "nt" else (
+        "lamborghini_modern", "lamborghini_modern.exe"
     )
-    build_roots = [repository / "build"]
-    build_roots.extend(
-        path for path in sorted(repository.glob("build-*")) if path.is_dir()
-    )
-    configurations = (Path(), Path("Release"), Path("Debug"), Path("RelWithDebInfo"))
-    for build_root in build_roots:
-        for configuration in configurations:
-            for name in executable_names:
-                candidate = build_root / configuration / name
-                if candidate.is_file():
-                    return candidate.resolve()
-
-    for name in executable_names:
+    for root in (repository / "build", *sorted(repository.glob("build-*"))):
+        for name in names:
+            candidate = root / name
+            if candidate.is_file():
+                return candidate.resolve()
+    for name in names:
         found = shutil.which(name)
         if found:
             return Path(found).resolve()
     raise ScenarioError("could not find lamborghini_modern; pass --exe PATH")
 
 
-def create_artifact_directory(root: Path, scenario_name: str) -> Path:
+def create_artifacts(root: Path, name: str) -> Path:
     root.mkdir(parents=True, exist_ok=True)
-    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", scenario_name).strip("-.") or "scenario"
-    return Path(tempfile.mkdtemp(prefix=f"{slug}-", dir=root)).resolve()
+    slug = "".join(ch if ch.isalnum() or ch in "._-" else "-" for ch in name).strip("-.")
+    return Path(tempfile.mkdtemp(prefix=(slug or "scenario") + "-", dir=root)).resolve()
 
 
-def _sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as stream:
-        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def stage_fixtures(
-    scenario: dict[str, Any], scenario_path: Path, artifact_directory: Path
-) -> tuple[dict[str, Any], list[dict[str, Any]]]:
-    """Freeze replay/save inputs in the run directory and return a rerunnable scenario."""
-
-    resolved_document = json.loads(scenario_path.read_text(encoding="utf-8"))
+def stage_fixtures(scenario: dict[str, Any], artifact: Path) -> dict[str, Any]:
+    runtime = copy.deepcopy(scenario)
+    fixture_root = artifact / "fixtures"
+    fixture_root.mkdir()
     fixtures: list[dict[str, Any]] = []
-    fixture_root = artifact_directory / "fixtures"
 
-    def stage(source: Path, role: str) -> tuple[Path, str]:
-        fixture_root.mkdir(parents=True, exist_ok=True)
-        suffix = "".join(source.suffixes)
-        destination = fixture_root / f"{role}{suffix}"
+    def stage(source: Path, role: str) -> str:
+        destination = fixture_root / (role + "".join(source.suffixes))
         shutil.copy2(source, destination)
-        relative = destination.relative_to(artifact_directory).as_posix()
-        fixtures.append(
-            {
-                "role": role,
-                "source": str(source),
-                "artifact": relative,
-                "bytes": destination.stat().st_size,
-                "sha256": _sha256(destination),
-            }
-        )
-        return destination.resolve(), relative
+        fixtures.append({"role": role, "file": destination.name, "bytes": destination.stat().st_size})
+        return str(destination.resolve())
 
     if "state_load" in scenario:
-        staged, relative = stage(scenario["state_load"], "state-load")
-        scenario["state_load"] = staged
-        resolved_document["state_load"] = relative
-
-    input_config = scenario["input"]
-    if "replay" in input_config:
-        staged, relative = stage(input_config["replay"], "input-replay")
-        input_config["replay"] = staged
-        resolved_input = resolved_document.setdefault("input", {})
-        resolved_input["replay"] = relative
-
-    return resolved_document, fixtures
-
-
-def build_environment(scenario: dict[str, Any], artifact_directory: Path) -> dict[str, str]:
-    environment = os.environ.copy()
-    for name in tuple(environment):
-        if name.startswith("LAMBO_") and name not in PRESERVED_LAMBO_ENVIRONMENT:
-            environment.pop(name, None)
-
-    harness_result = artifact_directory / "harness-result.json"
-    environment.update(
-        {
-            "LAMBO_HEADLESS": "1" if scenario.get("headless", True) else "0",
-            "LAMBO_GRAPHICS_CONFIG": str(artifact_directory / "graphics.json"),
-            "LAMBO_CONTROLLER_PAK_FILE": str(artifact_directory / "controller.mpk"),
-            "LAMBO_HARNESS_RESULT": str(harness_result),
-            "LAMBO_MODERN_MAX_VIS": str(scenario.get("max_vis", DEFAULT_MAX_VIS)),
-        }
+        runtime["state_load"] = stage(scenario["state_load"], "state-load")
+    if "replay" in scenario["input"]:
+        runtime["input"]["replay"] = stage(scenario["input"]["replay"], "input-replay")
+    (artifact / "fixtures.json").write_text(
+        json.dumps({"schema": SCHEMA_VERSION, "fixtures": fixtures}, indent=2) + "\n",
+        encoding="utf-8",
     )
+    return runtime
 
-    if "warp" in scenario:
-        environment["LAMBO_WARP"] = str(scenario["warp"])
-    if "warp_mode" in scenario:
-        environment["LAMBO_WARP_MODE"] = str(scenario["warp_mode"])
-    if "state_load" in scenario:
-        environment["LAMBO_STATE_LOAD"] = str(scenario["state_load"])
 
-    input_config = scenario["input"]
-    if "replay" in input_config:
-        environment["LAMBO_INPUT_REPLAY"] = str(input_config["replay"])
-        # A replay is normally a complete autonomous run.  Scenarios may opt out
-        # when they intentionally want the VI cap to be the stopping condition.
-        environment["LAMBO_INPUT_EXIT_ON_END"] = (
-            "1" if input_config.get("exit_on_end", True) else "0"
-        )
-    elif "exit_on_end" in input_config:
-        environment["LAMBO_INPUT_EXIT_ON_END"] = (
-            "1" if input_config["exit_on_end"] else "0"
-        )
-    if "start_state" in input_config:
-        environment["LAMBO_INPUT_START_STATE"] = str(input_config["start_state"])
-    if "start_delay" in input_config:
-        environment["LAMBO_INPUT_START_DELAY"] = str(input_config["start_delay"])
+def build_environment(scenario: dict[str, Any], runtime: dict[str, Any], artifact: Path) -> dict[str, str]:
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("LAMBO_") or key == "LAMBO_ASSET_DIR"
+    }
+    environment.update({
+        "LAMBO_HEADLESS": "1" if scenario.get("headless", True) else "0",
+        "LAMBO_GRAPHICS_CONFIG": str(artifact / "graphics.json"),
+        "LAMBO_CONTROLLER_PAK_FILE": str(artifact / "controller.mpk"),
+        "LAMBO_HARNESS_RESULT": str(artifact / "harness-result.json"),
+        "LAMBO_MODERN_MAX_VIS": str(scenario.get("max_vis", DEFAULT_MAX_VIS)),
+    })
+    if "warp" in runtime:
+        environment["LAMBO_WARP"] = runtime["warp"]
+    if "warp_mode" in runtime:
+        environment["LAMBO_WARP_MODE"] = str(runtime["warp_mode"])
+    if "state_load" in runtime:
+        environment["LAMBO_STATE_LOAD"] = runtime["state_load"]
 
-    capture = scenario.get("capture")
-    if capture is not None:
-        capture_root = artifact_directory / "capture"
-        capture["run_path"] = (capture_root / capture["path"]).resolve()
-        capture["run_path"].parent.mkdir(parents=True, exist_ok=True)
-        environment["LAMBO_DL_RENDER_OUT"] = str(capture["run_path"])
+    inputs = runtime["input"]
+    if "replay" in inputs:
+        environment["LAMBO_INPUT_REPLAY"] = inputs["replay"]
+        environment["LAMBO_INPUT_EXIT_ON_END"] = "1" if inputs.get("exit_on_end", True) else "0"
+        if "start_state" in inputs:
+            environment["LAMBO_INPUT_START_STATE"] = str(inputs["start_state"])
+        if "start_delay" in inputs:
+            environment["LAMBO_INPUT_START_DELAY"] = str(inputs["start_delay"])
+
+    capture = runtime.get("capture")
+    if capture:
+        capture_path = Path(capture["path"])
+        run_path = (artifact / "capture" / capture_path).resolve()
+        run_path.parent.mkdir(parents=True, exist_ok=True)
+        capture["run_path"] = str(run_path)
+        environment["LAMBO_DL_RENDER_OUT"] = str(run_path)
         if "state" in capture:
             environment["LAMBO_DL_RENDER_STATE"] = str(capture["state"])
         if "every" in capture:
@@ -437,387 +204,141 @@ def build_environment(scenario: dict[str, Any], artifact_directory: Path) -> dic
     return environment
 
 
-def executable_command(executable: Path) -> list[str]:
-    # A Python script is accepted as an executable override so the runner itself
-    # can be tested on Windows without a ROM or a compiled game.
-    if executable.suffix.lower() in {".py", ".pyw"}:
-        return [sys.executable, str(executable), "--console", "--verbose"]
-    return [str(executable), "--console", "--verbose"]
+def command_for(executable: Path) -> list[str]:
+    return ([sys.executable, str(executable), "--console", "--verbose"]
+            if executable.suffix.lower() in {".py", ".pyw"}
+            else [str(executable), "--console", "--verbose"])
 
 
-def run_process(
-    command: list[str], environment: dict[str, str], cwd: Path, timeout: float
-) -> tuple[int | None, str, str, bool]:
+def run_process(command: list[str], environment: dict[str, str], cwd: Path,
+                timeout: float) -> tuple[int | None, str, str, bool]:
     process = subprocess.Popen(
-        command,
-        cwd=cwd,
-        env=environment,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        start_new_session=os.name != "nt",
+        command, cwd=cwd, env=environment, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, encoding="utf-8", errors="replace", start_new_session=os.name != "nt"
     )
     try:
         stdout, stderr = process.communicate(timeout=timeout)
         return process.returncode, stdout, stderr, False
     except subprocess.TimeoutExpired:
         if os.name == "nt":
-            try:
-                subprocess.run(
-                    ["taskkill", "/PID", str(process.pid), "/T", "/F"],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    timeout=5,
-                    check=False,
-                )
-            except (OSError, subprocess.TimeoutExpired):
-                process.kill()
+            subprocess.run(["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
         else:
             try:
                 os.killpg(process.pid, signal.SIGKILL)
             except ProcessLookupError:
                 pass
-            except OSError:
-                process.kill()
-        if process.poll() is None:
-            process.kill()
-        try:
-            stdout, stderr = process.communicate(timeout=5)
-        except subprocess.TimeoutExpired as drain_error:
-            # A descendant outside the tree can retain a copied pipe handle. Do
-            # not let that defeat the scenario's wall-clock timeout.
-            stdout_value = drain_error.output or b""
-            stderr_value = drain_error.stderr or b""
-            stdout = (
-                stdout_value.decode("utf-8", errors="replace")
-                if isinstance(stdout_value, bytes)
-                else stdout_value
-            )
-            stderr = (
-                stderr_value.decode("utf-8", errors="replace")
-                if isinstance(stderr_value, bytes)
-                else stderr_value
-            )
-            if process.stdout is not None:
-                process.stdout.close()
-            if process.stderr is not None:
-                process.stderr.close()
-            try:
-                process.wait(timeout=1)
-            except subprocess.TimeoutExpired:
-                pass
+        stdout, stderr = process.communicate()
         return process.returncode, stdout, stderr, True
 
 
 def load_native_result(path: Path) -> dict[str, Any]:
-    if not path.is_file():
-        raise ScenarioError("native result file is missing")
     try:
         result = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
-        raise ScenarioError(f"native result JSON is invalid: {error}") from error
-    result = _mapping(result, "native result")
-
-    schema = result.get("schema")
-    if isinstance(schema, bool) or not isinstance(schema, int) or schema != SCHEMA_VERSION:
+        raise ScenarioError(f"native result is missing or invalid: {error}") from error
+    result = _dict(result, "native result")
+    if result.get("schema") != SCHEMA_VERSION:
         raise ScenarioError(f"native result.schema must be {SCHEMA_VERSION}")
-    for key in ("outcome", "reason"):
-        if not isinstance(result.get(key), str):
-            raise ScenarioError(f"native result.{key} must be a string")
-    for key in (
-        "exit_code",
-        "vis",
-        "swaps",
-        "max_state",
-        "final_state",
-        "loaded_circuit",
-    ):
-        _integer(result.get(key), f"native result.{key}")
-    _signed_integer(result.get("menu_screen"), "native result.menu_screen")
-    _integer(result.get("player_vehicle"), "native result.player_vehicle", minimum=-1)
-    _signed_integer(result.get("player_speed"), "native result.player_speed")
-    _integer(result.get("max_abs_player_speed"), "native result.max_abs_player_speed")
-
-    warp = _mapping(result.get("warp"), "native result.warp")
-    for key in ("requested", "applied", "failed"):
-        _boolean(warp.get(key), f"native result.warp.{key}")
-    for key in ("circuit", "laps", "car", "players"):
-        _integer(warp.get(key), f"native result.warp.{key}")
-    _signed_integer(warp.get("mode"), "native result.warp.mode")
-
-    state_load = _mapping(result.get("state_load"), "native result.state_load")
-    for key in ("requested", "applied", "failed"):
-        _boolean(state_load.get(key), f"native result.state_load.{key}")
-
-    replay = _mapping(result.get("replay"), "native result.replay")
-    for key in ("configured", "recording", "active", "complete", "failed"):
-        _boolean(replay.get(key), f"native result.replay.{key}")
-    for key in (
-        "total_frames",
-        "frames_consumed",
-        "guest_frames_verified",
-        "dispatcher_ticks",
-    ):
-        _integer(replay.get(key), f"native result.replay.{key}")
     return result
 
 
-def evaluate(
-    scenario: dict[str, Any], result: dict[str, Any], process_returncode: int
-) -> list[str]:
+def evaluate(scenario: dict[str, Any], result: dict[str, Any], returncode: int | None) -> list[str]:
     failures: list[str] = []
-    if process_returncode != 0:
-        failures.append(f"process exited {process_returncode}")
-    if result["exit_code"] != process_returncode:
-        failures.append(
-            f"native exit_code {result['exit_code']} != process exit {process_returncode}"
-        )
-    if result["outcome"].lower() not in {"ok", "pass", "passed", "success", "completed"}:
-        failures.append(f"native outcome {result['outcome']!r}: {result['reason']}")
-    if result["replay"]["failed"]:
-        failures.append("native replay reported failure")
+    if returncode != 0:
+        failures.append(f"process exited {returncode}")
+    if result.get("exit_code") != returncode:
+        failures.append(f"native exit_code {result.get('exit_code')} != process exit {returncode}")
+    if result.get("outcome") not in {"ok", "pass", "passed", "success", "completed"}:
+        failures.append(f"native outcome {result.get('outcome')!r}: {result.get('reason')}")
+
+    replay = _dict(result.get("replay", {}), "native result.replay")
+    input_config = scenario["input"]
+    replay_requested = "replay" in input_config
+    if bool(replay.get("configured")) != replay_requested:
+        failures.append("native replay configuration does not match scenario")
+    if replay_requested:
+        if replay.get("failed"):
+            failures.append("native replay reported failure")
+        if not replay.get("active"):
+            failures.append("native replay never became active")
+        if replay.get("frames_consumed", 0) == 0:
+            failures.append("native replay did not consume any frames")
+        if replay.get("guest_frames_verified") != replay.get("frames_consumed"):
+            failures.append("guest input verification did not cover every consumed frame")
+        expected_complete = scenario["expect"].get("replay_complete", True)
+        if bool(replay.get("complete")) != expected_complete:
+            failures.append(f"replay_complete was {replay.get('complete')}, expected {expected_complete}")
+        if expected_complete and replay.get("frames_consumed") != replay.get("total_frames"):
+            failures.append("replay completed before consuming the full trace")
+
+    warp = _dict(result.get("warp", {}), "native result.warp")
+    if bool(warp.get("requested")) != ("warp" in scenario):
+        failures.append("native warp configuration does not match scenario")
+    if "warp" in scenario:
+        expected = [int(part) for part in scenario["warp"].split(":")]
+        expected += [3, 0, 1][: 4 - len(expected)]
+        for key, value in zip(("circuit", "laps", "car", "players"), expected):
+            if warp.get(key) != value:
+                failures.append(f"warp {key} {warp.get(key)} != requested {value}")
+        if not warp.get("applied") or warp.get("failed"):
+            failures.append("native warp was not applied cleanly")
+        if result.get("loaded_circuit") != expected[0]:
+            failures.append(f"loaded_circuit {result.get('loaded_circuit')} != requested {expected[0]}")
+
+    if "state_load" in scenario:
+        state_load = _dict(result.get("state_load", {}), "native result.state_load")
+        if not state_load.get("applied") or state_load.get("failed"):
+            failures.append("native state load was not applied cleanly")
 
     expected = scenario["expect"]
-    replay_scenario = "replay" in scenario["input"]
-    if result["replay"]["configured"] != replay_scenario:
+    if "max_state_at_least" in expected and result.get("max_state", 0) < expected["max_state_at_least"]:
+        failures.append(f"max_state {result.get('max_state')} < {expected['max_state_at_least']}")
+    if "min_swaps" in expected and result.get("swaps", 0) < expected["min_swaps"]:
+        failures.append(f"swaps {result.get('swaps')} < {expected['min_swaps']}")
+    if "min_abs_player_speed" in expected and result.get("max_abs_player_speed", 0) < expected["min_abs_player_speed"]:
         failures.append(
-            f"native replay configured={result['replay']['configured']}, "
-            f"expected {replay_scenario}"
-        )
-    if replay_scenario:
-        if result["replay"]["recording"]:
-            failures.append("native replay unexpectedly entered recording mode")
-        if not result["replay"]["active"]:
-            failures.append("native replay never became active")
-        if result["replay"]["total_frames"] == 0:
-            failures.append("native replay reported an empty trace")
-        if result["replay"]["frames_consumed"] == 0:
-            failures.append("native replay did not consume any frames")
-        if (
-            result["replay"]["guest_frames_verified"]
-            != result["replay"]["frames_consumed"]
-        ):
-            failures.append(
-                "guest input verification covered "
-                f"{result['replay']['guest_frames_verified']}/"
-                f"{result['replay']['frames_consumed']} consumed frames"
-            )
-
-    warp_scenario = "warp" in scenario
-    warp_result = result["warp"]
-    if warp_result["requested"] != warp_scenario:
-        failures.append(
-            f"native warp requested={warp_result['requested']}, expected {warp_scenario}"
-        )
-    if warp_scenario:
-        if warp_result["failed"]:
-            failures.append("native warp reported failure")
-        if not warp_result["applied"]:
-            failures.append("native warp was requested but never applied")
-        requested_warp = dict(scenario["_warp_expected"])
-        requested_warp["mode"] = scenario.get("warp_mode", 2)
-        for field, requested in requested_warp.items():
-            if warp_result[field] != requested:
-                failures.append(
-                    f"warp {field} {warp_result[field]} != requested {requested}"
-                )
-        if result["loaded_circuit"] != requested_warp["circuit"]:
-            failures.append(
-                f"loaded_circuit {result['loaded_circuit']} != requested "
-                f"{requested_warp['circuit']}"
-            )
-
-    state_load_scenario = "state_load" in scenario
-    load_result = result["state_load"]
-    if load_result["requested"] != state_load_scenario:
-        failures.append(
-            "native state_load "
-            f"requested={load_result['requested']}, expected {state_load_scenario}"
-        )
-    if state_load_scenario:
-        if load_result["failed"]:
-            failures.append("native state load reported failure")
-        if not load_result["applied"]:
-            failures.append("native state load was requested but never applied")
-    minimum_state = expected.get("max_state_at_least")
-    if minimum_state is not None and result["max_state"] < minimum_state:
-        failures.append(f"max_state {result['max_state']} < {minimum_state}")
-    require_replay_complete = expected.get(
-        "replay_complete",
-        replay_scenario,
-    )
-    if require_replay_complete:
-        actual = result["replay"]["complete"]
-        if not actual:
-            failures.append("replay_complete was false, expected true")
-        elif result["replay"]["frames_consumed"] != result["replay"]["total_frames"]:
-            failures.append(
-                "replay completed with "
-                f"{result['replay']['frames_consumed']}/{result['replay']['total_frames']} frames"
-            )
-    elif expected.get("replay_complete") is False and result["replay"]["complete"]:
-        failures.append("replay_complete was true, expected false")
-    minimum_swaps = expected.get("min_swaps")
-    if minimum_swaps is not None and result["swaps"] < minimum_swaps:
-        failures.append(f"swaps {result['swaps']} < {minimum_swaps}")
-    minimum_speed = expected.get("min_abs_player_speed")
-    if minimum_speed is not None and result["max_abs_player_speed"] < minimum_speed:
-        failures.append(
-            f"max_abs_player_speed {result['max_abs_player_speed']} < {minimum_speed}"
+            f"max_abs_player_speed {result.get('max_abs_player_speed')} < {expected['min_abs_player_speed']}"
         )
     if expected.get("capture"):
-        capture_outputs = [
-            path for path in _capture_outputs(scenario["capture"])
-            if _complete_renderer_bmp(path)
-        ]
-        if not capture_outputs:
-            failures.append(
-                "capture was not written as a complete renderer BMP: "
-                f"{scenario['capture']['run_path']}"
-            )
+        capture = scenario.get("capture", {})
+        path = Path(capture.get("run_path", ""))
+        if not path.is_file() or path.stat().st_size == 0:
+            failures.append(f"capture was not written: {path}")
     return failures
 
 
-def _write_artifacts(
-    artifact_directory: Path,
-    scenario_path: Path,
-    resolved_scenario: dict[str, Any],
-    fixtures: list[dict[str, Any]],
-    environment: dict[str, str],
-    stdout: str,
-    stderr: str,
-) -> None:
-    (artifact_directory / "stdout.log").write_text(stdout, encoding="utf-8")
-    (artifact_directory / "stderr.log").write_text(stderr, encoding="utf-8")
-    shutil.copy2(scenario_path, artifact_directory / "scenario.json")
-    (artifact_directory / "scenario-resolved.json").write_text(
-        json.dumps(resolved_scenario, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+def write_artifacts(artifact: Path, original: Path, runtime: dict[str, Any],
+                    environment: dict[str, str], stdout: str, stderr: str) -> None:
+    (artifact / "stdout.log").write_text(stdout, encoding="utf-8")
+    (artifact / "stderr.log").write_text(stderr, encoding="utf-8")
+    shutil.copy2(original, artifact / "scenario.json")
+    (artifact / "scenario-resolved.json").write_text(
+        json.dumps(runtime, indent=2, default=str) + "\n", encoding="utf-8"
     )
-    (artifact_directory / "fixtures-manifest.json").write_text(
-        json.dumps({"schema": SCHEMA_VERSION, "fixtures": fixtures}, indent=2, sort_keys=True)
-        + "\n",
-        encoding="utf-8",
-    )
-    harness_environment = {
-        key: environment[key]
-        for key in sorted(MANAGED_ENVIRONMENT | PRESERVED_LAMBO_ENVIRONMENT)
-        if key in environment
-    }
-    (artifact_directory / "harness-environment.json").write_text(
-        json.dumps(harness_environment, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    selected = {key: environment[key] for key in sorted(environment) if key.startswith("LAMBO_")}
+    (artifact / "harness-environment.json").write_text(
+        json.dumps(selected, indent=2) + "\n", encoding="utf-8"
     )
 
 
-def _write_runner_result(
-    artifact_directory: Path,
-    scenario_name: str,
-    executable: Path,
-    process_returncode: int | None,
-    timed_out: bool,
-    failures: list[str],
-    native_result: dict[str, Any] | None,
-) -> None:
-    result = {
-        "schema": SCHEMA_VERSION,
-        "outcome": "failed" if failures else "passed",
-        "scenario": scenario_name,
-        "executable": str(executable),
-        "process_exit_code": process_returncode,
-        "timed_out": timed_out,
-        "failures": failures,
-        "native_result": native_result,
-    }
-    (artifact_directory / "runner-result.json").write_text(
-        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
-
-
-def _capture_outputs(capture: dict[str, Any]) -> list[Path]:
-    capture_path = capture["run_path"]
-    captures = [capture_path] if capture_path.is_file() else []
-    if capture_path.parent.is_dir():
-        numbered_prefix = capture_path.name + "."
-        for candidate in capture_path.parent.iterdir():
-            name = candidate.name
-            if not name.startswith(numbered_prefix) or not name.endswith(".bmp"):
-                continue
-            sequence = name[len(numbered_prefix) : -len(".bmp")]
-            if candidate.is_file() and sequence.isdigit():
-                captures.append(candidate)
-    return captures
-
-
-def _complete_renderer_bmp(path: Path) -> bool:
-    """Accept only the complete 24-bit BMP shape emitted by the headless renderer."""
-
-    try:
-        size = path.stat().st_size
-        with path.open("rb") as stream:
-            header = stream.read(54)
-    except OSError:
-        return False
-    if len(header) != 54 or header[:2] != b"BM":
-        return False
-
-    unsigned = lambda offset, width: int.from_bytes(
-        header[offset : offset + width], "little", signed=False
-    )
-    signed = lambda offset: int.from_bytes(
-        header[offset : offset + 4], "little", signed=True
-    )
-    declared_size = unsigned(2, 4)
-    pixel_offset = unsigned(10, 4)
-    dib_size = unsigned(14, 4)
-    width = signed(18)
-    height = signed(22)
-    planes = unsigned(26, 2)
-    bits_per_pixel = unsigned(28, 2)
-    compression = unsigned(30, 4)
-    image_size = unsigned(34, 4)
-    if (
-        width <= 0
-        or height <= 0
-        or planes != 1
-        or bits_per_pixel != 24
-        or compression != 0
-        or dib_size != 40
-        or pixel_offset != 54
-    ):
-        return False
-    expected_image_size = ((width * 3 + 3) // 4) * 4 * height
-    return (
-        image_size == expected_image_size
-        and declared_size == pixel_offset + expected_image_size
-        and size == declared_size
-    )
-
-
-def positive_float(value: str) -> float:
-    try:
-        parsed = float(value)
-    except ValueError as error:
-        raise argparse.ArgumentTypeError("must be a number") from error
-    if not math.isfinite(parsed) or parsed <= 0:
-        raise argparse.ArgumentTypeError("must be greater than zero")
-    return parsed
+def write_runner_result(artifact: Path, scenario: str, executable: Path,
+                        returncode: int | None, timed_out: bool,
+                        failures: list[str], native: dict[str, Any] | None) -> None:
+    (artifact / "runner-result.json").write_text(json.dumps({
+        "schema": SCHEMA_VERSION, "outcome": "failed" if failures else "passed",
+        "scenario": scenario, "executable": str(executable),
+        "process_exit_code": returncode, "timed_out": timed_out,
+        "failures": failures, "native_result": native,
+    }, indent=2) + "\n", encoding="utf-8")
 
 
 def parse_arguments(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("scenario", type=Path, help="schema-1 scenario JSON")
+    parser.add_argument("scenario", type=Path)
     parser.add_argument("--exe", help="path to lamborghini_modern (or a .py test double)")
-    parser.add_argument(
-        "--artifacts-dir",
-        type=Path,
-        help="artifact parent directory (default: <repo>/artifacts/game-scenarios)",
-    )
-    parser.add_argument(
-        "--timeout",
-        type=positive_float,
-        help=f"wall-clock timeout in seconds (default: scenario or {DEFAULT_TIMEOUT_SECONDS:g})",
-    )
+    parser.add_argument("--artifacts-dir", type=Path)
+    parser.add_argument("--timeout", type=float)
     return parser.parse_args(argv)
 
 
@@ -828,100 +349,51 @@ def main(argv: list[str] | None = None) -> int:
     try:
         scenario = load_scenario(scenario_path)
         executable = find_executable(args.exe, repository)
-    except ScenarioError as error:
+        root = (args.artifacts_dir.expanduser().resolve()
+                if args.artifacts_dir else repository / "artifacts" / "game-scenarios")
+        artifact = create_artifacts(root, scenario["name"])
+        runtime = stage_fixtures(scenario, artifact)
+        environment = build_environment(scenario, runtime, artifact)
+    except (OSError, ScenarioError) as error:
         print(f"ERROR: {error}", file=sys.stderr)
-        return 2
-
-    artifact_root = (
-        args.artifacts_dir.expanduser().resolve()
-        if args.artifacts_dir is not None
-        else repository / "artifacts" / "game-scenarios"
-    )
-    try:
-        artifact_directory = create_artifact_directory(artifact_root, scenario["name"])
-        resolved_scenario, fixtures = stage_fixtures(
-            scenario, scenario_path, artifact_directory
-        )
-        environment = build_environment(scenario, artifact_directory)
-    except OSError as error:
-        artifact_note = (
-            f" (artifacts={artifact_directory})" if "artifact_directory" in locals() else ""
-        )
-        print(f"ERROR: cannot prepare scenario artifacts: {error}{artifact_note}", file=sys.stderr)
         return 2
 
     timeout = args.timeout or float(scenario.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS))
     try:
         returncode, stdout, stderr, timed_out = run_process(
-            executable_command(executable), environment, repository, timeout
+            command_for(executable), environment, repository, timeout
         )
     except OSError as error:
         returncode, stdout, stderr, timed_out = None, "", str(error), False
-
     try:
-        _write_artifacts(
-            artifact_directory,
-            scenario_path,
-            resolved_scenario,
-            fixtures,
-            environment,
-            stdout,
-            stderr,
-        )
+        write_artifacts(artifact, scenario_path, runtime, environment, stdout, stderr)
     except OSError as error:
-        print(
-            f"FAIL {scenario['name']}: could not preserve artifacts: {error} "
-            f"(artifacts={artifact_directory})"
-        )
+        print(f"FAIL {scenario['name']}: could not preserve artifacts: {error}")
         return 1
 
-    failures: list[str] = []
-    if timed_out:
-        failures.append(f"timed out after {timeout:g}s")
-    if returncode is None:
-        failures.append(f"could not start executable: {stderr}")
-
-    result: dict[str, Any] | None = None
+    failures = [f"timed out after {timeout:g}s"] if timed_out else []
+    native: dict[str, Any] | None = None
     try:
-        result = load_native_result(artifact_directory / "harness-result.json")
+        native = load_native_result(artifact / "harness-result.json")
     except ScenarioError as error:
         failures.append(str(error))
-
-    if result is not None and returncode is not None:
-        failures.extend(evaluate(scenario, result, returncode))
-
+    if native is not None:
+        failures.extend(evaluate(runtime, native, returncode))
     try:
-        _write_runner_result(
-            artifact_directory,
-            scenario["name"],
-            executable,
-            returncode,
-            timed_out,
-            failures,
-            result,
-        )
+        write_runner_result(artifact, scenario["name"], executable, returncode,
+                            timed_out, failures, native)
     except OSError as error:
-        print(
-            f"FAIL {scenario['name']}: could not write runner result: {error} "
-            f"(artifacts={artifact_directory})"
-        )
+        print(f"FAIL {scenario['name']}: could not write runner result: {error}")
         return 1
 
     if failures:
-        print(
-            f"FAIL {scenario['name']}: {'; '.join(failures)} "
-            f"(artifacts={artifact_directory})"
-        )
+        print(f"FAIL {scenario['name']}: {'; '.join(failures)} (artifacts={artifact})")
         return 1
-
-    assert result is not None
-    replay = result["replay"]
-    print(
-        f"PASS {scenario['name']}: vis={result['vis']} swaps={result['swaps']} "
-        f"max_state={result['max_state']} "
-        f"replay={replay['frames_consumed']}/{replay['total_frames']} "
-        f"(artifacts={artifact_directory})"
-    )
+    replay = native["replay"]
+    print(f"PASS {scenario['name']}: vis={native['vis']} swaps={native['swaps']} "
+          f"max_state={native['max_state']} "
+          f"replay={replay['frames_consumed']}/{replay['total_frames']} "
+          f"(artifacts={artifact})")
     return 0
 
 

--- a/tools/run_game_scenario.py
+++ b/tools/run_game_scenario.py
@@ -1,0 +1,929 @@
+#!/usr/bin/env python3
+"""Run one deterministic Lamborghini scenario and evaluate its result.
+
+The game process owns simulation and replay.  This wrapper owns isolation,
+timeouts, artifact collection, and the small set of assertions that make a run
+useful in automation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+DEFAULT_TIMEOUT_SECONDS = 90.0
+DEFAULT_MAX_VIS = 3600
+
+# These are the variables this runner may set and records in its manifest.  All
+# inherited LAMBO_* knobs are cleared except asset discovery: rendering tweaks,
+# one-off probes, and old input drivers would make a scenario non-reproducible.
+MANAGED_ENVIRONMENT = {
+    "LAMBO_ANALOG_BRAKE",
+    "LAMBO_ANALOG_BRAKE_PROBE",
+    "LAMBO_ANALOG_THROTTLE",
+    "LAMBO_ANALOG_THROTTLE_PROBE",
+    "LAMBO_CONTROLLER_PAK",
+    "LAMBO_CONTROLLER_PAK_FILE",
+    "LAMBO_CRASH_TEST",
+    "LAMBO_DL_RENDER_EVERY",
+    "LAMBO_DL_RENDER_OUT",
+    "LAMBO_DL_RENDER_STATE",
+    "LAMBO_GRAPHICS_CONFIG",
+    "LAMBO_HARNESS_RESULT",
+    "LAMBO_HEADLESS",
+    "LAMBO_INPUT_EXIT_ON_END",
+    "LAMBO_INPUT_PULSE",
+    "LAMBO_INPUT_RECORD",
+    "LAMBO_INPUT_REPLAY",
+    "LAMBO_INPUT_START_DELAY",
+    "LAMBO_INPUT_START_STATE",
+    "LAMBO_LAUNCHER",
+    "LAMBO_LIGHTING_SELFTEST",
+    "LAMBO_MODERN_INPUT",
+    "LAMBO_MODERN_MAX_VIS",
+    "LAMBO_STATE_FILE",
+    "LAMBO_STATE_LOAD",
+    "LAMBO_STATE_LOAD_DELAY",
+    "LAMBO_STATE_LOAD_STATE",
+    "LAMBO_STATE_SAVE",
+    "LAMBO_STATE_SAVE_DELAY",
+    "LAMBO_STATE_SAVE_STATE",
+    "LAMBO_WARP",
+    "LAMBO_WARP_MODE",
+}
+PRESERVED_LAMBO_ENVIRONMENT = {"LAMBO_ASSET_DIR"}
+
+TOP_LEVEL_KEYS = {
+    "schema",
+    "name",
+    "headless",
+    "warp",
+    "warp_mode",
+    "state_load",
+    "input",
+    "max_vis",
+    "timeout_seconds",
+    "capture",
+    "expect",
+}
+INPUT_KEYS = {"replay", "start_state", "start_delay", "exit_on_end"}
+CAPTURE_KEYS = {"path", "state", "every"}
+EXPECTATION_KEYS = {
+    "max_state_at_least",
+    "replay_complete",
+    "min_swaps",
+    "min_abs_player_speed",
+    "capture",
+}
+
+
+class ScenarioError(ValueError):
+    """A user-facing scenario or result validation error."""
+
+
+def _integer(value: Any, label: str, *, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ScenarioError(f"{label} must be an integer >= {minimum}")
+    return value
+
+
+def _signed_integer(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ScenarioError(f"{label} must be an integer")
+    return value
+
+
+def _boolean(value: Any, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise ScenarioError(f"{label} must be a boolean")
+    return value
+
+
+def _mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ScenarioError(f"{label} must be an object")
+    return value
+
+
+def _reject_unknown_keys(value: dict[str, Any], allowed: set[str], label: str) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise ScenarioError(f"{label} has unknown field(s): {', '.join(unknown)}")
+
+
+def _path(value: Any, label: str, scenario_directory: Path) -> Path:
+    if not isinstance(value, str) or not value.strip():
+        raise ScenarioError(f"{label} must be a non-empty path string")
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = scenario_directory / path
+    return path.resolve()
+
+
+def _capture_path(value: Any, label: str) -> Path:
+    if not isinstance(value, str) or not value.strip():
+        raise ScenarioError(f"{label} must be a non-empty relative path string")
+    path = Path(value)
+    if path.is_absolute() or path.anchor or ".." in path.parts:
+        raise ScenarioError(f"{label} must stay inside the run artifact directory")
+    return path
+
+
+def _parse_warp(value: str | int) -> tuple[str, dict[str, int]]:
+    text = str(value)
+    parts = text.split(":")
+    if not 1 <= len(parts) <= 4 or any(not re.fullmatch(r"[0-9]+", part) for part in parts):
+        raise ScenarioError(
+            "scenario.warp must use circuit[:laps[:car[:players]]] with decimal integers"
+        )
+    values = [int(part) for part in parts]
+    values.extend((3, 0, 1)[len(values) - 1 :])
+    circuit, laps, car, players = values
+    if not 1 <= circuit <= 6:
+        raise ScenarioError("scenario.warp circuit must be in [1, 6]")
+    if not 1 <= laps <= 30:
+        raise ScenarioError("scenario.warp laps must be in [1, 30]")
+    if car != 0:
+        raise ScenarioError(
+            "scenario.warp currently supports only runtime-verified car 0"
+        )
+    if not 1 <= players <= 4:
+        raise ScenarioError("scenario.warp players must be in [1, 4]")
+    if players >= 3 and circuit > 3:
+        raise ScenarioError("scenario.warp circuits 4-6 are unavailable with 3-4 players")
+    return text, {
+        "circuit": circuit,
+        "laps": laps,
+        "car": car,
+        "players": players,
+    }
+
+
+def load_scenario(path: Path) -> dict[str, Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise ScenarioError(f"cannot read scenario: {error}") from error
+    except json.JSONDecodeError as error:
+        raise ScenarioError(
+            f"invalid scenario JSON at line {error.lineno}, column {error.colno}: {error.msg}"
+        ) from error
+
+    scenario = _mapping(raw, "scenario")
+    _reject_unknown_keys(scenario, TOP_LEVEL_KEYS, "scenario")
+    schema = scenario.get("schema")
+    if isinstance(schema, bool) or not isinstance(schema, int) or schema != SCHEMA_VERSION:
+        raise ScenarioError(f"scenario.schema must be {SCHEMA_VERSION}")
+
+    name = scenario.get("name", path.stem)
+    if not isinstance(name, str) or not name.strip():
+        raise ScenarioError("scenario.name must be a non-empty string")
+
+    if "headless" in scenario:
+        _boolean(scenario["headless"], "scenario.headless")
+    if "warp" in scenario and (
+        isinstance(scenario["warp"], bool)
+        or not isinstance(scenario["warp"], (str, int))
+        or not str(scenario["warp"]).strip()
+    ):
+        raise ScenarioError("scenario.warp must be a non-empty string or integer")
+    if "warp_mode" in scenario:
+        warp_mode = _integer(scenario["warp_mode"], "scenario.warp_mode")
+        if "warp" not in scenario:
+            raise ScenarioError("scenario.warp_mode requires scenario.warp")
+        if warp_mode not in {0, 2}:
+            raise ScenarioError("scenario.warp_mode must be 0 (time trial) or 2 (single race)")
+    if "warp" in scenario and "state_load" in scenario:
+        raise ScenarioError(
+            "scenario.warp and scenario.state_load are alternative bootstraps; choose one"
+        )
+
+    if "max_vis" in scenario:
+        _integer(scenario["max_vis"], "scenario.max_vis", minimum=1)
+    if "timeout_seconds" in scenario:
+        timeout = scenario["timeout_seconds"]
+        if (
+            isinstance(timeout, bool)
+            or not isinstance(timeout, (int, float))
+            or not math.isfinite(timeout)
+            or timeout <= 0
+        ):
+            raise ScenarioError("scenario.timeout_seconds must be a number > 0")
+
+    base = path.parent
+    resolved = dict(scenario)
+    resolved["name"] = name.strip()
+    if "warp" in scenario:
+        resolved["warp"], resolved["_warp_expected"] = _parse_warp(scenario["warp"])
+    if "state_load" in scenario:
+        resolved["state_load"] = _path(scenario["state_load"], "scenario.state_load", base)
+
+    input_config = _mapping(scenario.get("input", {}), "scenario.input")
+    _reject_unknown_keys(input_config, INPUT_KEYS, "scenario.input")
+    resolved_input = dict(input_config)
+    if "replay" in input_config:
+        resolved_input["replay"] = _path(
+            input_config["replay"], "scenario.input.replay", base
+        )
+    if "start_state" in input_config:
+        _integer(input_config["start_state"], "scenario.input.start_state")
+    if "start_delay" in input_config:
+        _integer(input_config["start_delay"], "scenario.input.start_delay")
+    if "exit_on_end" in input_config:
+        _boolean(input_config["exit_on_end"], "scenario.input.exit_on_end")
+    if "replay" not in input_config and set(input_config) & {
+        "start_state",
+        "start_delay",
+        "exit_on_end",
+    }:
+        raise ScenarioError("scenario.input start/exit fields require scenario.input.replay")
+    resolved["input"] = resolved_input
+
+    if "capture" in scenario:
+        capture = _mapping(scenario["capture"], "scenario.capture")
+        _reject_unknown_keys(capture, CAPTURE_KEYS, "scenario.capture")
+        if "path" not in capture:
+            raise ScenarioError("scenario.capture.path is required")
+        resolved_capture = dict(capture)
+        resolved_capture["path"] = _capture_path(
+            capture["path"], "scenario.capture.path"
+        )
+        if "state" in capture:
+            _integer(capture["state"], "scenario.capture.state")
+        if "every" in capture:
+            _integer(capture["every"], "scenario.capture.every", minimum=1)
+        resolved["capture"] = resolved_capture
+
+    expectations = _mapping(scenario.get("expect", {}), "scenario.expect")
+    _reject_unknown_keys(expectations, EXPECTATION_KEYS, "scenario.expect")
+    if "max_state_at_least" in expectations:
+        _integer(expectations["max_state_at_least"], "scenario.expect.max_state_at_least")
+    if "replay_complete" in expectations:
+        _boolean(expectations["replay_complete"], "scenario.expect.replay_complete")
+    if "min_swaps" in expectations:
+        _integer(expectations["min_swaps"], "scenario.expect.min_swaps")
+    if "min_abs_player_speed" in expectations:
+        _integer(
+            expectations["min_abs_player_speed"], "scenario.expect.min_abs_player_speed"
+        )
+    if "capture" in expectations:
+        _boolean(expectations["capture"], "scenario.expect.capture")
+        if expectations["capture"] and "capture" not in resolved:
+            raise ScenarioError("scenario.expect.capture requires scenario.capture")
+    resolved["expect"] = dict(expectations)
+
+    for source, label in (
+        (resolved.get("state_load"), "state-load"),
+        (resolved_input.get("replay"), "replay"),
+    ):
+        if source is not None and not source.is_file():
+            raise ScenarioError(f"{label} file does not exist: {source}")
+    return resolved
+
+
+def find_executable(override: str | None, repository: Path) -> Path:
+    if override:
+        candidate = Path(override).expanduser()
+        if not candidate.is_absolute():
+            candidate = Path.cwd() / candidate
+        candidate = candidate.resolve()
+        if not candidate.is_file():
+            raise ScenarioError(f"executable does not exist: {candidate}")
+        return candidate
+
+    executable_names = (
+        ("lamborghini_modern.exe", "lamborghini_modern")
+        if os.name == "nt"
+        else ("lamborghini_modern", "lamborghini_modern.exe")
+    )
+    build_roots = [repository / "build"]
+    build_roots.extend(
+        path for path in sorted(repository.glob("build-*")) if path.is_dir()
+    )
+    configurations = (Path(), Path("Release"), Path("Debug"), Path("RelWithDebInfo"))
+    for build_root in build_roots:
+        for configuration in configurations:
+            for name in executable_names:
+                candidate = build_root / configuration / name
+                if candidate.is_file():
+                    return candidate.resolve()
+
+    for name in executable_names:
+        found = shutil.which(name)
+        if found:
+            return Path(found).resolve()
+    raise ScenarioError("could not find lamborghini_modern; pass --exe PATH")
+
+
+def create_artifact_directory(root: Path, scenario_name: str) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", scenario_name).strip("-.") or "scenario"
+    return Path(tempfile.mkdtemp(prefix=f"{slug}-", dir=root)).resolve()
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def stage_fixtures(
+    scenario: dict[str, Any], scenario_path: Path, artifact_directory: Path
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Freeze replay/save inputs in the run directory and return a rerunnable scenario."""
+
+    resolved_document = json.loads(scenario_path.read_text(encoding="utf-8"))
+    fixtures: list[dict[str, Any]] = []
+    fixture_root = artifact_directory / "fixtures"
+
+    def stage(source: Path, role: str) -> tuple[Path, str]:
+        fixture_root.mkdir(parents=True, exist_ok=True)
+        suffix = "".join(source.suffixes)
+        destination = fixture_root / f"{role}{suffix}"
+        shutil.copy2(source, destination)
+        relative = destination.relative_to(artifact_directory).as_posix()
+        fixtures.append(
+            {
+                "role": role,
+                "source": str(source),
+                "artifact": relative,
+                "bytes": destination.stat().st_size,
+                "sha256": _sha256(destination),
+            }
+        )
+        return destination.resolve(), relative
+
+    if "state_load" in scenario:
+        staged, relative = stage(scenario["state_load"], "state-load")
+        scenario["state_load"] = staged
+        resolved_document["state_load"] = relative
+
+    input_config = scenario["input"]
+    if "replay" in input_config:
+        staged, relative = stage(input_config["replay"], "input-replay")
+        input_config["replay"] = staged
+        resolved_input = resolved_document.setdefault("input", {})
+        resolved_input["replay"] = relative
+
+    return resolved_document, fixtures
+
+
+def build_environment(scenario: dict[str, Any], artifact_directory: Path) -> dict[str, str]:
+    environment = os.environ.copy()
+    for name in tuple(environment):
+        if name.startswith("LAMBO_") and name not in PRESERVED_LAMBO_ENVIRONMENT:
+            environment.pop(name, None)
+
+    harness_result = artifact_directory / "harness-result.json"
+    environment.update(
+        {
+            "LAMBO_HEADLESS": "1" if scenario.get("headless", True) else "0",
+            "LAMBO_GRAPHICS_CONFIG": str(artifact_directory / "graphics.json"),
+            "LAMBO_CONTROLLER_PAK_FILE": str(artifact_directory / "controller.mpk"),
+            "LAMBO_HARNESS_RESULT": str(harness_result),
+            "LAMBO_MODERN_MAX_VIS": str(scenario.get("max_vis", DEFAULT_MAX_VIS)),
+        }
+    )
+
+    if "warp" in scenario:
+        environment["LAMBO_WARP"] = str(scenario["warp"])
+    if "warp_mode" in scenario:
+        environment["LAMBO_WARP_MODE"] = str(scenario["warp_mode"])
+    if "state_load" in scenario:
+        environment["LAMBO_STATE_LOAD"] = str(scenario["state_load"])
+
+    input_config = scenario["input"]
+    if "replay" in input_config:
+        environment["LAMBO_INPUT_REPLAY"] = str(input_config["replay"])
+        # A replay is normally a complete autonomous run.  Scenarios may opt out
+        # when they intentionally want the VI cap to be the stopping condition.
+        environment["LAMBO_INPUT_EXIT_ON_END"] = (
+            "1" if input_config.get("exit_on_end", True) else "0"
+        )
+    elif "exit_on_end" in input_config:
+        environment["LAMBO_INPUT_EXIT_ON_END"] = (
+            "1" if input_config["exit_on_end"] else "0"
+        )
+    if "start_state" in input_config:
+        environment["LAMBO_INPUT_START_STATE"] = str(input_config["start_state"])
+    if "start_delay" in input_config:
+        environment["LAMBO_INPUT_START_DELAY"] = str(input_config["start_delay"])
+
+    capture = scenario.get("capture")
+    if capture is not None:
+        capture_root = artifact_directory / "capture"
+        capture["run_path"] = (capture_root / capture["path"]).resolve()
+        capture["run_path"].parent.mkdir(parents=True, exist_ok=True)
+        environment["LAMBO_DL_RENDER_OUT"] = str(capture["run_path"])
+        if "state" in capture:
+            environment["LAMBO_DL_RENDER_STATE"] = str(capture["state"])
+        if "every" in capture:
+            environment["LAMBO_DL_RENDER_EVERY"] = str(capture["every"])
+    return environment
+
+
+def executable_command(executable: Path) -> list[str]:
+    # A Python script is accepted as an executable override so the runner itself
+    # can be tested on Windows without a ROM or a compiled game.
+    if executable.suffix.lower() in {".py", ".pyw"}:
+        return [sys.executable, str(executable), "--console", "--verbose"]
+    return [str(executable), "--console", "--verbose"]
+
+
+def run_process(
+    command: list[str], environment: dict[str, str], cwd: Path, timeout: float
+) -> tuple[int | None, str, str, bool]:
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        start_new_session=os.name != "nt",
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+        return process.returncode, stdout, stderr, False
+    except subprocess.TimeoutExpired:
+        if os.name == "nt":
+            try:
+                subprocess.run(
+                    ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=5,
+                    check=False,
+                )
+            except (OSError, subprocess.TimeoutExpired):
+                process.kill()
+        else:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            except OSError:
+                process.kill()
+        if process.poll() is None:
+            process.kill()
+        try:
+            stdout, stderr = process.communicate(timeout=5)
+        except subprocess.TimeoutExpired as drain_error:
+            # A descendant outside the tree can retain a copied pipe handle. Do
+            # not let that defeat the scenario's wall-clock timeout.
+            stdout_value = drain_error.output or b""
+            stderr_value = drain_error.stderr or b""
+            stdout = (
+                stdout_value.decode("utf-8", errors="replace")
+                if isinstance(stdout_value, bytes)
+                else stdout_value
+            )
+            stderr = (
+                stderr_value.decode("utf-8", errors="replace")
+                if isinstance(stderr_value, bytes)
+                else stderr_value
+            )
+            if process.stdout is not None:
+                process.stdout.close()
+            if process.stderr is not None:
+                process.stderr.close()
+            try:
+                process.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                pass
+        return process.returncode, stdout, stderr, True
+
+
+def load_native_result(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise ScenarioError("native result file is missing")
+    try:
+        result = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ScenarioError(f"native result JSON is invalid: {error}") from error
+    result = _mapping(result, "native result")
+
+    schema = result.get("schema")
+    if isinstance(schema, bool) or not isinstance(schema, int) or schema != SCHEMA_VERSION:
+        raise ScenarioError(f"native result.schema must be {SCHEMA_VERSION}")
+    for key in ("outcome", "reason"):
+        if not isinstance(result.get(key), str):
+            raise ScenarioError(f"native result.{key} must be a string")
+    for key in (
+        "exit_code",
+        "vis",
+        "swaps",
+        "max_state",
+        "final_state",
+        "loaded_circuit",
+    ):
+        _integer(result.get(key), f"native result.{key}")
+    _signed_integer(result.get("menu_screen"), "native result.menu_screen")
+    _integer(result.get("player_vehicle"), "native result.player_vehicle", minimum=-1)
+    _signed_integer(result.get("player_speed"), "native result.player_speed")
+    _integer(result.get("max_abs_player_speed"), "native result.max_abs_player_speed")
+
+    warp = _mapping(result.get("warp"), "native result.warp")
+    for key in ("requested", "applied", "failed"):
+        _boolean(warp.get(key), f"native result.warp.{key}")
+    for key in ("circuit", "laps", "car", "players"):
+        _integer(warp.get(key), f"native result.warp.{key}")
+    _signed_integer(warp.get("mode"), "native result.warp.mode")
+
+    state_load = _mapping(result.get("state_load"), "native result.state_load")
+    for key in ("requested", "applied", "failed"):
+        _boolean(state_load.get(key), f"native result.state_load.{key}")
+
+    replay = _mapping(result.get("replay"), "native result.replay")
+    for key in ("configured", "recording", "active", "complete", "failed"):
+        _boolean(replay.get(key), f"native result.replay.{key}")
+    for key in (
+        "total_frames",
+        "frames_consumed",
+        "guest_frames_verified",
+        "dispatcher_ticks",
+    ):
+        _integer(replay.get(key), f"native result.replay.{key}")
+    return result
+
+
+def evaluate(
+    scenario: dict[str, Any], result: dict[str, Any], process_returncode: int
+) -> list[str]:
+    failures: list[str] = []
+    if process_returncode != 0:
+        failures.append(f"process exited {process_returncode}")
+    if result["exit_code"] != process_returncode:
+        failures.append(
+            f"native exit_code {result['exit_code']} != process exit {process_returncode}"
+        )
+    if result["outcome"].lower() not in {"ok", "pass", "passed", "success", "completed"}:
+        failures.append(f"native outcome {result['outcome']!r}: {result['reason']}")
+    if result["replay"]["failed"]:
+        failures.append("native replay reported failure")
+
+    expected = scenario["expect"]
+    replay_scenario = "replay" in scenario["input"]
+    if result["replay"]["configured"] != replay_scenario:
+        failures.append(
+            f"native replay configured={result['replay']['configured']}, "
+            f"expected {replay_scenario}"
+        )
+    if replay_scenario:
+        if result["replay"]["recording"]:
+            failures.append("native replay unexpectedly entered recording mode")
+        if not result["replay"]["active"]:
+            failures.append("native replay never became active")
+        if result["replay"]["total_frames"] == 0:
+            failures.append("native replay reported an empty trace")
+        if result["replay"]["frames_consumed"] == 0:
+            failures.append("native replay did not consume any frames")
+        if (
+            result["replay"]["guest_frames_verified"]
+            != result["replay"]["frames_consumed"]
+        ):
+            failures.append(
+                "guest input verification covered "
+                f"{result['replay']['guest_frames_verified']}/"
+                f"{result['replay']['frames_consumed']} consumed frames"
+            )
+
+    warp_scenario = "warp" in scenario
+    warp_result = result["warp"]
+    if warp_result["requested"] != warp_scenario:
+        failures.append(
+            f"native warp requested={warp_result['requested']}, expected {warp_scenario}"
+        )
+    if warp_scenario:
+        if warp_result["failed"]:
+            failures.append("native warp reported failure")
+        if not warp_result["applied"]:
+            failures.append("native warp was requested but never applied")
+        requested_warp = dict(scenario["_warp_expected"])
+        requested_warp["mode"] = scenario.get("warp_mode", 2)
+        for field, requested in requested_warp.items():
+            if warp_result[field] != requested:
+                failures.append(
+                    f"warp {field} {warp_result[field]} != requested {requested}"
+                )
+        if result["loaded_circuit"] != requested_warp["circuit"]:
+            failures.append(
+                f"loaded_circuit {result['loaded_circuit']} != requested "
+                f"{requested_warp['circuit']}"
+            )
+
+    state_load_scenario = "state_load" in scenario
+    load_result = result["state_load"]
+    if load_result["requested"] != state_load_scenario:
+        failures.append(
+            "native state_load "
+            f"requested={load_result['requested']}, expected {state_load_scenario}"
+        )
+    if state_load_scenario:
+        if load_result["failed"]:
+            failures.append("native state load reported failure")
+        if not load_result["applied"]:
+            failures.append("native state load was requested but never applied")
+    minimum_state = expected.get("max_state_at_least")
+    if minimum_state is not None and result["max_state"] < minimum_state:
+        failures.append(f"max_state {result['max_state']} < {minimum_state}")
+    require_replay_complete = expected.get(
+        "replay_complete",
+        replay_scenario,
+    )
+    if require_replay_complete:
+        actual = result["replay"]["complete"]
+        if not actual:
+            failures.append("replay_complete was false, expected true")
+        elif result["replay"]["frames_consumed"] != result["replay"]["total_frames"]:
+            failures.append(
+                "replay completed with "
+                f"{result['replay']['frames_consumed']}/{result['replay']['total_frames']} frames"
+            )
+    elif expected.get("replay_complete") is False and result["replay"]["complete"]:
+        failures.append("replay_complete was true, expected false")
+    minimum_swaps = expected.get("min_swaps")
+    if minimum_swaps is not None and result["swaps"] < minimum_swaps:
+        failures.append(f"swaps {result['swaps']} < {minimum_swaps}")
+    minimum_speed = expected.get("min_abs_player_speed")
+    if minimum_speed is not None and result["max_abs_player_speed"] < minimum_speed:
+        failures.append(
+            f"max_abs_player_speed {result['max_abs_player_speed']} < {minimum_speed}"
+        )
+    if expected.get("capture"):
+        capture_outputs = [
+            path for path in _capture_outputs(scenario["capture"])
+            if _complete_renderer_bmp(path)
+        ]
+        if not capture_outputs:
+            failures.append(
+                "capture was not written as a complete renderer BMP: "
+                f"{scenario['capture']['run_path']}"
+            )
+    return failures
+
+
+def _write_artifacts(
+    artifact_directory: Path,
+    scenario_path: Path,
+    resolved_scenario: dict[str, Any],
+    fixtures: list[dict[str, Any]],
+    environment: dict[str, str],
+    stdout: str,
+    stderr: str,
+) -> None:
+    (artifact_directory / "stdout.log").write_text(stdout, encoding="utf-8")
+    (artifact_directory / "stderr.log").write_text(stderr, encoding="utf-8")
+    shutil.copy2(scenario_path, artifact_directory / "scenario.json")
+    (artifact_directory / "scenario-resolved.json").write_text(
+        json.dumps(resolved_scenario, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (artifact_directory / "fixtures-manifest.json").write_text(
+        json.dumps({"schema": SCHEMA_VERSION, "fixtures": fixtures}, indent=2, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+    harness_environment = {
+        key: environment[key]
+        for key in sorted(MANAGED_ENVIRONMENT | PRESERVED_LAMBO_ENVIRONMENT)
+        if key in environment
+    }
+    (artifact_directory / "harness-environment.json").write_text(
+        json.dumps(harness_environment, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _write_runner_result(
+    artifact_directory: Path,
+    scenario_name: str,
+    executable: Path,
+    process_returncode: int | None,
+    timed_out: bool,
+    failures: list[str],
+    native_result: dict[str, Any] | None,
+) -> None:
+    result = {
+        "schema": SCHEMA_VERSION,
+        "outcome": "failed" if failures else "passed",
+        "scenario": scenario_name,
+        "executable": str(executable),
+        "process_exit_code": process_returncode,
+        "timed_out": timed_out,
+        "failures": failures,
+        "native_result": native_result,
+    }
+    (artifact_directory / "runner-result.json").write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _capture_outputs(capture: dict[str, Any]) -> list[Path]:
+    capture_path = capture["run_path"]
+    captures = [capture_path] if capture_path.is_file() else []
+    if capture_path.parent.is_dir():
+        numbered_prefix = capture_path.name + "."
+        for candidate in capture_path.parent.iterdir():
+            name = candidate.name
+            if not name.startswith(numbered_prefix) or not name.endswith(".bmp"):
+                continue
+            sequence = name[len(numbered_prefix) : -len(".bmp")]
+            if candidate.is_file() and sequence.isdigit():
+                captures.append(candidate)
+    return captures
+
+
+def _complete_renderer_bmp(path: Path) -> bool:
+    """Accept only the complete 24-bit BMP shape emitted by the headless renderer."""
+
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as stream:
+            header = stream.read(54)
+    except OSError:
+        return False
+    if len(header) != 54 or header[:2] != b"BM":
+        return False
+
+    unsigned = lambda offset, width: int.from_bytes(
+        header[offset : offset + width], "little", signed=False
+    )
+    signed = lambda offset: int.from_bytes(
+        header[offset : offset + 4], "little", signed=True
+    )
+    declared_size = unsigned(2, 4)
+    pixel_offset = unsigned(10, 4)
+    dib_size = unsigned(14, 4)
+    width = signed(18)
+    height = signed(22)
+    planes = unsigned(26, 2)
+    bits_per_pixel = unsigned(28, 2)
+    compression = unsigned(30, 4)
+    image_size = unsigned(34, 4)
+    if (
+        width <= 0
+        or height <= 0
+        or planes != 1
+        or bits_per_pixel != 24
+        or compression != 0
+        or dib_size != 40
+        or pixel_offset != 54
+    ):
+        return False
+    expected_image_size = ((width * 3 + 3) // 4) * 4 * height
+    return (
+        image_size == expected_image_size
+        and declared_size == pixel_offset + expected_image_size
+        and size == declared_size
+    )
+
+
+def positive_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a number") from error
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def parse_arguments(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("scenario", type=Path, help="schema-1 scenario JSON")
+    parser.add_argument("--exe", help="path to lamborghini_modern (or a .py test double)")
+    parser.add_argument(
+        "--artifacts-dir",
+        type=Path,
+        help="artifact parent directory (default: <repo>/artifacts/game-scenarios)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=positive_float,
+        help=f"wall-clock timeout in seconds (default: scenario or {DEFAULT_TIMEOUT_SECONDS:g})",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_arguments(argv)
+    repository = Path(__file__).resolve().parents[1]
+    scenario_path = args.scenario.expanduser().resolve()
+    try:
+        scenario = load_scenario(scenario_path)
+        executable = find_executable(args.exe, repository)
+    except ScenarioError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+
+    artifact_root = (
+        args.artifacts_dir.expanduser().resolve()
+        if args.artifacts_dir is not None
+        else repository / "artifacts" / "game-scenarios"
+    )
+    try:
+        artifact_directory = create_artifact_directory(artifact_root, scenario["name"])
+        resolved_scenario, fixtures = stage_fixtures(
+            scenario, scenario_path, artifact_directory
+        )
+        environment = build_environment(scenario, artifact_directory)
+    except OSError as error:
+        artifact_note = (
+            f" (artifacts={artifact_directory})" if "artifact_directory" in locals() else ""
+        )
+        print(f"ERROR: cannot prepare scenario artifacts: {error}{artifact_note}", file=sys.stderr)
+        return 2
+
+    timeout = args.timeout or float(scenario.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS))
+    try:
+        returncode, stdout, stderr, timed_out = run_process(
+            executable_command(executable), environment, repository, timeout
+        )
+    except OSError as error:
+        returncode, stdout, stderr, timed_out = None, "", str(error), False
+
+    try:
+        _write_artifacts(
+            artifact_directory,
+            scenario_path,
+            resolved_scenario,
+            fixtures,
+            environment,
+            stdout,
+            stderr,
+        )
+    except OSError as error:
+        print(
+            f"FAIL {scenario['name']}: could not preserve artifacts: {error} "
+            f"(artifacts={artifact_directory})"
+        )
+        return 1
+
+    failures: list[str] = []
+    if timed_out:
+        failures.append(f"timed out after {timeout:g}s")
+    if returncode is None:
+        failures.append(f"could not start executable: {stderr}")
+
+    result: dict[str, Any] | None = None
+    try:
+        result = load_native_result(artifact_directory / "harness-result.json")
+    except ScenarioError as error:
+        failures.append(str(error))
+
+    if result is not None and returncode is not None:
+        failures.extend(evaluate(scenario, result, returncode))
+
+    try:
+        _write_runner_result(
+            artifact_directory,
+            scenario["name"],
+            executable,
+            returncode,
+            timed_out,
+            failures,
+            result,
+        )
+    except OSError as error:
+        print(
+            f"FAIL {scenario['name']}: could not write runner result: {error} "
+            f"(artifacts={artifact_directory})"
+        )
+        return 1
+
+    if failures:
+        print(
+            f"FAIL {scenario['name']}: {'; '.join(failures)} "
+            f"(artifacts={artifact_directory})"
+        )
+        return 1
+
+    assert result is not None
+    replay = result["replay"]
+    print(
+        f"PASS {scenario['name']}: vis={result['vis']} swaps={result['swaps']} "
+        f"max_state={result['max_state']} "
+        f"replay={replay['frames_consumed']}/{replay['total_frames']} "
+        f"(artifacts={artifact_directory})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The harness now records effective controller input on the game's 30 Hz dispatch clock, replays it without wall-clock coupling, and reports machine-readable boot, warp, save-state, replay, telemetry, and headless-capture evidence. Recording stays in memory until shutdown, and the scenario runner is a small process/fixture wrapper.

## Why?

Closes none - user-requested harness change; no issue number was supplied.

## How was it verified?

- [x] Built clean with `build.ps1` (Windows) - no manual cmake incantation
- [x] Booted smoke-tested: attract -> title -> menu -> race
- [ ] If visual: screenshot or short clip attached / linked below (not a visual change; headless BMP capture is checked by the runner)
- [x] If config/schema: defaults preserved when fields absent in `graphics.json`
- [ ] If new dep patch: mirrored in both `build.sh` AND `build.ps1` AND CI (`build-release.yml`) (no dependency patch added)
- [x] If new hook into recompiled code: also mirrored in `scripts/gen_syms_toml.py` (the `PATCH_BLOCKS`-stale trap)
- [x] No comments that explain *what* the code does (only *why* - see `CLAUDE.md`)
- [x] No "Generated with Claude Code" footer in commits or PR description

Additional verification:

- [x] `build.ps1` application build and `cmake --build build --target lambo_track_patch_tests -j`
- [x] `ctest --test-dir build --output-on-failure -R '^lambo_'` (27/27)
- [x] `python -m unittest tests.test_game_scenario -v` (4/4)
- [x] Live one-frame replay and 600-frame smoke replay (1/1 and 600/600; state 8; sustained swaps; non-empty capture)
- [x] Live record -> replay round trip (127/127 frames, guest verification complete)
- [x] Save-state fixture replay path verified
- [x] Branch synchronized with current `main` at `7451c095` in merge commit `1ddfbbe`

## Screenshots / video

The autonomous smoke runner writes the headless 24-bit BMP into its isolated artifact directory and verifies that a capture was produced. This change does not alter the player-facing renderer.

## Risk / rollback

Replay is opt-in through `LAMBO_INPUT_*` variables or the scenario runner; omit those variables to keep the normal input path, or revert commits `249e1b7`, `65fe2e6`, `d5e4932`, and `50b650b`.
