### PR TITLE
feat(menu): expose camera knobs and driver name in options surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ N64Recomp ports (Zelda 64: Recompiled et al.):
 | `fog_scale_circuit` | array of 6 numbers | `[1,1,1,1,1,1]` | Per-circuit fog multipliers (multiplied with `fog_scale`), e.g. clear a single hazy track by lowering its entry. |
 | `draw_distance` | `0` or `0.1`–`100` | `1.5` | Multiplier on the authored per-circuit draw-distance radii (needs `no_lod`). `1.0` = the N64 distances, higher = see further, `0` = unlimited — note that unlimited draws distant track pieces the artists never meant to be visible (they float with nothing in between). |
 | `draw_distance_circuit` | array of 6 numbers | `[1,1,1,1,1,1]` | Per-circuit draw-distance multipliers (multiplied with `draw_distance`), e.g. extend just one short-sighted city track. |
+| `camera_distance_scale` | `0.2`–`3.0` | `1.0` | Multiplier on the chase camera's authored distance from the car (`1.0` = stock, `0.5` = half as far). Also settable live from the Enhancements menu / options page. |
+| `camera_height_scale` | `0.2`–`3.0` | `1.0` | Multiplier on the chase camera's authored eye-height offset. Also settable live from the Enhancements menu / options page. |
 | `camera_fov_add` | `-20`–`60` degrees | `0` | Degrees added to each camera layout's authored field of view (sense-of-speed effect). The scene builder's view-cone cull widens to match, so higher values do not cause peripheral pop-in. Also settable live from the Enhancements menu. |
 | `show_launcher` | `true`, `false` | `false` | When `false`, the game auto-boots directly into gameplay with the in-game configuration overlay available during play. When `true`, presents the standalone launcher shell at boot. Overridable via `LAMBO_LAUNCHER=1/0`. |
 
@@ -109,7 +111,8 @@ generating `rt64.json`, testing a loose pack, and packaging it as `.rtz`.
 
 ## In-Game Configuration & Controls
 
-- **Configuration Overlay**: Press the **Menu / Back / Start / Guide** button on your controller, or press <kbd>Esc</kbd> / <kbd>F1</kbd> on your keyboard (or use the native window menu `Game -> Settings` / `Controls`) to open the in-game configuration overlay at any time.
+- **Configuration Overlay**: Press the **Menu / Back / Start / Guide** button on your controller, or press <kbd>Esc</kbd> / <kbd>F1</kbd> on your keyboard (or use the native window menu `Game -> Settings` / `Controls` / `Driver name`) to open the in-game configuration overlay at any time.
+- **Driver Name**: Player one's identity for Championship records lives in `player.json` next to the other config files. Edit it under Settings → Driver Name in the overlay (or the in-game Championship name editor — both stay in sync), or clear it there to return to the ROM default. The launcher shows the current driver.
 - **Controls Remapping**: The **Controls Mapper** provides a 4-column N64 controller mapping interface for all digital buttons, triggers, C-buttons, D-Pad, and analog stick axes. Custom mappings persist per physical controller (by SDL GUID) in `%LOCALAPPDATA%\LamborghiniRecomp\controls.json` (or `~/.config/LamborghiniRecomp/controls.json`; portable mode keeps it next to the game — see above).
 
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ N64Recomp ports (Zelda 64: Recompiled et al.):
 | `draw_distance_circuit` | array of 6 numbers | `[1,1,1,1,1,1]` | Per-circuit draw-distance multipliers (multiplied with `draw_distance`), e.g. extend just one short-sighted city track. |
 | `camera_distance_scale` | `0.2`–`3.0` | `1.0` | Multiplier on the chase camera's authored distance from the car (`1.0` = stock, `0.5` = half as far). Also settable live from the Enhancements menu / options page. |
 | `camera_height_scale` | `0.2`–`3.0` | `1.0` | Multiplier on the chase camera's authored eye-height offset. Also settable live from the Enhancements menu / options page. |
-| `camera_fov_add` | `-20`–`60` degrees | `0` | Degrees added to each camera layout's authored field of view (sense-of-speed effect). The scene builder's view-cone cull widens to match, so higher values do not cause peripheral pop-in. Also settable live from the Enhancements menu. |
+| `camera_fov_add` | `-20`–`60` degrees | `0` | Degrees added to each camera layout's authored field of view (sense-of-speed effect). The scene builder's view-cone cull widens to match, so higher values do not cause peripheral pop-in. Also settable live from the Enhancements menu / options page. |
 | `show_launcher` | `true`, `false` | `false` | When `false`, the game auto-boots directly into gameplay with the in-game configuration overlay available during play. When `true`, presents the standalone launcher shell at boot. Overridable via `LAMBO_LAUNCHER=1/0`. |
 
 ## Texture packs

--- a/assets/ui/lambo.rcss
+++ b/assets/ui/lambo.rcss
@@ -190,6 +190,19 @@ input {
   text-transform: uppercase;
 }
 
