### PR TITLE
fix: restore persisted player names before recording results

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,26 @@ endif()
 if(BUILD_TESTING)
     find_program(LAMBO_PYTHON_EXECUTABLE NAMES python python3)
 
+    if(LAMBO_PYTHON_EXECUTABLE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/RecompiledFuncs/funcs.h")
+        file(GLOB PLAYER_RECORD_RECOMP_SOURCES CONFIGURE_DEPENDS RecompiledFuncs/funcs_*.c)
+        add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/player_record_funcs.c
+            COMMAND ${LAMBO_PYTHON_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/extract_player_record_funcs.py
+                ${CMAKE_CURRENT_SOURCE_DIR}/RecompiledFuncs
+                ${CMAKE_CURRENT_BINARY_DIR}/player_record_funcs.c
+            DEPENDS tests/extract_player_record_funcs.py ${PLAYER_RECORD_RECOMP_SOURCES}
+            VERBATIM)
+        add_executable(lambo_player_records_tests
+            tests/test_player_records.cpp
+            ${CMAKE_CURRENT_BINARY_DIR}/player_record_funcs.c
+            src/lambo_player_name.cpp src/lambo_log.cpp)
+        target_include_directories(lambo_player_records_tests PRIVATE
+            src RecompiledFuncs ${N64MR}/N64Recomp/include
+            ${N64MR}/ultramodern/include ${N64MR}/thirdparty)
+        target_link_libraries(lambo_player_records_tests PRIVATE Threads::Threads)
+        add_test(NAME lambo_player_records COMMAND lambo_player_records_tests)
+    endif()
+
     add_executable(lambo_config_tests
         tests/test_live_config.cpp
         src/lambo_config.cpp

--- a/docs/player-names.md
+++ b/docs/player-names.md
@@ -1,0 +1,39 @@
+# Persisted player names and records
+
+Issue #170 had two independent causes: restoration ran only when the name editor
+opened, and `player.json` values such as `Adam` failed the uppercase-only validator.
+A no-edit run therefore left the ROM's player-one buffer as `TITUS`. Loading now
+normalizes ASCII lowercase to the ROM keyboard's uppercase alphabet, and record
+writers restore the saved identity without requiring a visit to the editor.
+
+The records header at `0x800A4160` is not the player's name. Do not overwrite it or
+pre-populate leaderboard rows. Both ROM record writers copy from
+`0x800A4160 + 0x6C6 + player_index * 13`, with zero-based player indices. Player
+one's source is `0x800A4826`, the same buffer used by the name editor (whose driver
+selector at `0x800CE6A6` is instead one-based).
+
+| Writer | Runtime entry / generated symbol | Restoration boundary |
+| --- | --- | --- |
+| Lap completion | `0x80029628` / `func_8002A228` | `0x80029C48`, after eligibility and player ownership have been resolved; player index is `s16[sp+0x2E]` |
+| Five-entry leaderboard | `0x8003F5F0` / `func_800401F0` | Entry, with the signed zero-based player index in `a0` |
+
+Lap completion has four name destinations relative to the records base: `0x72`
+(race), `0x17A` (mirrored race), `0x516` (Time Trial), and `0x61E` (mirrored Time
+Trial), plus the ROM's class/track offsets. The leaderboard has normal (`0x402`)
+and mirrored (`0x470`) tables. Each table row is 14 bytes; the ROM copies the
+13-byte name and preserves its own ranking and row-shifting behavior.
+
+`lambo_player_records_tests` extracts and compiles both complete generated ROM
+functions, retaining the production hooks. It exercises no-edit persisted names,
+both modes/directions, guest ownership, record shifting, confirmed edits and name
+validation. The extraction output is generated locally from the user's ROM and
+is never committed. Regenerate `RecompiledFuncs` before running this test after
+hook changes:
+
+```sh
+cmake --build build --target lambo_player_records_tests
+ctest --test-dir build -R '^lambo_player_records$' --output-on-failure
+```
+
+This deterministic test verifies the record-writing code, not driving, rendering,
+Controller Pak serialization, or complete gameplay traversal.

--- a/docs/player-names.md
+++ b/docs/player-names.md
@@ -15,7 +15,7 @@ selector at `0x800CE6A6` is instead one-based).
 | Writer | Runtime entry / generated symbol | Restoration boundary |
 | --- | --- | --- |
 | Lap completion | `0x80029628` / `func_8002A228` | `0x80029C48`, after eligibility and player ownership have been resolved; player index is `s16[sp+0x2E]` |
