### PR TITLE
feat: exe-anchored portable mode with --portable flag

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -86,7 +86,7 @@ lamborghini_modern.exe --console --verbose
 ```
 
 Then attach the newest `logs/lamborghini-*.log` from
-`%LOCALAPPDATA%\LamborghiniRecomp` (or the portable launch directory). The
+`%LOCALAPPDATA%\LamborghiniRecomp` (or the portable game directory). The
 preferred `--verbose` flag is equivalent to `--log-level=debug`; use
 `--log-level=trace` only when a maintainer requests the noisier trace.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,14 @@ if(BUILD_TESTING)
     target_link_libraries(lambo_log_tests PRIVATE Threads::Threads)
     add_test(NAME lambo_logging_policy COMMAND lambo_log_tests)
 
+    add_executable(lambo_portable_paths_tests
+        tests/test_portable_paths.cpp
+    )
+    target_include_directories(lambo_portable_paths_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    add_test(NAME lambo_portable_paths COMMAND lambo_portable_paths_tests)
+
     add_executable(lambo_camera_projection_tests
         tests/test_camera_projection.cpp
     )

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ file at once.
 ## Graphics options
 
 Graphics settings persist in `graphics.json` (in `%LOCALAPPDATA%\LamborghiniRecomp` on
-Windows, `~/.config/LamborghiniRecomp` elsewhere; create a `portable.txt` in the
-directory you launch from to keep everything there instead). Game saves live in the
+Windows, `~/.config/LamborghiniRecomp` elsewhere; create an empty `portable.txt` next
+to the game executable, or launch with `--portable`, to keep everything next to the
+game instead — handy for USB-stick or D:-drive installs). Game saves live in the
 same directory. The file is created with
 defaults on first run. On Windows, the **Graphics** and **Enhancements** menu-bar menus
 apply the commonly used options immediately and save them automatically. The graphics API
@@ -107,7 +108,7 @@ generating `rt64.json`, testing a loose pack, and packaging it as `.rtz`.
 ## In-Game Configuration & Controls
 
 - **Configuration Overlay**: Press the **Menu / Back / Start / Guide** button on your controller, or press <kbd>Esc</kbd> / <kbd>F1</kbd> on your keyboard (or use the native window menu `Game -> Settings` / `Controls`) to open the in-game configuration overlay at any time.
-- **Controls Remapping**: The **Controls Mapper** provides a 4-column N64 controller mapping interface for all digital buttons, triggers, C-buttons, D-Pad, and analog stick axes. Custom mappings persist per physical controller (by SDL GUID) in `%LOCALAPPDATA%\LamborghiniRecomp\controls.json` (or `~/.config/LamborghiniRecomp/controls.json`).
+- **Controls Remapping**: The **Controls Mapper** provides a 4-column N64 controller mapping interface for all digital buttons, triggers, C-buttons, D-Pad, and analog stick axes. Custom mappings persist per physical controller (by SDL GUID) in `%LOCALAPPDATA%\LamborghiniRecomp\controls.json` (or `~/.config/LamborghiniRecomp/controls.json`; portable mode keeps it next to the game — see above).
 
 
 ## Troubleshooting

--- a/src/lambo_config.h
+++ b/src/lambo_config.h
@@ -19,6 +19,9 @@ namespace config {
 // Per-user persistent config directory (created on demand):
 //   Windows: %LOCALAPPDATA%\LamborghiniRecomp
 //   else:    $XDG_CONFIG_HOME/LamborghiniRecomp (or ~/.config/LamborghiniRecomp)
+// Portable mode (issue #190): an empty portable.txt next to the executable,
+// the --portable flag, or LAMBO_PORTABLE=1 keeps everything next to the game
+// instead (see lambo_paths.h).
 std::filesystem::path app_config_dir();
 
 // Absolute path of the live graphics.json (honours the LAMBO_GRAPHICS_CONFIG

--- a/src/lambo_paths.h
+++ b/src/lambo_paths.h
@@ -1,8 +1,11 @@
 #ifndef LAMBO_PATHS_H
 #define LAMBO_PATHS_H
 
+#include <cctype>
 #include <cstdlib>
 #include <filesystem>
+#include <optional>
+#include <string>
 
 #if defined(_WIN32)
 #include <cwchar>
@@ -12,12 +15,96 @@
 // lambo::config::app_config_dir() forwards here for existing callers, while
 // logging/crash reporting can use the state sibling without depending on the
 // full graphics-config implementation.
+//
+// Portable mode (issue #190) keeps everything next to the game instead of on
+// the system drive, for USB/D: installs. It follows the de-facto emulator
+// convention (Dolphin, DuckStation, PCSX2, Zelda64Recomp): an empty
+// portable.txt next to the executable, or the --portable flag /
+// LAMBO_PORTABLE env var, forces the exe directory. A portable.txt in the
+// launch working directory is still honoured as a fallback so developer and
+// test runs from a build tree keep working.
 namespace lambo::paths {
 
-inline std::filesystem::path app_config_dir() {
+namespace detail {
+
+inline std::optional<std::filesystem::path>& executable_dir_slot() {
+    static std::optional<std::filesystem::path> slot;
+    return slot;
+}
+
+inline bool& portable_forced_slot() {
+    static bool forced = false;
+    return forced;
+}
+
+inline bool env_portable_requested() {
+    if (const char* value = std::getenv("LAMBO_PORTABLE");
+        value != nullptr && value[0] != '\0') {
+        std::string text{value};
+        for (auto& c : text) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        return !(text == "0" || text == "false" || text == "no" || text == "off");
+    }
+    return false;
+}
+
+inline bool marker_in(const std::filesystem::path& dir) {
     std::error_code ec;
-    if (std::filesystem::exists("portable.txt", ec))
-        return std::filesystem::current_path();
+    return std::filesystem::exists(dir / "portable.txt", ec);
+}
+
+} // namespace detail
+
+// Startup seam: main() records the executable directory before logging
+// initialises (the log directory itself depends on portable resolution).
+// Tests use this plus the forced flag to control resolution hermetically.
+inline void set_executable_dir(const std::filesystem::path& dir) {
+    detail::executable_dir_slot() = dir;
+}
+inline void clear_executable_dir() { detail::executable_dir_slot().reset(); }
+inline void set_portable_forced(bool forced) { detail::portable_forced_slot() = forced; }
+
+// Directory selected by a portable.txt marker: the executable directory wins
+// over the launch working directory. Empty when no marker is present.
+inline std::optional<std::filesystem::path> portable_marker_dir() {
+    const auto& exe = detail::executable_dir_slot();
+    if (exe.has_value() && detail::marker_in(*exe)) return exe;
+    std::error_code ec;
+    if (std::filesystem::exists("portable.txt", ec)) {
+        std::error_code cwd_ec;
+        std::filesystem::path cwd = std::filesystem::current_path(cwd_ec);
+        if (!cwd_ec) return cwd;
+        return std::filesystem::path{"."};
+    }
+    return std::nullopt;
+}
+
+inline bool portable_mode() {
+    if (detail::portable_forced_slot() || detail::env_portable_requested()) return true;
+    return portable_marker_dir().has_value();
+}
+
+// Directory portable mode keeps files in: the marker that triggered it, or
+// the executable directory (forced mode), falling back to the launch
+// directory when the executable directory is unknown (tests).
+inline std::filesystem::path portable_root() {
+    if (const auto marker = portable_marker_dir(); marker.has_value()) return *marker;
+    const auto& exe = detail::executable_dir_slot();
+    if (exe.has_value()) return *exe;
+    return std::filesystem::current_path();
+}
+
+// Short human-readable reason for the startup log line. Only meaningful when
+// portable_mode() is true.
+inline const char* portable_mode_source() {
+    if (detail::portable_forced_slot()) return "--portable flag";
+    if (detail::env_portable_requested()) return "LAMBO_PORTABLE";
+    const auto& exe = detail::executable_dir_slot();
+    if (exe.has_value() && detail::marker_in(*exe)) return "portable.txt next to executable";
+    return "portable.txt in launch directory";
+}
+
+inline std::filesystem::path app_config_dir() {
+    if (portable_mode()) return portable_root();
 #if defined(_WIN32)
     if (const wchar_t* localappdata = _wgetenv(L"LOCALAPPDATA");
         localappdata != nullptr && localappdata[0] != L'\0')
@@ -35,9 +122,7 @@ inline std::filesystem::path app_config_dir() {
 }
 
 inline std::filesystem::path app_state_dir() {
-    std::error_code ec;
-    if (std::filesystem::exists("portable.txt", ec))
-        return std::filesystem::current_path();
+    if (portable_mode()) return portable_root();
 #if defined(_WIN32)
     return app_config_dir();
 #else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include <latch>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include <utility>
@@ -43,10 +44,16 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <shellapi.h>
+#elif defined(__APPLE__)
+#include <mach-o/dyld.h>
+#include <limits.h>
+#else
+#include <unistd.h>
 #endif
 #include "lambo_rt64.h"
 #include "lambo_audio.h"
 #include "lambo_config.h"
+#include "lambo_paths.h"
 #include "lambo_crash.h"   // issue #13 / A14
 #include "lambo_gpu_advisory.h"  // issue #109: outdated-driver popup handoff
 #include "lambo_log.h"   
@@ -708,7 +715,80 @@ static std::filesystem::path unused_backup_path(const std::filesystem::path& pat
     return candidate;
 }
 
+// Portable mode (issue #190): exact --portable match. Parsed here rather than
+// in lambo_log_parse_args because the log directory itself depends on it.
+static bool has_portable_arg(int argc, char** argv) {
+    for (int i = 1; i < argc; ++i) {
+        if (argv[i] != nullptr && std::strcmp(argv[i], "--portable") == 0) return true;
+    }
+    return false;
+}
+
+// Resolve the directory containing this executable. The launch working
+// directory is not reliable: shortcuts, Steam, drag-drop imports, and CLI
+// runs from another folder all change it, while users expect portable files
+// next to the game itself.
+static std::optional<std::filesystem::path> executable_dir_from_platform(const char* argv0) {
+#if defined(_WIN32)
+    std::vector<wchar_t> buffer(32768);
+    const DWORD length =
+        GetModuleFileNameW(nullptr, buffer.data(), static_cast<DWORD>(buffer.size()));
+    if (length > 0 && length < buffer.size()) {
+        const std::filesystem::path parent =
+            std::filesystem::path{std::wstring(buffer.data(), length)}.parent_path();
+        if (!parent.empty()) return parent;
+    }
+#elif defined(__APPLE__)
+    uint32_t size = 0;
+    _NSGetExecutablePath(nullptr, &size);
+    if (size > 0) {
+        std::string buffer(size, '\0');
+        if (_NSGetExecutablePath(buffer.data(), &size) == 0) {
+            std::vector<char> resolved(PATH_MAX);
+            if (::realpath(buffer.c_str(), resolved.data()) != nullptr)
+                return std::filesystem::path{resolved.data()}.parent_path();
+            return std::filesystem::path{buffer.c_str()}.parent_path();
+        }
+    }
+#else
+    std::vector<char> buffer(4096);
+    for (;;) {
+        const ssize_t length =
+            ::readlink("/proc/self/exe", buffer.data(), buffer.size());
+        if (length < 0) break;
+        if (static_cast<size_t>(length) < buffer.size()) {
+            const std::filesystem::path parent =
+                std::filesystem::path{std::string(buffer.data(), static_cast<size_t>(length))}
+                    .parent_path();
+            if (!parent.empty()) return parent;
+            break;
+        }
+        if (buffer.size() >= 1u << 20) break;
+        buffer.resize(buffer.size() * 2);
+    }
+#endif
+    // argv[0] fallback: an absolute (or CWD-relative, separator-bearing) path
+    // still identifies the executable directory. A bare filename found via
+    // PATH tells us nothing, so report unknown and let callers use CWD.
+    if (argv0 != nullptr && argv0[0] != '\0') {
+        const std::filesystem::path candidate = path_from_utf8(argv0);
+        if (candidate.has_parent_path()) {
+            std::error_code ec;
+            if (candidate.is_absolute()) return candidate.parent_path();
+            const std::filesystem::path absolute = std::filesystem::absolute(candidate, ec);
+            if (!ec) return absolute.parent_path();
+        }
+    }
+    return std::nullopt;
+}
+
 static int application_main(int argc, char** argv) {
+    // Portable mode must resolve before logging initialises: the log file
+    // directory itself depends on it (issue #190).
+    if (const auto exe = executable_dir_from_platform(argc > 0 ? argv[0] : nullptr);
+        exe.has_value())
+        lambo::paths::set_executable_dir(*exe);
+    lambo::paths::set_portable_forced(has_portable_arg(argc, argv));
     // Parse and initialise logging before any startup path can emit a message.
     // The Windows target is GUI-subsystem, so --console is responsible for
     // attaching/allocating the live stderr sink.
@@ -720,6 +800,16 @@ static int application_main(int argc, char** argv) {
         return 2;
     }
     (void)lambo_log_initialize();
+    // Say once where settings and saves live so "it forgot my progress"
+    // reports are answerable from the log.
+    if (lambo::paths::portable_mode()) {
+        LAMBO_LOG_INFO("config", "portable mode (%s): settings and saves in %s\n",
+                       lambo::paths::portable_mode_source(),
+                       path_to_utf8(lambo::config::app_config_dir()).c_str());
+    } else {
+        LAMBO_LOG("config", "settings and saves in %s\n",
+                  path_to_utf8(lambo::config::app_config_dir()).c_str());
+    }
 #if defined(_WIN32)
     // SDL2main normally performs this when it owns WinMain. This target owns
     // WinMain because it is a GUI-subsystem executable.

--- a/tests/test_portable_paths.cpp
+++ b/tests/test_portable_paths.cpp
@@ -1,0 +1,188 @@
+// Portable-mode path resolution (issue #190): an empty portable.txt next to
+// the executable (or --portable / LAMBO_PORTABLE) keeps settings and saves
+// next to the game instead of %LOCALAPPDATA% / XDG. The executable directory
+// wins over the launch working directory.
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "lambo_paths.h"
+
+namespace {
+
+void set_env(const char* name, const char* value) {
+#if defined(_WIN32)
+    _putenv_s(name, value);
+#else
+    if (value[0] == '\0')
+        unsetenv(name);
+    else
+        setenv(name, value, 1);
+#endif
+}
+
+struct PathsReset {
+    PathsReset() { reset(); }
+    ~PathsReset() { reset(); }
+    static void reset() {
+        lambo::paths::clear_executable_dir();
+        lambo::paths::set_portable_forced(false);
+        set_env("LAMBO_PORTABLE", "");
+    }
+};
+
+struct CwdGuard {
+    std::filesystem::path saved;
+    bool ok = false;
+    explicit CwdGuard(const std::filesystem::path& dir) {
+        std::error_code ec;
+        saved = std::filesystem::current_path(ec);
+        if (ec) return;
+        std::filesystem::current_path(dir, ec);
+        ok = !ec;
+    }
+    ~CwdGuard() {
+        if (ok) {
+            std::error_code ec;
+            std::filesystem::current_path(saved, ec);
+        }
+    }
+};
+
+bool same_dir(const std::filesystem::path& a, const std::filesystem::path& b) {
+    std::error_code ec;
+    if (std::filesystem::equivalent(a, b, ec) && !ec) return true;
+    return a == b;
+}
+
+void touch(const std::filesystem::path& path) {
+    std::ofstream out{path};
+    out << "";
+}
+
+} // namespace
+
+int main() {
+    int failures = 0;
+    auto expect = [&](bool condition, const char* message) {
+        if (!condition) {
+            std::fprintf(stderr, "FAIL: %s\n", message);
+            ++failures;
+        }
+    };
+
+    const std::filesystem::path base =
+        std::filesystem::temp_directory_path() / "lambo-portable-paths-test";
+    const std::filesystem::path exe_dir = base / "exe";
+    const std::filesystem::path cwd_dir = base / "cwd";
+    const std::filesystem::path plain_dir = base / "plain";
+    std::error_code ec;
+    std::filesystem::remove_all(base, ec);
+    std::filesystem::create_directories(exe_dir, ec);
+    std::filesystem::create_directories(cwd_dir, ec);
+    std::filesystem::create_directories(plain_dir, ec);
+    if (ec) {
+        std::fprintf(stderr, "FAIL: cannot create temp dirs: %s\n", ec.message().c_str());
+        return 1;
+    }
+    // Markers for the exe-wins and cwd-fallback cases; plain_dir stays clean
+    // for the default-off / forced / env cases.
+    touch(exe_dir / "portable.txt");
+    touch(cwd_dir / "portable.txt");
+
+    {
+        // Executable-directory marker wins over the launch-directory marker.
+        PathsReset reset;
+        CwdGuard cwd{cwd_dir};
+        expect(cwd.ok, "test setup: chdir to marker cwd works");
+        lambo::paths::set_executable_dir(exe_dir);
+        expect(lambo::paths::portable_mode(), "exe portable.txt enables portable mode");
+        expect(same_dir(lambo::paths::portable_root(), exe_dir),
+               "exe directory wins over launch directory");
+        expect(same_dir(lambo::paths::app_config_dir(), exe_dir),
+               "config dir follows the exe directory in portable mode");
+        expect(same_dir(lambo::paths::app_state_dir(), exe_dir),
+               "state dir follows the exe directory in portable mode");
+        expect(std::string(lambo::paths::portable_mode_source()).find("executable") !=
+                   std::string::npos,
+               "source names the executable directory");
+    }
+
+    {
+        // Launch-directory marker is the fallback when the exe dir is unknown
+        // (developer build-tree runs) or has no marker.
+        PathsReset reset;
+        CwdGuard cwd{cwd_dir};
+        expect(cwd.ok, "test setup: chdir to marker cwd works");
+        expect(lambo::paths::portable_mode(), "cwd portable.txt enables portable mode");
+        expect(same_dir(lambo::paths::portable_root(), cwd_dir),
+               "launch directory is the portable fallback");
+        expect(std::string(lambo::paths::portable_mode_source()).find("launch") !=
+                   std::string::npos,
+               "source names the launch directory fallback");
+    }
+
+    {
+        // No markers anywhere: system locations, not portable.
+        PathsReset reset;
+        lambo::paths::set_executable_dir(plain_dir);
+        CwdGuard cwd{plain_dir};
+        expect(cwd.ok, "test setup: chdir to plain dir works");
+        expect(!lambo::paths::portable_mode(), "no marker means portable mode is off");
+    }
+
+    {
+        // --portable force flag: portable without any marker file, rooted at
+        // the executable directory.
+        PathsReset reset;
+        lambo::paths::set_executable_dir(plain_dir);
+        CwdGuard cwd{plain_dir};
+        expect(cwd.ok, "test setup: chdir to plain dir works");
+        lambo::paths::set_portable_forced(true);
+        expect(lambo::paths::portable_mode(), "--portable forces portable mode");
+        expect(same_dir(lambo::paths::portable_root(), plain_dir),
+               "forced portable mode roots at the executable directory");
+        expect(same_dir(lambo::paths::app_config_dir(), plain_dir),
+               "forced portable config dir is the executable directory");
+        expect(std::string(lambo::paths::portable_mode_source()).find("portable flag") !=
+                   std::string::npos,
+               "source names the --portable flag");
+    }
+
+    {
+        // Forced mode without a known executable directory falls back to CWD.
+        PathsReset reset;
+        CwdGuard cwd{plain_dir};
+        expect(cwd.ok, "test setup: chdir to plain dir works");
+        lambo::paths::set_portable_forced(true);
+        expect(lambo::paths::portable_mode(), "--portable works without exe dir");
+        expect(same_dir(lambo::paths::portable_root(), plain_dir),
+               "forced portable without exe dir uses the launch directory");
+    }
+
+    {
+        // LAMBO_PORTABLE env var enables portable mode; falsy values opt out.
+        PathsReset reset;
+        lambo::paths::set_executable_dir(plain_dir);
+        CwdGuard cwd{plain_dir};
+        expect(cwd.ok, "test setup: chdir to plain dir works");
+        set_env("LAMBO_PORTABLE", "1");
+        expect(lambo::paths::portable_mode(), "LAMBO_PORTABLE=1 enables portable mode");
+        expect(same_dir(lambo::paths::portable_root(), plain_dir),
+               "env portable mode roots at the executable directory");
+        expect(std::string(lambo::paths::portable_mode_source()).find("LAMBO_PORTABLE") !=
+                   std::string::npos,
+               "source names LAMBO_PORTABLE");
+        for (const char* off : {"0", "false", "no", "off"}) {
+            set_env("LAMBO_PORTABLE", off);
+            expect(!lambo::paths::portable_mode(),
+                   "falsy LAMBO_PORTABLE values leave portable mode off");
+        }
+    }
+
+    std::filesystem::remove_all(base, ec);
+    if (failures == 0) std::printf("portable paths: all cases passed\n");
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Closes #190

## What

Keeps settings, saves, logs, and crash reports next to the game instead of
`%LOCALAPPDATA%` / XDG, for USB-stick and secondary-drive installs.

- `src/lambo_paths.h`: portable mode now anchors to the **executable
  directory** (was: launch working directory, which silently broke under
  shortcuts, Steam, drag-drop imports, and CLI runs from another folder).
  An empty `portable.txt` next to the exe triggers it; a `portable.txt` in
  the launch directory remains as a fallback for build-tree runs. This
  matches the Dolphin / DuckStation / PCSX2 / Zelda64Recomp convention.
- `src/main.cpp`: new `--portable` CLI flag, exe-dir detection before log
  init (`GetModuleFileNameW` / `/proc/self/exe` / `_NSGetExecutablePath` /
  `argv[0]` fallback), and a startup log line so "where are my saves?" is
  answerable from the log:
  `portable mode (--portable flag): settings and saves in <dir>`.
- `LAMBO_PORTABLE=1` env var as a non-file trigger (consistent with the
  existing `LAMBO_*` overrides). No auto-migration of existing AppData
  files: fresh dir + log line, same as the reference emulators.
- `tests/test_portable_paths.cpp` (new, wired into CMake/CTest): exe marker
  beats CWD marker, CWD fallback, default-off, forced flag with and without
  a known exe dir, env on/falsy-offs, source strings.
- Docs: README graphics + controls sections, `lambo_config.h` comment,
  bug-report template.

## Verification

- Full `build.ps1` build green; `ctest -R "^lambo"`: 30/30 pass, including
  the new `lambo_portable_paths`.
- `python tools/run_game_scenario.py scenarios/harness-smoke.json`: PASS.
- Live E2E from the repo root (CWD != exe dir): both `--portable` and a
  `portable.txt` next to the exe wrote `graphics.json`, the Controller Pak,
  and `logs/` into `build/` with the correct log line, and nothing leaked
  into the repo root or `%LOCALAPPDATA%`. Verified artifacts, then removed
  them.