+.mouse-active input:hover,
+.controller-active input:focus,
+input:focus,
+input:focus-visible {
+  background-color: #2b3e5c;
+  border-color: #4dabf7;
+  color: #ffffff;
+}
+
+.menu-card.slim {
+  min-height: 110dp;
+}
+
 .overlay-actions {
   display: flex;
   flex-direction: row;

--- a/assets/ui/lambo.rcss
+++ b/assets/ui/lambo.rcss
@@ -174,6 +174,22 @@ button:disabled {
   border-color: #1e2837;
 }
 
+input {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 8dp 0;
+  padding: 14dp 20dp;
+  border: 1.5dp solid #334661;
+  border-radius: 8dp;
+  background-color: #0b101b;
+  color: #ffffff;
+  font-size: 20dp;
+  font-weight: bold;
+  letter-spacing: 2dp;
+  text-transform: uppercase;
+}
+
 .overlay-actions {
   display: flex;
   flex-direction: row;

--- a/assets/ui/launcher.rml
+++ b/assets/ui/launcher.rml
@@ -11,6 +11,7 @@
             <h1>AUTOMOBILI LAMBORGHINI</h1>
             <span class="badge-pill">RECOMPILED</span>
           </div>
+          <p class="brand-subtitle">Driver: <span id="launcher-driver-name" class="highlight-val">Loading...</span> (change it under Settings, Driver Name)</p>
         </div>
 
         <div class="grid-2x2">

--- a/assets/ui/pages/enhancements.rml
+++ b/assets/ui/pages/enhancements.rml
@@ -33,6 +33,12 @@
             <button onclick="setting:circuit:5"><span class="setting-label">Circuit 5 (Pro)</span><span id="enhancement-circuit-5" class="setting-value">Loading...</span></button>
             <button onclick="setting:circuit:6"><span class="setting-label">Circuit 6 (Pro)</span><span id="enhancement-circuit-6" class="setting-value">Loading...</span></button>
           </div>
+          <div class="column">
+            <h2>Chase camera (sense of speed)</h2>
+            <button onclick="setting:camdist:next"><span class="setting-label">Camera distance</span><span id="enhancement-camdist" class="setting-value">Loading...</span></button>
+            <button onclick="setting:camheight:next"><span class="setting-label">Camera height</span><span id="enhancement-camheight" class="setting-value">Loading...</span></button>
+            <button onclick="setting:fov:next"><span class="setting-label">Field-of-view boost</span><span id="enhancement-fov" class="setting-value">Loading...</span></button>
+          </div>
         </div>
 
         <button class="secondary exit-btn" onclick="back">Back to Settings</button>

--- a/assets/ui/pages/player.rml
+++ b/assets/ui/pages/player.rml
@@ -10,7 +10,7 @@
           <div class="brand-title-row">
             <h1>DRIVER NAME</h1>
           </div>
-          <p class="brand-subtitle">Player one's saved identity, used for Championship records. Settings save automatically.</p>
+          <p class="brand-subtitle">Player one's saved identity, used for Championship records. Saved to player.json when you activate Save below.</p>
         </div>
 
         <p class="help">1-12 letters A-Z and spaces. Lowercase is uppercased automatically. The in-game Championship name editor saves here too, so both stay in sync.</p>
@@ -21,8 +21,8 @@
             <p>Current driver: <span id="player-name-current" class="highlight-val">Loading...</span></p>
             <p>Edit the name below, then activate Save. Keyboard: click the field and type, then Tab to Save.</p>
             <input type="text" id="player-name-input" maxlength="12" size="14" value=""/>
-            <button id="autofocus" onclick="player:save"><span class="setting-label">Save driver name</span></button>
-            <button onclick="player:clear"><span class="setting-label">Clear saved name (use ROM default)</span></button>
+            <button id="autofocus" onclick="player:save">Save driver name</button>
+            <button onclick="player:clear">Clear saved name (use ROM default)</button>
             <p id="player-name-status" class="summary"></p>
           </div>
         </div>

--- a/assets/ui/pages/player.rml
+++ b/assets/ui/pages/player.rml
@@ -1,0 +1,42 @@
+<rml>
+  <head>
+    <title>Driver name</title>
+    <link type="text/rcss" href="../lambo.rcss"/>
+  </head>
+  <body>
+    <div id="window">
+      <div class="panel">
+        <div class="header-brand">
+          <div class="brand-title-row">
+            <h1>DRIVER NAME</h1>
+          </div>
+          <p class="brand-subtitle">Player one's saved identity, used for Championship records. Settings save automatically.</p>
+        </div>
+
+        <p class="help">1-12 letters A-Z and spaces. Lowercase is uppercased automatically. The in-game Championship name editor saves here too, so both stay in sync.</p>
+
+        <div class="columns">
+          <div class="column">
+            <h2>Saved driver</h2>
+            <p>Current driver: <span id="player-name-current" class="highlight-val">Loading...</span></p>
+            <p>Edit the name below, then activate Save. Keyboard: click the field and type, then Tab to Save.</p>
+            <input type="text" id="player-name-input" maxlength="12" size="14" value=""/>
+            <button id="autofocus" onclick="player:save"><span class="setting-label">Save driver name</span></button>
+            <button onclick="player:clear"><span class="setting-label">Clear saved name (use ROM default)</span></button>
+            <p id="player-name-status" class="summary"></p>
+          </div>
+        </div>
+
+        <button class="secondary exit-btn" onclick="back">Back to Settings</button>
+
+        <div class="footer-bar">
+          <div class="controller-guide">
+            <span class="guide-item"><span class="guide-key">A / Enter</span> Save / Clear</span>
+            <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
+            <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</rml>

--- a/assets/ui/settings.rml
+++ b/assets/ui/settings.rml
@@ -37,7 +37,7 @@
           </div>
 
           <div class="grid-row">
-            <button class="menu-card" onclick="page:player">
+            <button class="menu-card slim" onclick="page:player">
               <span class="btn-main-label">Driver Name</span>
               <span class="btn-sub-label">Player one's saved identity for Championship records</span>
             </button>

--- a/assets/ui/settings.rml
+++ b/assets/ui/settings.rml
@@ -21,7 +21,7 @@
             </button>
             <button class="menu-card" onclick="page:enhancements">
               <span class="btn-main-label">Visual Enhancements</span>
-              <span class="btn-sub-label">Widescreen fog and sky matching, draw distance, and per-circuit LOD</span>
+              <span class="btn-sub-label">Widescreen fog and sky matching, draw distance, per-circuit LOD, and chase camera</span>
             </button>
           </div>
 
@@ -33,6 +33,13 @@
             <button class="menu-card" disabled="disabled" onclick="page:haptics">
               <span class="btn-main-label">Haptics and Rumble (Coming Soon)</span>
               <span class="btn-sub-label">Controller rumble vibration motors and trigger feedback</span>
+            </button>
+          </div>
+
+          <div class="grid-row">
+            <button class="menu-card" onclick="page:player">
+              <span class="btn-main-label">Driver Name</span>
+              <span class="btn-sub-label">Player one's saved identity for Championship records</span>
             </button>
           </div>
         </div>

--- a/src/lambo_menu.cpp
+++ b/src/lambo_menu.cpp
@@ -43,6 +43,7 @@ enum Command : UINT {
     CMD_FULLSCREEN = 1000,
     CMD_SETTINGS,
     CMD_CONTROLS,
+    CMD_PLAYER_NAME,
     CMD_QUIT,
 
     CMD_RES_AUTO = 1100,
@@ -303,6 +304,7 @@ void dispatch(UINT command) {
         case CMD_FULLSCREEN: lambo::menu::toggle_fullscreen(); break;
         case CMD_SETTINGS: lambo::ui::open_settings(); break;
         case CMD_CONTROLS: lambo::ui::open_controls(); break;
+        case CMD_PLAYER_NAME: lambo::ui::open_player(); break;
         case CMD_QUIT: {
             SDL_Event quit{};
             quit.type = SDL_QUIT;
@@ -365,6 +367,7 @@ void attach(SDL_Window* window) {
     append_item(game, CMD_FULLSCREEN, "&Fullscreen\tF11");
     append_item(game, CMD_SETTINGS, "&Settings...");
     append_item(game, CMD_CONTROLS, "&Controls...");
+    append_item(game, CMD_PLAYER_NAME, "&Driver name...");
     AppendMenuW(game, MF_SEPARATOR, 0, nullptr);
     append_item(game, CMD_QUIT, "E&xit");
 

--- a/src/lambo_menu.cpp
+++ b/src/lambo_menu.cpp
@@ -367,7 +367,7 @@ void attach(SDL_Window* window) {
     append_item(game, CMD_FULLSCREEN, "&Fullscreen\tF11");
     append_item(game, CMD_SETTINGS, "&Settings...");
     append_item(game, CMD_CONTROLS, "&Controls...");
-    append_item(game, CMD_PLAYER_NAME, "&Driver name...");
+    append_item(game, CMD_PLAYER_NAME, "&Driver Name...");
     AppendMenuW(game, MF_SEPARATOR, 0, nullptr);
     append_item(game, CMD_QUIT, "E&xit");
 

--- a/src/lambo_player_name.cpp
+++ b/src/lambo_player_name.cpp
@@ -1,5 +1,6 @@
 #include "lambo_player_name.h"
 
+#include <cctype>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -100,7 +101,59 @@ int current_driver(uint8_t* rdram) {
     return (int16_t)MEM_H(0, (gpr)(int32_t)kCurrentDriverAddr);
 }
 
+// Normalise free input to the ROM keyboard vocabulary: surrounding whitespace
+// trimmed, lowercase uppercased. Internal runs of whitespace collapse to a
+// single space so gamepad/keyboard entry agree.
+std::string normalize_input(const std::string& name) {
+    size_t begin = 0;
+    while (begin < name.size() && std::isspace((unsigned char)name[begin])) ++begin;
+    size_t end = name.size();
+    while (end > begin && std::isspace((unsigned char)name[end - 1])) --end;
+    std::string result;
+    result.reserve(end - begin);
+    bool pending_space = false;
+    for (size_t i = begin; i < end; ++i) {
+        char ch = name[i];
+        if (std::isspace((unsigned char)ch)) {
+            pending_space = true;
+            continue;
+        }
+        if (pending_space && !result.empty()) result.push_back(' ');
+        pending_space = false;
+        if (ch >= 'a' && ch <= 'z') ch = static_cast<char>(ch - 'a' + 'A');
+        result.push_back(ch);
+    }
+    return result;
+}
+
+void clear_saved_name_file() {
+    const std::filesystem::path path = player_config_path();
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+}
+
 } // namespace
+
+namespace lambo {
+namespace player {
+
+std::string saved_name() {
+    return load_saved_name();
+}
+
+bool set_saved_name(const std::string& name) {
+    const std::string normalized = normalize_input(name);
+    if (!valid_name(normalized)) return false;
+    save_name(normalized);
+    return true;
+}
+
+void clear_saved_name() {
+    clear_saved_name_file();
+}
+
+} // namespace player
+} // namespace lambo
 
 extern "C" void lambo_player_name_seed(uint8_t* rdram) {
     if (current_driver(rdram) != kPlayerOne) return;

--- a/src/lambo_player_name.cpp
+++ b/src/lambo_player_name.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <mutex>
 #include <string>
 
 #include "json/json.hpp"
@@ -35,6 +36,35 @@ bool valid_name(const std::string& name) {
     return true;
 }
 
+// Normalise free input to the ROM keyboard vocabulary: surrounding whitespace
+// trimmed, lowercase uppercased. Internal runs of whitespace collapse to a
+// single space so gamepad/keyboard entry agree.
+std::string normalize_input(const std::string& name) {
+    size_t begin = 0;
+    while (begin < name.size() && std::isspace((unsigned char)name[begin])) ++begin;
+    size_t end = name.size();
+    while (end > begin && std::isspace((unsigned char)name[end - 1])) --end;
+    std::string result;
+    result.reserve(end - begin);
+    bool pending_space = false;
+    for (size_t i = begin; i < end; ++i) {
+        char ch = name[i];
+        if (std::isspace((unsigned char)ch)) {
+            pending_space = true;
+            continue;
+        }
+        if (pending_space && !result.empty()) result.push_back(' ');
+        pending_space = false;
+        if (ch >= 'a' && ch <= 'z') ch = static_cast<char>(ch - 'a' + 'A');
+        result.push_back(ch);
+    }
+    return result;
+}
+
+// player.json is touched from both the UI thread (options page) and the guest
+// CPU thread (name-editor hooks), so every file access takes this.
+std::mutex g_player_file_mutex;
+
 std::filesystem::path player_config_path() {
     if (const char* path = std::getenv("LAMBO_PLAYER_CONFIG")) {
         return std::filesystem::path{path};
@@ -43,6 +73,7 @@ std::filesystem::path player_config_path() {
 }
 
 std::string load_saved_name() {
+    std::lock_guard<std::mutex> lock(g_player_file_mutex);
     const std::filesystem::path path = player_config_path();
     std::ifstream in{path};
     if (!in.good()) return {};
@@ -51,11 +82,9 @@ std::string load_saved_name() {
         in >> json;
         const auto field = json.find("name");
         if (field == json.end() || !field->is_string()) return {};
-        std::string name = field->get<std::string>();
-        // player.json can be edited outside the ROM's uppercase-only keyboard.
-        for (char& ch : name) {
-            if (ch >= 'a' && ch <= 'z') ch = static_cast<char>(ch - 'a' + 'A');
-        }
+        // player.json can be hand-edited outside the ROM's uppercase-only
+        // keyboard, so it goes through the same normalisation as typed input.
+        const std::string name = normalize_input(field->get<std::string>());
         return valid_name(name) ? name : std::string{};
     } catch (const nlohmann::json::exception& e) {
         LAMBO_LOG_WARN("name", "%s unparseable (%s); keeping ROM default\n",
@@ -65,6 +94,7 @@ std::string load_saved_name() {
 }
 
 void save_name(const std::string& name) {
+    std::lock_guard<std::mutex> lock(g_player_file_mutex);
     const std::filesystem::path path = player_config_path();
     const std::filesystem::path tmp = path.string() + ".tmp";
     std::error_code ec;
@@ -101,32 +131,8 @@ int current_driver(uint8_t* rdram) {
     return (int16_t)MEM_H(0, (gpr)(int32_t)kCurrentDriverAddr);
 }
 
-// Normalise free input to the ROM keyboard vocabulary: surrounding whitespace
-// trimmed, lowercase uppercased. Internal runs of whitespace collapse to a
-// single space so gamepad/keyboard entry agree.
-std::string normalize_input(const std::string& name) {
-    size_t begin = 0;
-    while (begin < name.size() && std::isspace((unsigned char)name[begin])) ++begin;
-    size_t end = name.size();
-    while (end > begin && std::isspace((unsigned char)name[end - 1])) --end;
-    std::string result;
-    result.reserve(end - begin);
-    bool pending_space = false;
-    for (size_t i = begin; i < end; ++i) {
-        char ch = name[i];
-        if (std::isspace((unsigned char)ch)) {
-            pending_space = true;
-            continue;
-        }
-        if (pending_space && !result.empty()) result.push_back(' ');
-        pending_space = false;
-        if (ch >= 'a' && ch <= 'z') ch = static_cast<char>(ch - 'a' + 'A');
-        result.push_back(ch);
-    }
-    return result;
-}
-
 void clear_saved_name_file() {
+    std::lock_guard<std::mutex> lock(g_player_file_mutex);
     const std::filesystem::path path = player_config_path();
     std::error_code ec;
     std::filesystem::remove(path, ec);

--- a/src/lambo_player_name.h
+++ b/src/lambo_player_name.h
@@ -4,6 +4,22 @@
 #include <stdint.h>
 
 #ifdef __cplusplus
+#include <string>
+
+namespace lambo {
+namespace player {
+
+// Player one's persisted identity (player.json "name", shared with the ROM's
+// Championship name editor which auto-saves on confirm). Uppercase A-Z plus
+// space, 1-12 characters; lowercase input is uppercased. Used by the Driver
+// name options page and the launcher so the name is visible outside the game.
+std::string saved_name();
+bool set_saved_name(const std::string& name);
+void clear_saved_name();
+
+} // namespace player
+} // namespace lambo
+
 extern "C" {
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -415,6 +415,7 @@ static void update_gfx_stub(void* /*gfx_data*/) {
                 else if (page == "graphics") lambo::ui::open_graphics();
                 else if (page == "enhancements") lambo::ui::open_enhancements();
                 else if (page == "haptics") lambo::ui::open_haptics();
+                else if (page == "player") lambo::ui::open_player();
                 else if (page == "launcher") lambo::ui::open_launcher();
             } else if (g_startup_controller->mode() == lambo::StartupMode::InteractiveLauncher) {
                 lambo::ui::open_launcher();

--- a/src/ui/lambo_ui.cpp
+++ b/src/ui/lambo_ui.cpp
@@ -24,6 +24,7 @@
 #include <concurrentqueue.h>
 
 #include "RmlUi/Core.h"
+#include "RmlUi/Core/Elements/ElementFormControl.h"
 #include "RmlUi/Debugger.h"
 #include "RmlUi_Platform_SDL.h"
 #include "rt64_render_hooks.h"
@@ -146,6 +147,7 @@ struct UiState {
     void set_input_value(const char* id, const std::string& value);
     std::string input_value(const char* id);
     void refresh_player_values();
+    void show_player_status();
     void refresh_document_values();
     void refresh_controls_values();
     void load_page(lambo::ui::Page page, bool push_history);
@@ -178,6 +180,7 @@ std::atomic<int> g_requested_page{-1};
 std::atomic<int> g_requested_entry_point{static_cast<int>(lambo::ui::EntryPoint::Startup)};
 std::atomic<bool> g_requested_back{false};
 std::atomic<bool> g_requested_controls_route{false};
+std::atomic<bool> g_requested_player_route{false};
 std::atomic<lambo::StartupController*> g_startup_controller{nullptr};
 moodycamel::ConcurrentQueue<QueuedEvent> g_event_queue;
 
@@ -236,17 +239,17 @@ void UiState::set_text(const char* id, const std::string& value) {
 
 void UiState::set_input_value(const char* id, const std::string& value) {
     if (document == nullptr) return;
-    if (Rml::Element* element = document->GetElementById(id)) {
-        element->SetAttribute("value", value.c_str());
+    if (auto* control =
+            dynamic_cast<Rml::ElementFormControl*>(document->GetElementById(id))) {
+        control->SetValue(value.c_str());
     }
 }
 
 std::string UiState::input_value(const char* id) {
     if (document == nullptr) return {};
-    Rml::Element* element = document->GetElementById(id);
-    if (element == nullptr) return {};
-    if (const Rml::Variant* value = element->GetAttribute("value")) {
-        return std::string(value->Get<Rml::String>().c_str());
+    if (auto* control =
+            dynamic_cast<Rml::ElementFormControl*>(document->GetElementById(id))) {
+        return std::string(control->GetValue().c_str());
     }
     return {};
 }
@@ -258,6 +261,12 @@ void UiState::refresh_player_values() {
     set_input_value("player-name-input", saved);
     set_text("player-name-status", player_status);
     set_text("launcher-driver-name", saved.empty() ? "(ROM default)" : saved);
+}
+
+// Status-only update: unlike refresh_player_values it leaves the typed input
+// buffer alone, so a rejected name stays visible for correction.
+void UiState::show_player_status() {
+    set_text("player-name-status", player_status);
 }
 
 void UiState::refresh_document_values() {
@@ -438,11 +447,12 @@ void process_action(const std::string& action, const std::string& parameter) {
                 g_state->player_status =
                     "Saved driver name " + lambo::player::saved_name() + ".";
                 LAMBO_LOG_INFO("ui", "driver name saved from options page\n");
+                g_state->refresh_document_values();
             } else {
                 g_state->player_status =
                     "Invalid name: use 1-12 letters A-Z and spaces.";
+                g_state->show_player_status();
             }
-            g_state->refresh_document_values();
         } else if (parameter == "clear") {
             lambo::player::clear_saved_name();
             g_state->player_status = "Cleared: the game will use its ROM default name.";
@@ -662,6 +672,13 @@ void draw_hook(RT64::RenderCommandList* command_list,
             else
                 g_state->pages = {lambo::ui::Page::Settings};
         }
+        if (requested == static_cast<int>(lambo::ui::Page::Player) &&
+            g_requested_player_route.exchange(false, std::memory_order_acq_rel)) {
+            if (g_state->entry_point == lambo::ui::EntryPoint::Startup)
+                g_state->pages = {lambo::ui::Page::Home, lambo::ui::Page::Settings};
+            else
+                g_state->pages = {lambo::ui::Page::Settings};
+        }
         g_state->show_page(static_cast<lambo::ui::Page>(requested));
     }
     if (g_requested_back.exchange(false, std::memory_order_acq_rel)) g_state->back();
@@ -745,6 +762,7 @@ void open_launcher() {
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
     g_requested_controls_route.store(false, std::memory_order_release);
+    g_requested_player_route.store(false, std::memory_order_release);
     g_requested_page.store(static_cast<int>(Page::Home), std::memory_order_release);
 }
 
@@ -753,6 +771,7 @@ void open_settings() {
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
     g_requested_controls_route.store(false, std::memory_order_release);
+    g_requested_player_route.store(false, std::memory_order_release);
     g_requested_page.store(static_cast<int>(Page::Settings), std::memory_order_release);
 }
 
@@ -772,6 +791,7 @@ void open_graphics() {
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
     g_requested_controls_route.store(false, std::memory_order_release);
+    g_requested_player_route.store(false, std::memory_order_release);
     g_requested_page.store(static_cast<int>(Page::Graphics), std::memory_order_release);
 }
 
@@ -780,6 +800,7 @@ void open_enhancements() {
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
     g_requested_controls_route.store(false, std::memory_order_release);
+    g_requested_player_route.store(false, std::memory_order_release);
     g_requested_page.store(static_cast<int>(Page::Enhancements), std::memory_order_release);
 }
 
@@ -788,14 +809,22 @@ void open_haptics() {
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
     g_requested_controls_route.store(false, std::memory_order_release);
+    g_requested_player_route.store(false, std::memory_order_release);
     g_requested_page.store(static_cast<int>(Page::Haptics), std::memory_order_release);
 }
 
 void open_player() {
-    g_requested_entry_point.store(static_cast<int>(EntryPoint::Startup), std::memory_order_release);
+    // Mirror open_controls: the entry point follows the runtime state so Back
+    // from a menu-bar invocation during gameplay returns through Settings
+    // instead of stranding a single Startup page with nowhere to go.
+    auto* startup = g_startup_controller.load(std::memory_order_acquire);
+    const EntryPoint entry = startup != nullptr && startup->state() == lambo::StartupState::Started
+        ? EntryPoint::InGameOverlay : EntryPoint::Startup;
+    g_requested_entry_point.store(static_cast<int>(entry), std::memory_order_release);
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
     g_requested_controls_route.store(false, std::memory_order_release);
+    g_requested_player_route.store(true, std::memory_order_release);
     g_requested_page.store(static_cast<int>(Page::Player), std::memory_order_release);
 }
 

--- a/src/ui/lambo_ui.cpp
+++ b/src/ui/lambo_ui.cpp
@@ -30,6 +30,7 @@
 
 #include "lambo_config.h"
 #include "lambo_log.h"
+#include "lambo_player_name.h"
 #include "lambo_startup.h"
 #include "lambo_ui_input.h"
 #include "lambo_ui_controls.h"
@@ -61,6 +62,7 @@ constexpr std::array page_descriptors{
     PageDescriptor{"pages/enhancements.rml", "Enhancements"},
     PageDescriptor{"pages/controls.rml", "Controls"},
     PageDescriptor{"pages/haptics.rml", "Haptics"},
+    PageDescriptor{"pages/player.rml", "Driver name"},
 };
 
 const PageDescriptor& page_descriptor(lambo::ui::Page page) {
@@ -134,11 +136,16 @@ struct UiState {
     InputMode input_mode = InputMode::Mouse;
     std::uint64_t controls_config_revision = ~std::uint64_t{};
     std::uint64_t controls_sample_revision = ~std::uint64_t{};
+    // Last Driver-name action result, shown on the Player page status line.
+    std::string player_status;
 
     void remember_focus();
     void restore_focus(lambo::ui::Page page);
     void set_input_mode(InputMode mode);
     void set_text(const char* id, const std::string& value);
+    void set_input_value(const char* id, const std::string& value);
+    std::string input_value(const char* id);
+    void refresh_player_values();
     void refresh_document_values();
     void refresh_controls_values();
     void load_page(lambo::ui::Page page, bool push_history);
@@ -227,6 +234,32 @@ void UiState::set_text(const char* id, const std::string& value) {
     }
 }
 
+void UiState::set_input_value(const char* id, const std::string& value) {
+    if (document == nullptr) return;
+    if (Rml::Element* element = document->GetElementById(id)) {
+        element->SetAttribute("value", value.c_str());
+    }
+}
+
+std::string UiState::input_value(const char* id) {
+    if (document == nullptr) return {};
+    Rml::Element* element = document->GetElementById(id);
+    if (element == nullptr) return {};
+    if (const Rml::Variant* value = element->GetAttribute("value")) {
+        return std::string(value->Get<Rml::String>().c_str());
+    }
+    return {};
+}
+
+void UiState::refresh_player_values() {
+    if (document == nullptr) return;
+    const std::string saved = lambo::player::saved_name();
+    set_text("player-name-current", saved.empty() ? "(ROM default)" : saved);
+    set_input_value("player-name-input", saved);
+    set_text("player-name-status", player_status);
+    set_text("launcher-driver-name", saved.empty() ? "(ROM default)" : saved);
+}
+
 void UiState::refresh_document_values() {
     if (document == nullptr) return;
     set_text("version", std::string("v") + LAMBO_VERSION);
@@ -244,10 +277,14 @@ void UiState::refresh_document_values() {
     set_text("enhancement-lod", values.lod_removal);
     set_text("enhancement-distance", values.draw_distance);
     set_text("enhancement-fog-density", values.fog_density);
+    set_text("enhancement-camdist", values.camera_distance);
+    set_text("enhancement-camheight", values.camera_height);
+    set_text("enhancement-fov", values.camera_fov);
     for (size_t circuit = 0; circuit < values.circuit_visibility.size(); ++circuit) {
         const std::string id = "enhancement-circuit-" + std::to_string(circuit + 1);
         set_text(id.c_str(), values.circuit_visibility[circuit]);
     }
+    refresh_player_values();
     refresh_controls_values();
 }
 
@@ -383,6 +420,7 @@ void process_action(const std::string& action, const std::string& parameter) {
         else if (parameter == "enhancements") g_state->show_page(lambo::ui::Page::Enhancements);
         else if (parameter == "controls") g_state->show_page(lambo::ui::Page::Controls);
         else if (parameter == "haptics") g_state->show_page(lambo::ui::Page::Haptics);
+        else if (parameter == "player") g_state->show_page(lambo::ui::Page::Player);
     } else if (action == "back") {
         if (g_state != nullptr) g_state->back();
     } else if (action == "setting") {
@@ -392,6 +430,25 @@ void process_action(const std::string& action, const std::string& parameter) {
         }
     } else if (action == "control") {
         lambo::ui::apply_control_action(parameter);
+    } else if (action == "player") {
+        if (g_state == nullptr) return;
+        if (parameter == "save") {
+            const std::string typed = g_state->input_value("player-name-input");
+            if (lambo::player::set_saved_name(typed)) {
+                g_state->player_status =
+                    "Saved driver name " + lambo::player::saved_name() + ".";
+                LAMBO_LOG_INFO("ui", "driver name saved from options page\n");
+            } else {
+                g_state->player_status =
+                    "Invalid name: use 1-12 letters A-Z and spaces.";
+            }
+            g_state->refresh_document_values();
+        } else if (parameter == "clear") {
+            lambo::player::clear_saved_name();
+            g_state->player_status = "Cleared: the game will use its ROM default name.";
+            LAMBO_LOG_INFO("ui", "driver name cleared from options page\n");
+            g_state->refresh_document_values();
+        }
     }
 }
 
@@ -403,6 +460,7 @@ void install_event_handlers(UiState& state) {
     state.event_listener_instancer.register_event("back", [](const std::string&) { process_action("back", ""); });
     state.event_listener_instancer.register_event("setting", [](const std::string& p) { process_action("setting", p); });
     state.event_listener_instancer.register_event("control", [](const std::string& p) { process_action("control", p); });
+    state.event_listener_instancer.register_event("player", [](const std::string& p) { process_action("player", p); });
 }
 
 void init_hook(RT64::RenderInterface* interface, RT64::RenderDevice* device) {
@@ -731,6 +789,14 @@ void open_haptics() {
     g_capture.store(true, std::memory_order_release);
     g_requested_controls_route.store(false, std::memory_order_release);
     g_requested_page.store(static_cast<int>(Page::Haptics), std::memory_order_release);
+}
+
+void open_player() {
+    g_requested_entry_point.store(static_cast<int>(EntryPoint::Startup), std::memory_order_release);
+    SDL_ShowCursor(SDL_ENABLE);
+    g_capture.store(true, std::memory_order_release);
+    g_requested_controls_route.store(false, std::memory_order_release);
+    g_requested_page.store(static_cast<int>(Page::Player), std::memory_order_release);
 }
 
 void close_top_page() {

--- a/src/ui/lambo_ui.h
+++ b/src/ui/lambo_ui.h
@@ -19,6 +19,7 @@ enum class Page {
     Enhancements,
     Controls,
     Haptics,
+    Player,
 };
 
 enum class EntryPoint {
@@ -36,6 +37,7 @@ void open_controls();
 void open_graphics();
 void open_enhancements();
 void open_haptics();
+void open_player();
 void close_top_page();
 bool is_initialized();
 bool is_visible();

--- a/src/ui/lambo_ui_settings.cpp
+++ b/src/ui/lambo_ui_settings.cpp
@@ -33,6 +33,9 @@ constexpr auto setting_bindings = std::to_array<std::pair<std::string_view, Sett
     {"circuit:6", SettingAction::Circuit6Toggle},
     {"distance:next", SettingAction::DrawDistanceNext},
     {"fogdensity:next", SettingAction::FogDensityNext},
+    {"camdist:next", SettingAction::CameraDistanceNext},
+    {"camheight:next", SettingAction::CameraHeightNext},
+    {"fov:next", SettingAction::FovNext},
 });
 
 template <typename T, size_t Size>
@@ -128,6 +131,25 @@ std::string multiplier_name(double value) {
     return std::to_string(tenths / 10) + "." + std::to_string(tenths % 10) + "x";
 }
 
+// Camera scales use two-decimal authored steps (0.65/0.66), so the tenths-only
+// multiplier_name would blur them. "Original" keeps the stock value obvious.
+std::string camera_scale_name(double value) {
+    if (std::abs(value - 1.0) < 0.0001) return "Original";
+    int hundredths = static_cast<int>(std::lround(value * 100.0));
+    std::string text = std::to_string(hundredths / 100) + ".";
+    const int cents = hundredths % 100;
+    text += static_cast<char>('0' + cents / 10);
+    text += static_cast<char>('0' + cents % 10);
+    while (text.back() == '0') text.pop_back();
+    if (text.back() == '.') text.pop_back();
+    return text + "x";
+}
+
+std::string fov_add_name(double value) {
+    if (std::abs(value) < 0.0001) return "Original";
+    return "+" + std::to_string(static_cast<int>(std::lround(value))) + " deg";
+}
+
 } // namespace
 
 namespace lambo::ui {
@@ -208,6 +230,15 @@ bool apply_setting_action(SettingAction action) {
         case SettingAction::FogDensityNext:
             lambo::config::set_global_fog_scale(next_number(
                 lambo::config::global_fog_scale(), std::array{0.0, 0.5, 0.75, 1.0, 1.5, 2.0})); return true;
+        case SettingAction::CameraDistanceNext:
+            lambo::config::set_camera_distance_scale(next_number(
+                lambo::config::camera_distance_scale(), std::array{1.0, 0.8, 0.65, 0.5})); return true;
+        case SettingAction::CameraHeightNext:
+            lambo::config::set_camera_height_scale(next_number(
+                lambo::config::camera_height_scale(), std::array{1.0, 0.66, 0.4})); return true;
+        case SettingAction::FovNext:
+            lambo::config::set_camera_fov_add(next_number(
+                lambo::config::camera_fov_add(), std::array{0.0, 5.0, 10.0, 15.0, 20.0})); return true;
     }
 
     lambo::config::apply_graphics(cfg, apply_live);
@@ -230,7 +261,9 @@ SettingsSnapshot settings_snapshot() {
         lambo::config::no_lod() ? "Enabled" : "Disabled",
         multiplier_name(lambo::config::global_draw_distance()),
         {},
-        {},
+        camera_scale_name(lambo::config::camera_distance_scale()),
+        camera_scale_name(lambo::config::camera_height_scale()),
+        fov_add_name(lambo::config::camera_fov_add()),
     };
     const int fog_percent = static_cast<int>(std::lround(lambo::config::global_fog_scale() * 100.0));
     result.fog_density = fog_percent == 0 ? "Off" : std::to_string(fog_percent) + "%";

--- a/src/ui/lambo_ui_settings.cpp
+++ b/src/ui/lambo_ui_settings.cpp
@@ -146,8 +146,10 @@ std::string camera_scale_name(double value) {
 }
 
 std::string fov_add_name(double value) {
-    if (std::abs(value) < 0.0001) return "Original";
-    return "+" + std::to_string(static_cast<int>(std::lround(value))) + " deg";
+    const int degrees = static_cast<int>(std::lround(value));
+    if (degrees == 0) return "Original";
+    if (degrees < 0) return std::to_string(degrees) + " deg";
+    return "+" + std::to_string(degrees) + " deg";
 }
 
 } // namespace

--- a/src/ui/lambo_ui_settings.h
+++ b/src/ui/lambo_ui_settings.h
@@ -28,6 +28,9 @@ enum class SettingAction {
     Circuit6Toggle,
     DrawDistanceNext,
     FogDensityNext,
+    CameraDistanceNext,
+    CameraHeightNext,
+    FovNext,
 };
 
 struct SettingsSnapshot {
@@ -44,6 +47,9 @@ struct SettingsSnapshot {
     std::string lod_removal;
     std::string draw_distance;
     std::string fog_density;
+    std::string camera_distance;
+    std::string camera_height;
+    std::string camera_fov;
     std::array<std::string, 6> circuit_visibility;
 };
 

--- a/tests/test_live_config.cpp
+++ b/tests/test_live_config.cpp
@@ -185,6 +185,15 @@ int main() {
     expect(lambo::player::saved_name().empty(), "cleared name falls back to ROM default");
     expect(!std::filesystem::exists(player_path), "cleared name removes player.json");
 
+    // Hand-edited player.json goes through the same normalisation as typed
+    // input instead of injecting raw padding into RDRAM.
+    {
+        std::ofstream output(player_path);
+        output << nlohmann::json{{"name", "  FAST  "}};
+    }
+    expect(lambo::player::saved_name() == "FAST",
+           "hand-edited padded name normalises on load");
+
     std::error_code ec;
     std::filesystem::remove_all(dir, ec);
     return failures == 0 ? 0 : 1;

--- a/tests/test_live_config.cpp
+++ b/tests/test_live_config.cpp
@@ -167,6 +167,24 @@ int main() {
     }
     expect(seeded == edited, "next run seeds the persisted name into the ROM buffer");
 
+    // The Driver-name options page shares the same player.json vocabulary as
+    // the ROM hooks: lowercase is uppercased, surrounding whitespace trimmed.
+    expect(lambo::player::set_saved_name("  speed  Racer  ") == true,
+           "options-page name normalises whitespace and case");
+    expect(lambo::player::saved_name() == "SPEED RACER",
+           "normalised options-page name round-trips");
+    expect(read_json(player_path).at("name") == "SPEED RACER",
+           "options-page name persists to player.json");
+    expect(lambo::player::set_saved_name("has-digits-1") == false,
+           "options-page name rejects ROM-unsupported characters");
+    expect(lambo::player::set_saved_name("WAY TOO LONG A NAME") == false,
+           "options-page name rejects overlong input");
+    expect(lambo::player::saved_name() == "SPEED RACER",
+           "rejected options-page input keeps the previous name");
+    lambo::player::clear_saved_name();
+    expect(lambo::player::saved_name().empty(), "cleared name falls back to ROM default");
+    expect(!std::filesystem::exists(player_path), "cleared name removes player.json");
+
     std::error_code ec;
     std::filesystem::remove_all(dir, ec);
     return failures == 0 ? 0 : 1;

--- a/tests/test_ui_assets.py
+++ b/tests/test_ui_assets.py
@@ -21,6 +21,7 @@ def main() -> None:
         "pages/enhancements.rml",
         "pages/controls.rml",
         "pages/haptics.rml",
+        "pages/player.rml",
     }
 
     for relative in required_documents:
@@ -48,11 +49,12 @@ def main() -> None:
         "fog:toggle", "sky:toggle", "lod:toggle",
         "circuit:1", "circuit:2", "circuit:3", "circuit:4", "circuit:5", "circuit:6",
         "distance:next", "fogdensity:next",
+        "camdist:next", "camheight:next", "fov:next",
     }
     require(setting_actions == expected_settings,
             f"setting actions differ: missing={expected_settings - setting_actions}, "
             f"unexpected={setting_actions - expected_settings}")
-    require({"graphics", "enhancements", "controls", "haptics"} <= page_actions,
+    require({"graphics", "enhancements", "controls", "haptics", "player"} <= page_actions,
             "settings hub is missing a stable route identifier")
 
     graphics = ET.parse(ui_root / "pages" / "graphics.rml")
@@ -106,6 +108,24 @@ def main() -> None:
     enhancements_text = (ui_root / "pages" / "enhancements.rml").read_text(encoding="utf-8")
     require(enhancements_text.index('class="help"') < enhancements_text.index('class="columns"'),
             "enhancement guidance must sit above both columns to keep their controls aligned")
+    enhancements = ET.parse(ui_root / "pages" / "enhancements.rml")
+    for value_id in ("enhancement-camdist", "enhancement-camheight", "enhancement-fov"):
+        require(any(element.attrib.get("id") == value_id for element in enhancements.iter()),
+                f"enhancements control is missing current-value target: {value_id}")
+
+    player = ET.parse(ui_root / "pages" / "player.rml")
+    player_ids = {element.attrib.get("id") for element in player.iter() if element.attrib.get("id")}
+    require({"player-name-current", "player-name-input", "player-name-status"} <= player_ids,
+            f"Driver page is missing state targets: "
+            f"{ {'player-name-current', 'player-name-input', 'player-name-status'} - player_ids}")
+    player_actions = {element.attrib.get("onclick") for element in player.iter()}
+    require({"player:save", "player:clear"} <= player_actions,
+            "Driver page is missing save/clear actions")
+
+    launcher_ids = {element.attrib.get("id") for element in ET.parse(ui_root / "launcher.rml").iter()
+                    if element.attrib.get("id")}
+    require("launcher-driver-name" in launcher_ids,
+            "launcher must surface the current driver name")
 
     launcher = (ui_root / "launcher.rml").read_text(encoding="utf-8")
     require("v1.0.0" not in launcher, "launcher must not hardcode a release version")

--- a/tests/test_ui_settings.cpp
+++ b/tests/test_ui_settings.cpp
@@ -62,6 +62,7 @@ int main() {
         "fog:toggle", "sky:toggle", "lod:toggle",
         "circuit:1", "circuit:2", "circuit:3", "circuit:4", "circuit:5", "circuit:6",
         "distance:next", "fogdensity:next",
+        "camdist:next", "camheight:next", "fov:next",
     };
     for (const char* name : binding_names) {
         expect(lambo::ui::setting_action_from_name(name).has_value(),
@@ -111,7 +112,8 @@ int main() {
 #endif
 
     expect(apply("fog:toggle") && apply("sky:toggle") && apply("lod:toggle") &&
-           apply("circuit:6") && apply("distance:next") && apply("fogdensity:next"),
+           apply("circuit:6") && apply("distance:next") && apply("fogdensity:next") &&
+           apply("camdist:next") && apply("camheight:next") && apply("fov:next"),
            "enhancement bindings apply through the typed settings seam");
     expect(!lambo::config::widescreen_fog_match(), "fog match toggles live");
     expect(!lambo::config::widescreen_sky_match(), "sky match toggles live");
@@ -119,6 +121,9 @@ int main() {
     expect(lambo::config::no_lod_circuit(5), "per-circuit visibility toggles live");
     expect(lambo::config::global_draw_distance() == 2.0, "draw-distance cycle applies live");
     expect(lambo::config::global_fog_scale() == 1.5, "fog-density cycle applies live");
+    expect(lambo::config::camera_distance_scale() == 0.8, "camera-distance cycle applies live");
+    expect(lambo::config::camera_height_scale() == 0.66, "camera-height cycle applies live");
+    expect(lambo::config::camera_fov_add() == 5.0, "FOV cycle applies live");
 
     const auto snapshot = lambo::ui::settings_snapshot();
     expect(snapshot.resolution == "Original", "settings snapshot presents resolution");
@@ -128,6 +133,9 @@ int main() {
            "settings snapshot presents every circuit");
     expect(snapshot.draw_distance == "2x", "settings snapshot presents draw distance");
     expect(snapshot.fog_density == "150%", "settings snapshot presents fog density");
+    expect(snapshot.camera_distance == "0.8x", "settings snapshot presents camera distance");
+    expect(snapshot.camera_height == "0.66x", "settings snapshot presents camera height");
+    expect(snapshot.camera_fov == "+5 deg", "settings snapshot presents FOV boost");
 
     using SnapshotStringMember = std::string lambo::ui::SettingsSnapshot::*;
     const auto expect_cycle_wraps = [&](const char* binding, int steps, const std::string& initial,
@@ -162,6 +170,12 @@ int main() {
                        &lambo::ui::SettingsSnapshot::draw_distance, "draw-distance cycle wraps");
     expect_cycle_wraps("fogdensity:next", 6, snapshot.fog_density,
                        &lambo::ui::SettingsSnapshot::fog_density, "fog-density cycle wraps");
+    expect_cycle_wraps("camdist:next", 4, snapshot.camera_distance,
+                       &lambo::ui::SettingsSnapshot::camera_distance, "camera-distance cycle wraps");
+    expect_cycle_wraps("camheight:next", 3, snapshot.camera_height,
+                       &lambo::ui::SettingsSnapshot::camera_height, "camera-height cycle wraps");
+    expect_cycle_wraps("fov:next", 5, snapshot.camera_fov,
+                       &lambo::ui::SettingsSnapshot::camera_fov, "FOV cycle wraps");
 
     lambo::config::flush_pending_graphics_updates();
     const auto persisted = read_json(config_path);
@@ -177,6 +191,9 @@ int main() {
            "per-circuit visibility persists");
     expect(persisted.at("draw_distance") == 2.0, "draw distance persists");
     expect(persisted.at("fog_scale") == 1.5, "fog density persists");
+    expect(persisted.at("camera_distance_scale") == 0.8, "camera distance persists");
+    expect(persisted.at("camera_height_scale") == 0.66, "camera height persists");
+    expect(persisted.at("camera_fov_add") == 5.0, "FOV boost persists");
 
     lambo::config::load_and_apply_graphics();
 #if defined(_WIN32)

--- a/tests/test_ui_settings.cpp
+++ b/tests/test_ui_settings.cpp
@@ -195,6 +195,16 @@ int main() {
     expect(persisted.at("camera_height_scale") == 0.66, "camera height persists");
     expect(persisted.at("camera_fov_add") == 5.0, "FOV boost persists");
 
+    // Negative deltas (graphics.json / env only; the menu cycles 0..+20) must
+    // not render a "+-" sign.
+    lambo::config::set_camera_fov_add(-10.0);
+    expect(lambo::ui::settings_snapshot().camera_fov == "-10 deg",
+           "settings snapshot presents negative FOV deltas");
+    lambo::config::set_camera_fov_add(0.0);
+    expect(lambo::ui::settings_snapshot().camera_fov == "Original",
+           "settings snapshot presents stock FOV");
+    lambo::config::flush_pending_graphics_updates();
+
     lambo::config::load_and_apply_graphics();
 #if defined(_WIN32)
     expect(lambo::config::current_graphics().api_option == GraphicsApi::D3D12,


### PR DESCRIPTION
Puts the chase-camera knobs and the player-one name where users can reach them: camera distance/height/FOV join the Enhancements options page, and a new Settings Driver Name page (plus launcher display and Game menu entry) edits the shared player.json identity.

## Why?

Closes #197

The camera knobs lived only in graphics.json and the Win32 menu bar, and the player name only in player.json plus the in-game ROM editor. The README already claimed camera_fov_add was settable from the Enhancements menu, which was only true for the native menu bar.

Update: review findings addressed in bb4c6a7 (Player page entry-point/back-stack route mirrors open_controls, failed saves no longer reseed the input buffer, ElementFormControl value API, mutex-guarded player.json with unified load normalisation, negative-FOV display, rml/rcss/menu-casing nits).

## How was it verified?

- [ ] Built clean with `build.sh` (Linux) / `build.ps1` (Windows) — no manual cmake incantation
- [ ] Booted smoke-tested: attract -> title -> menu -> race
- [ ] If visual: screenshot or short clip attached / linked below
- [x] If config/schema: defaults preserved when fields absent in `graphics.json`
- [ ] If new dep patch: mirrored in both `build.sh` AND `build.ps1` AND CI (`build-release.yml`)
- [ ] If new hook into recompiled code: also mirrored in `scripts/gen_syms_toml.py` (the `PATCH_BLOCKS`-stale trap)
- [x] No comments that explain *what* the code does (only *why* — see `CLAUDE.md`)
- [x] No "Generated with Claude Code" footer in commits or PR description

Notes: no new recompiled-code hooks (the player-name hooks are untouched; the UI uses the existing player.json seam), no new deps, no schema changes (camera keys and player.json already existed with defaults). `tests/test_ui_assets.py` passes all checks up to the pre-existing missing-submodule font assertion in this worktree; C++ suites (`test_ui_settings`, `test_live_config`) are extended but need CI to compile (submodules not checked out here). RML edits are LF-only; `lambo_menu.cpp`/`test_live_config.cpp` keep their original mixed endings (insertions only).

## Screenshots / video

None — no runtime available in this worktree; visual check (Enhancements third column, Driver Name page, launcher driver line) needs a local run.

## Risk / rollback

Low: additive UI surfaces over existing config seams; revert with `git revert bb4c6a7 af55a79` (newest first) to restore file/menu-only camera and name handling.