-| Five-entry leaderboard | `0x8003F5F0` / `func_800401F0` | Entry, with the signed zero-based player index in `a0` |
+| Five-entry leaderboard | `0x8003F5F0` / `func_800401F0` | Name-byte copy sites `0x8003F924` and `0x8003FC0C`; the ROM walks a mode-specific source one byte at a time |
 
 Lap completion has four name destinations relative to the records base: `0x72`
 (race), `0x17A` (mirrored race), `0x516` (Time Trial), and `0x61E` (mirrored Time
@@ -34,6 +34,11 @@ hook changes:
 cmake --build build --target lambo_player_records_tests
 ctest --test-dir build -R '^lambo_player_records$' --output-on-failure
 ```
+
+The leaderboard hooks override only player one's name bytes at those copy sites;
+guest source ranges are left untouched. This is necessary because restoring the
+editor buffer at the leaderboard entry is too early—the ROM's ranking pass can
+select a different stale profile source before it copies the name.
 
 This deterministic test verifies the record-writing code, not driving, rendering,
 Controller Pak serialization, or complete gameplay traversal.

--- a/docs/player-names.md
+++ b/docs/player-names.md
@@ -1,10 +1,9 @@
 # Persisted player names and records
 
-Issue #170 is caused by the leaderboard ranking pass reading a mode-specific
-profile source after the editor buffer has been bypassed or overwritten. Loading
-also normalizes ASCII lowercase in `player.json` to the ROM keyboard's uppercase
-alphabet as defensive input handling. Record writers now restore the saved
-identity without requiring a visit to the editor.
+Issue #170 occurs when a persisted player name is not restored to the ROM's source
+buffer before a record writer runs. Loading also normalizes ASCII lowercase in
+`player.json` to the ROM keyboard's uppercase alphabet as defensive input handling.
+Record writers now restore the saved identity without requiring a visit to the editor.
 
 The records header at `0x800A4160` is not the player's name. Do not overwrite it or
 pre-populate leaderboard rows. Both ROM record writers copy from
@@ -15,7 +14,7 @@ selector at `0x800CE6A6` is instead one-based).
 | Writer | Runtime entry / generated symbol | Restoration boundary |
 | --- | --- | --- |
 | Lap completion | `0x80029628` / `func_8002A228` | `0x80029C48`, after eligibility and player ownership have been resolved; player index is `s16[sp+0x2E]` |
-| Five-entry leaderboard | `0x8003F5F0` / `func_800401F0` | Name-byte copy sites `0x8003F924` and `0x8003FC0C`; the ROM walks a mode-specific source one byte at a time |
+| Five-entry leaderboard | `0x8003F5F0` / `func_800401F0` | Entry, with the signed zero-based player index in `a0` |
 
 Lap completion has four name destinations relative to the records base: `0x72`
 (race), `0x17A` (mirrored race), `0x516` (Time Trial), and `0x61E` (mirrored Time
@@ -35,10 +34,8 @@ cmake --build build --target lambo_player_records_tests
 ctest --test-dir build -R '^lambo_player_records$' --output-on-failure
 ```
 
-The leaderboard hooks override only player one's name bytes at those copy sites;
-guest source ranges are left untouched. This is necessary because restoring the
-editor buffer at the leaderboard entry is too early—the ROM's ranking pass can
-select a different stale profile source before it copies the name.
+The leaderboard hook restores only player one's source buffer before the ROM's
+ranking and insertion logic runs; guest source ranges are left untouched.
 
 This deterministic test verifies the record-writing code, not driving, rendering,
 Controller Pak serialization, or complete gameplay traversal.

--- a/docs/player-names.md
+++ b/docs/player-names.md
@@ -1,10 +1,10 @@
 # Persisted player names and records
 
-Issue #170 had two independent causes: restoration ran only when the name editor
-opened, and `player.json` values such as `Adam` failed the uppercase-only validator.
-A no-edit run therefore left the ROM's player-one buffer as `TITUS`. Loading now
-normalizes ASCII lowercase to the ROM keyboard's uppercase alphabet, and record
-writers restore the saved identity without requiring a visit to the editor.
+Issue #170 is caused by the leaderboard ranking pass reading a mode-specific
+profile source after the editor buffer has been bypassed or overwritten. Loading
+also normalizes ASCII lowercase in `player.json` to the ROM keyboard's uppercase
+alphabet as defensive input handling. Record writers now restore the saved
+identity without requiring a visit to the editor.
 
 The records header at `0x800A4160` is not the player's name. Do not overwrite it or
 pre-populate leaderboard rows. Both ROM record writers copy from

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -1155,3 +1155,20 @@ text = "{ extern void lambo_player_name_seed(uint8_t*); lambo_player_name_seed(r
 func = "func_800400EC"
 before_vram = 0x8003F4EC
 text = "{ extern void lambo_player_name_save(uint8_t*); lambo_player_name_save(rdram); }"
+
+# No-edit runs never enter the name screen. Restore the source buffer before
+# both independent ROM record writers; do not write leaderboard/history rows.
+# Lap completion: 0x80029628 (symbol func_8002A228). At 0x80029C48 the
+# faster-lap branch has resolved vehicle ownership to a zero-based player in
+# s16[sp+0x2E]. All four mode/direction name-copy branches follow this point.
+[[patches.hook]]
+func = "func_8002A228"
+before_vram = 0x80029C48
+text = "{ extern void lambo_player_name_restore_for_record(uint8_t*, int); lambo_player_name_restore_for_record(rdram, MEM_H(0x2E, ctx->r29)); }"
+
+# Results leaderboard: 0x8003F5F0 (symbol func_800401F0), a0 = zero-based player.
+# The ROM ranks/shifts/inserts into the normal or mirrored five-entry table.
+[[patches.hook]]
+func = "func_800401F0"
+before_vram = 0x8003F5F0
+text = "{ extern void lambo_player_name_restore_for_record(uint8_t*, int); lambo_player_name_restore_for_record(rdram, (int16_t)ctx->r4); }"

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -1166,13 +1166,7 @@ func = "func_8002A228"
 before_vram = 0x80029C48
 text = "{ extern void lambo_player_name_restore_for_record(uint8_t*, int); lambo_player_name_restore_for_record(rdram, MEM_H(0x2E, ctx->r29)); }"
 
-# Results leaderboard: refresh the mode-specific profile source immediately
-# before the ROM copies its name byte (normal and mirrored paths).
 [[patches.hook]]
 func = "func_800401F0"
-before_vram = 0x8003F924
-text = "{ extern uint32_t lambo_player_name_record_byte(uintptr_t); uint32_t ch = lambo_player_name_record_byte((uintptr_t)ctx->r15); if (ch != 0xFFFFFFFFu) ctx->r9 = ch; }"
-[[patches.hook]]
-func = "func_800401F0"
-before_vram = 0x8003FC0C
-text = "{ extern uint32_t lambo_player_name_record_byte(uintptr_t); uint32_t ch = lambo_player_name_record_byte((uintptr_t)ctx->r12); if (ch != 0xFFFFFFFFu) ctx->r8 = ch; }"
+before_vram = 0x8003F5F0
+text = "{ extern void lambo_player_name_restore_for_record(uint8_t*, int); lambo_player_name_restore_for_record(rdram, (int16_t)ctx->r4); }"

--- a/lamborghini.us.toml
+++ b/lamborghini.us.toml
@@ -1166,9 +1166,13 @@ func = "func_8002A228"
 before_vram = 0x80029C48
 text = "{ extern void lambo_player_name_restore_for_record(uint8_t*, int); lambo_player_name_restore_for_record(rdram, MEM_H(0x2E, ctx->r29)); }"
 
-# Results leaderboard: 0x8003F5F0 (symbol func_800401F0), a0 = zero-based player.
-# The ROM ranks/shifts/inserts into the normal or mirrored five-entry table.
+# Results leaderboard: refresh the mode-specific profile source immediately
+# before the ROM copies its name byte (normal and mirrored paths).
 [[patches.hook]]
 func = "func_800401F0"
-before_vram = 0x8003F5F0
-text = "{ extern void lambo_player_name_restore_for_record(uint8_t*, int); lambo_player_name_restore_for_record(rdram, (int16_t)ctx->r4); }"
+before_vram = 0x8003F924
+text = "{ extern uint32_t lambo_player_name_record_byte(uintptr_t); uint32_t ch = lambo_player_name_record_byte((uintptr_t)ctx->r15); if (ch != 0xFFFFFFFFu) ctx->r9 = ch; }"
+[[patches.hook]]
+func = "func_800401F0"
+before_vram = 0x8003FC0C
+text = "{ extern uint32_t lambo_player_name_record_byte(uintptr_t); uint32_t ch = lambo_player_name_record_byte((uintptr_t)ctx->r12); if (ch != 0xFFFFFFFFu) ctx->r8 = ch; }"

--- a/scripts/gen_syms_toml.py
+++ b/scripts/gen_syms_toml.py
@@ -1468,6 +1468,29 @@ text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gp
 func = "func_800030F8"
 before_vram = 0x80004374
 text = "{ extern unsigned int lambo_camera_fov_bits(unsigned int); ctx->r6 = (gpr)(int32_t)lambo_camera_fov_bits((uint32_t)ctx->r6); }"
+
+# Player-one persistence: editor setup/Done and both independent record writers.
+# Keep these hooks aligned with lamborghini.us.toml; record writers use zero-based
+# player indices, unlike the name editor's one-based current-driver selector.
+[[patches.hook]]
+func = "func_8003CD84"
+before_vram = 0x8003CE68
+text = "{ extern void lambo_player_name_seed(uint8_t*); lambo_player_name_seed(rdram); }"
+
+[[patches.hook]]
+func = "func_800400EC"
+before_vram = 0x8003F4EC
+text = "{ extern void lambo_player_name_save(uint8_t*); lambo_player_name_save(rdram); }"
+
+[[patches.hook]]
+func = "func_8002A228"
+before_vram = 0x80029C48
+text = "{ extern void lambo_player_name_restore_for_record(uint8_t*, int); lambo_player_name_restore_for_record(rdram, MEM_H(0x2E, ctx->r29)); }"
+
+[[patches.hook]]
+func = "func_800401F0"
+before_vram = 0x8003F5F0
+text = "{ extern void lambo_player_name_restore_for_record(uint8_t*, int); lambo_player_name_restore_for_record(rdram, (int16_t)ctx->r4); }"
 """
 
 UNSTUB = [

--- a/scripts/gen_syms_toml.py
+++ b/scripts/gen_syms_toml.py
@@ -1489,8 +1489,12 @@ text = "{ extern void lambo_player_name_restore_for_record(uint8_t*, int); lambo
 
 [[patches.hook]]
 func = "func_800401F0"
-before_vram = 0x8003F5F0
-text = "{ extern void lambo_player_name_restore_for_record(uint8_t*, int); lambo_player_name_restore_for_record(rdram, (int16_t)ctx->r4); }"
+before_vram = 0x8003F924
+text = "{ extern uint32_t lambo_player_name_record_byte(uintptr_t); uint32_t ch = lambo_player_name_record_byte((uintptr_t)ctx->r15); if (ch != 0xFFFFFFFFu) ctx->r9 = ch; }"
+[[patches.hook]]
+func = "func_800401F0"
+before_vram = 0x8003FC0C
+text = "{ extern uint32_t lambo_player_name_record_byte(uintptr_t); uint32_t ch = lambo_player_name_record_byte((uintptr_t)ctx->r12); if (ch != 0xFFFFFFFFu) ctx->r8 = ch; }"
 """
 
 UNSTUB = [

--- a/scripts/gen_syms_toml.py
+++ b/scripts/gen_syms_toml.py
@@ -1489,12 +1489,8 @@ text = "{ extern void lambo_player_name_restore_for_record(uint8_t*, int); lambo
 
 [[patches.hook]]
 func = "func_800401F0"
-before_vram = 0x8003F924
-text = "{ extern uint32_t lambo_player_name_record_byte(uintptr_t); uint32_t ch = lambo_player_name_record_byte((uintptr_t)ctx->r15); if (ch != 0xFFFFFFFFu) ctx->r9 = ch; }"
-[[patches.hook]]
-func = "func_800401F0"
-before_vram = 0x8003FC0C
-text = "{ extern uint32_t lambo_player_name_record_byte(uintptr_t); uint32_t ch = lambo_player_name_record_byte((uintptr_t)ctx->r12); if (ch != 0xFFFFFFFFu) ctx->r8 = ch; }"
+before_vram = 0x8003F5F0
+text = "{ extern void lambo_player_name_restore_for_record(uint8_t*, int); lambo_player_name_restore_for_record(rdram, (int16_t)ctx->r4); }"
 """
 
 UNSTUB = [

--- a/src/lambo_player_name.cpp
+++ b/src/lambo_player_name.cpp
@@ -51,6 +51,10 @@ std::string load_saved_name() {
         const auto field = json.find("name");
         if (field == json.end() || !field->is_string()) return {};
         std::string name = field->get<std::string>();
+        // player.json can be edited outside the ROM's uppercase-only keyboard.
+        for (char& ch : name) {
+            if (ch >= 'a' && ch <= 'z') ch = static_cast<char>(ch - 'a' + 'A');
+        }
         return valid_name(name) ? name : std::string{};
     } catch (const nlohmann::json::exception& e) {
         LAMBO_LOG_WARN("name", "%s unparseable (%s); keeping ROM default\n",
@@ -100,6 +104,14 @@ int current_driver(uint8_t* rdram) {
 
 extern "C" void lambo_player_name_seed(uint8_t* rdram) {
     if (current_driver(rdram) != kPlayerOne) return;
+
+    lambo_player_name_restore_for_record(rdram, 0);
+}
+
+extern "C" void lambo_player_name_restore_for_record(uint8_t* rdram, int player_index) {
+    // Record writers use zero-based player indices, independently of the name
+    // editor's current-driver selector (which may never have been initialized).
+    if (player_index != 0) return;
 
     const std::string saved = load_saved_name();
     if (!valid_name(saved)) return;

--- a/src/lambo_player_name.cpp
+++ b/src/lambo_player_name.cpp
@@ -120,16 +120,7 @@ extern "C" void lambo_player_name_restore_for_record(uint8_t* rdram, int player_
     for (int i = 0; i < kNameStride; ++i) {
         MEM_B(i, dst) = i < (int)saved.size() ? saved[(size_t)i] : 0;
     }
-    LAMBO_LOG_INFO("name", "seeded player name: %s\n", saved.c_str());
-}
-
-extern "C" uint32_t lambo_player_name_record_byte(uintptr_t source_base) {
-    const uint32_t base = static_cast<uint32_t>(source_base);
-    if (base < 0x800A4160u || base >= 0x800A416Du) return 0xFFFFFFFFu;
-    const std::string saved = load_saved_name();
-    if (!valid_name(saved)) return 0xFFFFFFFFu;
-    const size_t index = base - 0x800A4160u;
-    return index < saved.size() ? static_cast<uint8_t>(saved[index]) : 0;
+    LAMBO_LOG_INFO("name", "restored player name for record: %s\n", saved.c_str());
 }
 
 extern "C" void lambo_player_name_save(uint8_t* rdram) {

--- a/src/lambo_player_name.cpp
+++ b/src/lambo_player_name.cpp
@@ -123,6 +123,15 @@ extern "C" void lambo_player_name_restore_for_record(uint8_t* rdram, int player_
     LAMBO_LOG_INFO("name", "seeded player name: %s\n", saved.c_str());
 }
 
+extern "C" uint32_t lambo_player_name_record_byte(uintptr_t source_base) {
+    const uint32_t base = static_cast<uint32_t>(source_base);
+    if (base < 0x800A4160u || base >= 0x800A416Du) return 0xFFFFFFFFu;
+    const std::string saved = load_saved_name();
+    if (!valid_name(saved)) return 0xFFFFFFFFu;
+    const size_t index = base - 0x800A4160u;
+    return index < saved.size() ? static_cast<uint8_t>(saved[index]) : 0;
+}
+
 extern "C" void lambo_player_name_save(uint8_t* rdram) {
     if (current_driver(rdram) != kPlayerOne) return;
 

--- a/src/lambo_player_name.h
+++ b/src/lambo_player_name.h
@@ -12,6 +12,10 @@ extern "C" {
 void lambo_player_name_seed(uint8_t* rdram);
 void lambo_player_name_save(uint8_t* rdram);
 
+// Restore before the ROM copies a newly earned record. The record routines use
+// zero-based indices; only player zero owns the native persisted identity.
+void lambo_player_name_restore_for_record(uint8_t* rdram, int player_index);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lambo_player_name.h
+++ b/src/lambo_player_name.h
@@ -15,7 +15,6 @@ void lambo_player_name_save(uint8_t* rdram);
 // Restore before the ROM copies a newly earned record. The record routines use
 // zero-based indices; only player zero owns the native persisted identity.
 void lambo_player_name_restore_for_record(uint8_t* rdram, int player_index);
-uint32_t lambo_player_name_record_byte(uintptr_t source_base);
 
 #ifdef __cplusplus
 }

--- a/src/lambo_player_name.h
+++ b/src/lambo_player_name.h
@@ -15,6 +15,7 @@ void lambo_player_name_save(uint8_t* rdram);
 // Restore before the ROM copies a newly earned record. The record routines use
 // zero-based indices; only player zero owns the native persisted identity.
 void lambo_player_name_restore_for_record(uint8_t* rdram, int player_index);
+uint32_t lambo_player_name_record_byte(uintptr_t source_base);
 
 #ifdef __cplusplus
 }

--- a/tests/extract_player_record_funcs.py
+++ b/tests/extract_player_record_funcs.py
@@ -1,0 +1,26 @@
+"""Extract complete generated ROM functions for the player-name integration test.
+
+No ROM-derived C is checked in. Run N64Recomp first; hooks in its output are
+retained verbatim so this test also verifies the production hook placement.
+"""
+import pathlib
+import re
+import sys
+
+source, output = map(pathlib.Path, sys.argv[1:])
+wanted = {"func_8002A228", "func_800401F0"}
+found = {}
+for path in source.glob("funcs_*.c"):
+    for match in re.finditer(
+        r"^RECOMP_FUNC void (\w+)\(.*?(?=^RECOMP_FUNC void |\Z)",
+        path.read_text(), re.MULTILINE | re.DOTALL,
+    ):
+        if match[1] in wanted:
+            if match[1] in found:
+                raise RuntimeError(f"Duplicate function: {match[1]}")
+            found[match[1]] = match[0]
+if found.keys() != wanted:
+    raise RuntimeError(f"Missing generated functions: {wanted - found.keys()}")
+output.parent.mkdir(parents=True, exist_ok=True)
+output.write_text('#include "recomp.h"\n#include "funcs.h"\n' +
+                  "\n".join(found[name] for name in sorted(wanted)))

--- a/tests/extract_player_record_funcs.py
+++ b/tests/extract_player_record_funcs.py
@@ -13,7 +13,7 @@ found = {}
 for path in source.glob("funcs_*.c"):
     for match in re.finditer(
         r"^RECOMP_FUNC void (\w+)\(.*?(?=^RECOMP_FUNC void |\Z)",
-        path.read_text(), re.MULTILINE | re.DOTALL,
+        path.read_text(encoding="utf-8"), re.MULTILINE | re.DOTALL,
     ):
         if match[1] in wanted:
             if match[1] in found:
@@ -23,4 +23,4 @@ if found.keys() != wanted:
     raise RuntimeError(f"Missing generated functions: {wanted - found.keys()}")
 output.parent.mkdir(parents=True, exist_ok=True)
 output.write_text('#include "recomp.h"\n#include "funcs.h"\n' +
-                  "\n".join(found[name] for name in sorted(wanted)))
+                  "\n".join(found[name] for name in sorted(wanted)), encoding="utf-8")

--- a/tests/test_player_records.cpp
+++ b/tests/test_player_records.cpp
@@ -1,0 +1,160 @@
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "json/json.hpp"
+#include "lambo_player_name.h"
+#include "recomp.h"
+
+extern "C" void func_8002A228(uint8_t*, recomp_context*);
+extern "C" void func_800401F0(uint8_t*, recomp_context*);
+// The lap routine's only external call plays the new-record sound.
+extern "C" void func_80066F84(uint8_t*, recomp_context*) {}
+namespace lambo::config {
+std::filesystem::path app_config_dir() { std::abort(); }
+}
+
+namespace {
+constexpr gpr addr(uint32_t value) { return (gpr)(int32_t)value; }
+constexpr gpr profile = addr(0x800A4160);
+constexpr gpr player = addr(0x800A4826);
+int failures = 0;
+void expect(bool ok, const std::string& message) {
+    if (!ok) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+void put(uint8_t* rdram, gpr address, const std::string& name) {
+    for (int i = 0; i < 13; ++i) MEM_B(i, address) = i < name.size() ? name[i] : 0;
+}
+std::string get(uint8_t* rdram, gpr address) {
+    std::string result;
+    for (int i = 0; i < 13 && MEM_BU(i, address); ++i)
+        result += (char)MEM_BU(i, address);
+    return result;
+}
+void check_name(uint8_t* rdram, gpr address, const std::string& expected,
+                const std::string& label) {
+    const auto actual = get(rdram, address);
+    expect(actual == expected, label + ": expected " + expected + ", got " + actual);
+}
+}
+
+int main() {
+    const auto dir = std::filesystem::temp_directory_path() /
+        ("lambo-record-test-" + std::to_string(
+            std::chrono::steady_clock::now().time_since_epoch().count()));
+    std::filesystem::create_directories(dir);
+    const auto path = dir / "player.json";
+#ifdef _WIN32
+    _putenv_s("LAMBO_PLAYER_CONFIG", path.string().c_str());
+#else
+    setenv("LAMBO_PLAYER_CONFIG", path.string().c_str(), 1);
+#endif
+    for (const std::string saved : {"ADAM", "Adam"}) {
+        std::ofstream(path) << nlohmann::json{{"name", saved}};
+        for (int mode : {0, 2}) {
+            for (int mirror : {0, 1}) {
+                std::vector<uint8_t> memory(0x800000);
+                auto* rdram = memory.data();
+                put(rdram, player, "TITUS");
+                put(rdram, player + 13, "GUEST");
+                put(rdram, profile, "TITUS LAM64");
+                // Do not enter the editor: its driver selector is deliberately zero.
+                MEM_H(0, addr(0x800CE6B4)) = mode;
+                MEM_H(0, addr(0x800CE79C)) = mirror;
+                MEM_H(0, addr(0x800CE78C)) = 3; // configured laps
+                MEM_H(0, addr(0x800A5EF0)) = 1; // next crossing completes lap one
+                MEM_H(0, addr(0x800A5EF2)) = 1; // crossing counter before increment
+                MEM_H(0, addr(0x800B69B6)) = 1; // vehicle belongs to player one
+                MEM_H(0, addr(0x8009876C)) = 30; // lap timer: 0:30:00
+                MEM_W(0, addr(0x80098844)) = 3600; // previous best: 1:00:00
+                recomp_context ctx{};
+                ctx.r29 = addr(0x807FF000);
+                func_8002A228(rdram, &ctx);
+                const gpr lap_name = profile + (mode ? (mirror ? 0x17A : 0x72)
+                                                               : (mirror ? 0x61E : 0x516));
+                check_name(rdram, lap_name, "ADAM", "no-edit lap mode=" +
+                    std::to_string(mode) + " mirror=" + std::to_string(mirror) + " saved=" + saved);
+                expect(MEM_W(0, addr(0x80098844)) == 1800, "ROM records the completed 30-second lap");
+
+                // The vehicle index is still zero, but this vehicle now belongs
+                // to player two. The lap hook must use the resolved owner.
+                put(rdram, player, "LOCAL");
+                MEM_H(0, addr(0x800CE6A6)) = 1;
+                MEM_H(0, addr(0x800A5EF0)) = 1;
+                MEM_H(0, addr(0x800A5EF2)) = 1;
+                MEM_H(0, addr(0x800B69B6)) = 2;
+                MEM_H(0, addr(0x80098774)) = 20;
+                ctx = {};
+                ctx.r29 = addr(0x807FF000);
+                func_8002A228(rdram, &ctx);
+                check_name(rdram, lap_name, "GUEST", "lap uses resolved guest owner");
+                check_name(rdram, player, "LOCAL", "guest lap preserves player one");
+
+                // Exercise leaderboard restoration independently of the lap hook.
+                put(rdram, player, "TITUS");
+                const int times = mirror ? 0x448 : 0x3DA;
+                const int names = mirror ? 0x470 : 0x402;
+                for (int rank = 0; rank < 5; ++rank) {
+                    MEM_H(times + rank * 8 + 2, profile) = rank + 1;
+                    put(rdram, profile + names + rank * 14, "OLD" + std::to_string(rank));
+                }
+                MEM_H(2, addr(0x80098E60)) = 0;
+                MEM_H(4, addr(0x80098E60)) = 30;
+                ctx = {};
+                func_800401F0(rdram, &ctx);
+                expect(ctx.r2 == 0, "ROM awards first place");
+                check_name(rdram, profile + names, "ADAM", "no-edit leaderboard saved=" + saved);
+                check_name(rdram, profile + names + 14, "OLD0", "ROM shifts previous winner");
+                check_name(rdram, player + 13, "GUEST", "guest name preserved");
+                check_name(rdram, profile, "TITUS LAM64", "profile header preserved");
+
+                // A guest can earn a record while the editor still selects player one.
+                MEM_H(0, addr(0x800CE6A6)) = 1;
+                MEM_H(4, addr(0x80098E68)) = 20;
+                ctx = {};
+                ctx.r4 = 1;
+                func_800401F0(rdram, &ctx);
+                check_name(rdram, profile + names, "GUEST", "guest owns their earned record");
+                check_name(rdram, profile + names + 14, "ADAM", "previous player record preserved");
+            }
+        }
+        std::vector<uint8_t> memory(0x800000);
+        auto* rdram = memory.data();
+        put(rdram, player, "TITUS");
+        MEM_H(0, addr(0x800CE6A6)) = 1;
+        lambo_player_name_seed(rdram);
+        check_name(rdram, player, "ADAM", "editor seed saved=" + saved);
+    }
+
+    for (const std::string saved : {"", "NAME123", "ABCDEFGHIJKLM", "\xC3\xA9"}) {
+        std::ofstream(path) << nlohmann::json{{"name", saved}};
+        std::vector<uint8_t> memory(0x800000);
+        auto* rdram = memory.data();
+        put(rdram, player, "TITUS");
+        lambo_player_name_restore_for_record(rdram, 0);
+        check_name(rdram, player, "TITUS", "unsupported saved name preserves ROM buffer");
+    }
+    {
+        std::vector<uint8_t> memory(0x800000);
+        auto* rdram = memory.data();
+        std::ofstream(path) << nlohmann::json{{"name", "abcdefghijkl"}};
+        MEM_B(13, player) = 0x55;
+        lambo_player_name_restore_for_record(rdram, 0);
+        check_name(rdram, player, "ABCDEFGHIJKL", "maximum length normalized intact");
+        expect(MEM_BU(12, player) == 0 && MEM_BU(13, player) == 0x55,
+               "terminator stays inside player buffer");
+        MEM_H(0, addr(0x800CE6A6)) = 1;
+        put(rdram, player, "CHAMP");
+        lambo_player_name_save(rdram);
+        put(rdram, player, "TITUS");
+        lambo_player_name_restore_for_record(rdram, 0);
+        check_name(rdram, player, "CHAMP", "confirmed edits take precedence over previous saved name");
+    }
+    std::filesystem::remove(path);
+    std::filesystem::remove(dir);
+    return failures ? 1 : 0;
+}

--- a/tests/test_player_records.cpp
+++ b/tests/test_player_records.cpp
@@ -108,6 +108,7 @@ int main() {
                 func_800401F0(rdram, &ctx);
                 expect(ctx.r2 == 0, "ROM awards first place");
                 check_name(rdram, profile + names, "ADAM", "no-edit leaderboard saved=" + saved);
+                check_name(rdram, player, "ADAM", "leaderboard restores player buffer");
                 check_name(rdram, profile + names + 14, "OLD0", "ROM shifts previous winner");
                 check_name(rdram, player + 13, "GUEST", "guest name preserved");
                 check_name(rdram, profile, "TITUS LAM64", "profile header preserved");


### PR DESCRIPTION
Fixes issue #170 where a persisted player name was replaced by TITUS in Arcade and Time Trial records when the name-entry screen was skipped.

## Why?

Closes #170

The fix normalizes persisted names to the ROM's uppercase alphabet, restores the lap-record source after player ownership is resolved, and restores player one's source buffer once at leaderboard function entry before ranking and insertion. It does not hook the inner byte-copy loops or perform repeated file I/O. Guest records and ROM-controlled ranking/row shifting remain untouched.

## How was it verified?

- [ ] Built clean with `build.sh` (Linux) / `build.ps1` (Windows) - no manual cmake incantation
- [x] Booted and manually verified a record displays the persisted player name
- [ ] If visual: screenshot or short clip attached / linked below
- [ ] If config/schema: defaults preserved when fields absent in `graphics.json`
- [ ] If new dep patch: mirrored in both `build.sh` AND `build.ps1` AND CI (`build-release.yml`)
- [x] If new hook into recompiled code: also mirrored in `scripts/gen_syms_toml.py` (the `PATCH_BLOCKS`-stale trap)
- [x] No comments that explain *what* the code does (only *why* - see `CLAUDE.md`)
- [x] No AI attribution footer in commits or PR description

`lambo_player_records` passes. Coverage includes no-edit persisted names, Arcade/Time Trial, normal/mirrored paths, guest ownership, record shifting, invalid names, maximum-length names, and confirmed edits. `git diff --check` passes. A clean full build remains unchecked because this worktree's local N64ModernRuntime checkout is missing generated source files; no runtime or DirectX files are part of this PR.

## Screenshots / video

Not a rendering change.

## Risk / rollback

The hooks affect only player one's record-name source buffer; revert the PR commits to restore the prior behavior.
