### PR TITLE
feat(ui): revamp settings navigation

### DIFF
--- a/assets/ui/lambo.rcss
+++ b/assets/ui/lambo.rcss
@@ -983,3 +983,473 @@ scrollbarvertical sliderarrowinc {
   color: #868e96;
   text-align: center;
 }
+
+/* =====================================================================
+   Settings shell: sidebar navigation + scrollable content pane
+   ===================================================================== */
+
+.settings-panel {
+  padding: 0;
+  overflow: hidden;
+}
+
+.settings-shell {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  background-color: #0b101b;
+}
+
+.settings-nav {
+  display: flex;
+  flex-direction: column;
+  width: 320dp;
+  flex-shrink: 0;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 34dp 22dp 26dp 22dp;
+  background-color: #0c1220;
+  border-right: 1.5dp solid #1c2940;
+}
+
+.nav-brand {
+  display: block;
+  margin-bottom: 24dp;
+  padding: 0 8dp 20dp 8dp;
+  border-bottom: 1.5dp solid #1c2940;
+}
+
+.nav-kicker {
+  display: block;
+  font-size: 11dp;
+  letter-spacing: 3dp;
+  font-weight: bold;
+  color: #d4a017;
+  margin-bottom: 6dp;
+}
+
+.nav-brand h1 {
+  font-size: 21dp;
+  line-height: 25dp;
+  letter-spacing: 0.5dp;
+  margin: 0;
+}
+
+.nav-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4dp;
+}
+
+.nav-item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 14dp;
+  width: 100%;
+  margin: 0;
+  padding: 12dp 14dp;
+  text-align: left;
+  background-color: transparent;
+  border: 1.5dp solid transparent;
+  border-radius: 10dp;
+  color: #9fb0c7;
+  font-size: 16dp;
+  font-weight: normal;
+  tab-index: auto;
+  nav: auto;
+}
+
+.nav-marker {
+  display: block;
+  width: 5dp;
+  height: 22dp;
+  border-radius: 3dp;
+  background-color: #2b3e5c;
+}
+
+.nav-label {
+  display: block;
+  flex: 1;
+}
+
+.nav-note {
+  display: block;
+  font-size: 11dp;
+  font-weight: bold;
+  color: #6c757d;
+  letter-spacing: 0.5dp;
+  margin-top: 2dp;
+}
+
+.nav-item:hover {
+  background-color: #131e30;
+  border-color: #22304a;
+  color: #f1f3f5;
+}
+
+.nav-item.active {
+  background-color: #17233a;
+  border-color: #2b3e5c;
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.nav-item.active .nav-marker {
+  background-color: #ffd43b;
+}
+
+.nav-item:focus,
+.nav-item.active:focus {
+  background-color: #1b2a44;
+  border-color: #ffd43b;
+  color: #ffffff;
+}
+
+.nav-item:disabled {
+  color: #4b586b;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.nav-spacer {
+  flex: 1;
+}
+
+.nav-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 14dp;
+  padding-top: 18dp;
+  border-top: 1.5dp solid #1c2940;
+}
+
+.nav-back {
+  width: 100%;
+  margin: 0;
+  padding: 13dp 20dp;
+  text-align: center;
+  font-size: 16dp;
+  font-weight: bold;
+  color: #ffffff;
+  background-color: #c92a2a;
+  border: 1.5dp solid #ff6b6b;
+  border-radius: 10dp;
+  tab-index: auto;
+  nav: auto;
+}
+
+.nav-back:hover,
+.nav-back:focus {
+  background-color: #e03131;
+  border-color: #ffd43b;
+}
+
+.nav-hints {
+  display: flex;
+  flex-direction: column;
+  gap: 6dp;
+}
+
+.nav-version {
+  font-size: 12dp;
+  color: #5f7188;
+}
+
+.settings-content {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  box-sizing: border-box;
+  overflow-y: auto;
+  padding: 46dp 60dp 72dp 60dp;
+}
+
+/* The mapper has four dense columns, so give it the extra width recovered
+   from the normal settings gutter while keeping the shared sidebar. */
+.controls-content {
+  padding: 30dp 34dp 46dp 34dp;
+}
+
+.controls-content .mapper-grid {
+  gap: 8dp;
+}
+
+.controls-content .mapper-section {
+  flex: 1;
+  min-width: 0;
+  padding: 10dp 8dp;
+}
+
+.controls-content .mapper-row {
+  gap: 4dp;
+}
+
+.controls-content .mapper-label-col {
+  width: 40%;
+}
+
+.controls-content .mapper-slot-btn {
+  width: 58%;
+  padding: 7dp 6dp;
+  font-size: 12dp;
+}
+
+.controls-content .mapper-target-name,
+.controls-content .mapper-slot-val {
+  font-size: 12dp;
+}
+
+.content-header {
+  display: block;
+  margin-bottom: 30dp;
+  padding-bottom: 20dp;
+  border-bottom: 2dp solid #1c2940;
+}
+
+.content-header h1 {
+  font-size: 30dp;
+  margin: 0 0 8dp 0;
+}
+
+.setting-group {
+  display: block;
+  margin-bottom: 34dp;
+}
+
+.setting-group-title {
+  display: block;
+  font-size: 12dp;
+  font-weight: bold;
+  letter-spacing: 2dp;
+  color: #d4a017;
+  margin-bottom: 6dp;
+}
+
+.setting-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.setting-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 28dp;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 15dp 18dp 15dp 16dp;
+  margin: 0;
+  border-left: 4dp solid transparent;
+  border-bottom: 1dp solid #16202f;
+  background-color: transparent;
+  border-radius: 0;
+  font-size: 16dp;
+  text-align: left;
+  color: #f1f3f5;
+  tab-index: auto;
+  nav: auto;
+}
+
+.setting-row:hover {
+  background-color: #101a29;
+}
+
+.setting-row:focus {
+  background-color: #16233a;
+  border-left-color: #ffd43b;
+  border-bottom-color: transparent;
+}
+
+.setting-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  gap: 3dp;
+}
+
+.setting-name {
+  display: block;
+  font-size: 17dp;
+  font-weight: bold;
+  color: #f1f3f5;
+}
+
+.setting-desc {
+  display: block;
+  font-size: 13dp;
+  line-height: 18dp;
+  color: #7d8ea6;
+}
+
+.setting-control {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  flex-shrink: 0;
+  gap: 7dp;
+}
+
+.setting-stepper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10dp;
+}
+
+.step-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34dp;
+  height: 34dp;
+  border-radius: 17dp;
+  background-color: #16233a;
+  border: 1.5dp solid #2b3e5c;
+  color: #9fb0c7;
+  font-size: 18dp;
+  font-weight: bold;
+  text-align: center;
+}
+
+.step-btn:hover {
+  background-color: #22304a;
+  border-color: #ffd43b;
+  color: #ffd43b;
+}
+
+.setting-value {
+  display: block;
+  width: auto;
+  min-width: 150dp;
+  padding: 6dp 16dp;
+  text-align: center;
+  font-size: 16dp;
+  font-weight: bold;
+  color: #ffd43b;
+  background-color: #101a29;
+  border: 1.5dp solid #1f2d44;
+  border-radius: 8dp;
+}
+
+.track {
+  display: flex;
+  flex-direction: row;
+  gap: 3dp;
+  margin-top: 1dp;
+}
+
+.track-step {
+  display: block;
+  width: 9dp;
+  height: 4dp;
+  border-radius: 2dp;
+  background-color: #22304a;
+}
+
+.track-step.on {
+  background-color: #ffd43b;
+}
+
+.switch {
+  display: block;
+  position: relative;
+  width: 56dp;
+  height: 30dp;
+  border-radius: 15dp;
+  background-color: #22304a;
+  border: 1.5dp solid #2b3e5c;
+}
+
+.switch .knob {
+  display: block;
+  position: absolute;
+  top: 3dp;
+  left: 3dp;
+  width: 20dp;
+  height: 20dp;
+  border-radius: 10dp;
+  background-color: #8ea0b8;
+}
+
+.switch.on {
+  background-color: #2b8a3e;
+  border-color: #51cf66;
+}
+
+.switch.on .knob {
+  left: 33dp;
+  background-color: #ffffff;
+}
+
+.overview-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12dp;
+  margin-bottom: 26dp;
+}
+
+.overview-item {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 20dp;
+  padding: 18dp 22dp;
+  background-color: #101a29;
+  border: 1.5dp solid #1c2940;
+  border-radius: 12dp;
+}
+
+.overview-kicker {
+  display: block;
+  font-size: 12dp;
+  font-weight: bold;
+  letter-spacing: 2dp;
+  color: #d4a017;
+}
+
+.overview-value {
+  display: block;
+  font-size: 17dp;
+  font-weight: bold;
+  color: #eef2f7;
+  text-align: right;
+}
+
+.driver-field {
+  margin: 4dp 0 10dp 0;
+}
+
+.driver-actions {
+  display: flex;
+  flex-direction: row;
+  gap: 12dp;
+  margin-top: 4dp;
+}
+
+.driver-actions button {
+  flex: 1;
+  margin: 0;
+  text-align: center;
+}
+
+.placeholder-card {
+  padding: 26dp 30dp;
+  background-color: #101a29;
+  border: 1.5dp solid #1c2940;
+  border-radius: 12dp;
+  color: #9fb0c7;
+}
+
+@media (max-width: 1100px) {
+  .settings-nav {
+    width: 240dp;
+  }
+  .settings-content {
+    padding: 34dp 34dp 56dp 34dp;
+  }
+}

--- a/assets/ui/pages/controls.rml
+++ b/assets/ui/pages/controls.rml
@@ -1,36 +1,10 @@
 <rml>
   <head>
     <title>Controls</title>
-    <link type="text/rcss" href="../lambo.rcss"/>
+    <link type="text/template" href="../settings_shell.rml"/>
   </head>
-  <body>
-    <div id="window">
-      <div class="panel controls-panel settings-panel">
-        <div class="settings-shell">
-          <div class="settings-nav">
-            <div class="nav-brand">
-              <span class="nav-kicker">AUTOMOBILI</span>
-              <h1>LAMBORGHINI</h1>
-            </div>
-            <div class="nav-list">
-              <button id="nav-settings" class="nav-item" onclick="page:settings"><span class="nav-marker"></span><span class="nav-label">Overview</span></button>
-              <button id="nav-graphics" class="nav-item" onclick="page:graphics"><span class="nav-marker"></span><span class="nav-label">Graphics &amp; Display</span></button>
-              <button id="nav-enhancements" class="nav-item" onclick="page:enhancements"><span class="nav-marker"></span><span class="nav-label">Visual Enhancements</span></button>
-              <button id="nav-controls" class="nav-item active" onclick="page:controls"><span class="nav-marker"></span><span class="nav-label">Controls Mapper</span></button>
-              <button id="nav-player" class="nav-item" onclick="page:player"><span class="nav-marker"></span><span class="nav-label">Driver Name</span></button>
-              <button id="nav-haptics" class="nav-item" disabled="disabled" onclick="page:haptics"><span class="nav-marker"></span><span class="nav-label">Haptics<span class="nav-note">COMING SOON</span></span></button>
-            </div>
-            <div class="nav-spacer"></div>
-            <div class="nav-footer">
-              <button class="nav-back" onclick="back">Back</button>
-              <div class="nav-hints">
-                <span class="guide-item"><span class="guide-key">A / Enter</span> Select</span>
-                <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
-                <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
-              </div>
-            </div>
-          </div>
-          <div class="settings-content controls-content">
+  <body template="settings-shell">
+    <div class="settings-content controls-content">
         <div class="header-brand">
           <div class="brand-title-row">
             <h1>N64 CONTROLLER MAPPER</h1>
@@ -69,16 +43,6 @@
           <p id="controls-persistence-status" class="controls-save-status">Defaults (not saved yet)</p>
         </div>
 
-        <button id="autofocus" class="secondary exit-btn" onclick="back">Back to Settings</button>
-
-        <div class="footer-bar">
-          <div class="controller-guide">
-            <span class="guide-item"><span class="guide-key">A / Enter</span> Remap Slot</span>
-            <span class="guide-item"><span class="guide-key">B / Esc</span> Back / Cancel</span>
-            <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
-          </div>
-        </div>
-
         <div id="controls-capture-modal" class="controls-modal">
           <div class="modal-card">
             <h2>CAPTURE INPUT BINDING</h2>
@@ -99,9 +63,6 @@
             </div>
           </div>
         </div>
-        </div>
-      </div>
-      </div>
-      </div>
+    </div>
   </body>
 </rml>

--- a/assets/ui/pages/controls.rml
+++ b/assets/ui/pages/controls.rml
@@ -5,7 +5,32 @@
   </head>
   <body>
     <div id="window">
-      <div class="panel controls-panel">
+      <div class="panel controls-panel settings-panel">
+        <div class="settings-shell">
+          <div class="settings-nav">
+            <div class="nav-brand">
+              <span class="nav-kicker">AUTOMOBILI</span>
+              <h1>LAMBORGHINI</h1>
+            </div>
+            <div class="nav-list">
+              <button id="nav-settings" class="nav-item" onclick="page:settings"><span class="nav-marker"></span><span class="nav-label">Overview</span></button>
+              <button id="nav-graphics" class="nav-item" onclick="page:graphics"><span class="nav-marker"></span><span class="nav-label">Graphics &amp; Display</span></button>
+              <button id="nav-enhancements" class="nav-item" onclick="page:enhancements"><span class="nav-marker"></span><span class="nav-label">Visual Enhancements</span></button>
+              <button id="nav-controls" class="nav-item active" onclick="page:controls"><span class="nav-marker"></span><span class="nav-label">Controls Mapper</span></button>
+              <button id="nav-player" class="nav-item" onclick="page:player"><span class="nav-marker"></span><span class="nav-label">Driver Name</span></button>
+              <button id="nav-haptics" class="nav-item" disabled="disabled" onclick="page:haptics"><span class="nav-marker"></span><span class="nav-label">Haptics<span class="nav-note">COMING SOON</span></span></button>
+            </div>
+            <div class="nav-spacer"></div>
+            <div class="nav-footer">
+              <button class="nav-back" onclick="back">Back</button>
+              <div class="nav-hints">
+                <span class="guide-item"><span class="guide-key">A / Enter</span> Select</span>
+                <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
+                <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
+              </div>
+            </div>
+          </div>
+          <div class="settings-content controls-content">
         <div class="header-brand">
           <div class="brand-title-row">
             <h1>N64 CONTROLLER MAPPER</h1>
@@ -74,7 +99,9 @@
             </div>
           </div>
         </div>
+        </div>
       </div>
-    </div>
+      </div>
+      </div>
   </body>
 </rml>

--- a/assets/ui/pages/enhancements.rml
+++ b/assets/ui/pages/enhancements.rml
@@ -5,49 +5,236 @@
   </head>
   <body>
     <div id="window">
-      <div class="panel">
-        <div class="header-brand">
-          <div class="brand-title-row">
-            <h1>VISUAL ENHANCEMENTS</h1>
+      <div class="panel settings-panel">
+        <div class="settings-shell">
+          <div class="settings-nav">
+            <div class="nav-brand">
+              <span class="nav-kicker">AUTOMOBILI</span>
+              <h1>LAMBORGHINI</h1>
+            </div>
+            <div class="nav-list">
+              <button id="nav-settings" class="nav-item" onclick="page:settings"><span class="nav-marker"></span><span class="nav-label">Overview</span></button>
+              <button id="nav-graphics" class="nav-item" onclick="page:graphics"><span class="nav-marker"></span><span class="nav-label">Graphics &amp; Display</span></button>
+              <button id="nav-enhancements" class="nav-item active" onclick="page:enhancements"><span class="nav-marker"></span><span class="nav-label">Visual Enhancements</span></button>
+              <button id="nav-controls" class="nav-item" onclick="page:controls"><span class="nav-marker"></span><span class="nav-label">Controls Mapper</span></button>
+              <button id="nav-player" class="nav-item" onclick="page:player"><span class="nav-marker"></span><span class="nav-label">Driver Name</span></button>
+              <button id="nav-haptics" class="nav-item" disabled="disabled" onclick="page:haptics"><span class="nav-marker"></span><span class="nav-label">Haptics<span class="nav-note">COMING SOON</span></span></button>
+            </div>
+            <div class="nav-spacer"></div>
+            <div class="nav-footer">
+              <button class="nav-back" onclick="back">Back</button>
+              <div class="nav-hints">
+                <span class="guide-item"><span class="guide-key">A / Enter</span> Toggle / Change</span>
+                <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
+                <span class="guide-item"><span class="guide-key">Left / Right</span> Change value</span>
+              </div>
+              <div id="version" class="nav-version">Loading version...</div>
+            </div>
           </div>
-          <p class="brand-subtitle">Optional visual polish and draw distance extensions. Settings save automatically.</p>
-        </div>
 
-        <p class="help">Full-track visibility reduces distant pop-in per circuit when LOD limits are removed. Pro circuits may reveal unfinished scenery.</p>
+          <div class="settings-content">
+            <div class="content-header">
+              <h1>VISUAL ENHANCEMENTS</h1>
+              <p class="brand-subtitle">Optional visual polish and draw distance extensions. Settings save automatically.</p>
+            </div>
 
-        <div class="columns">
-          <div class="column">
-            <h2>Visual Polish</h2>
-            <button id="autofocus" onclick="setting:fog:toggle"><span class="setting-label">Match 3P/4P fog</span><span id="enhancement-fog" class="setting-value">Loading...</span></button>
-            <button onclick="setting:sky:toggle"><span class="setting-label">Match 3P/4P sky</span><span id="enhancement-sky" class="setting-value">Loading...</span></button>
-            <button onclick="setting:lod:toggle"><span class="setting-label">Remove original LOD limits</span><span id="enhancement-lod" class="setting-value">Loading...</span></button>
-            <button onclick="setting:distance:next"><span class="setting-label">Draw distance</span><span id="enhancement-distance" class="setting-value">Loading...</span></button>
-            <button onclick="setting:fogdensity:next"><span class="setting-label">Fog density</span><span id="enhancement-fog-density" class="setting-value">Loading...</span></button>
-          </div>
-          <div class="column">
-            <h2>Full-track visibility</h2>
-            <button onclick="setting:circuit:1"><span class="setting-label">Circuit 1 (Basic)</span><span id="enhancement-circuit-1" class="setting-value">Loading...</span></button>
-            <button onclick="setting:circuit:2"><span class="setting-label">Circuit 2 (Basic)</span><span id="enhancement-circuit-2" class="setting-value">Loading...</span></button>
-            <button onclick="setting:circuit:3"><span class="setting-label">Circuit 3 (Basic)</span><span id="enhancement-circuit-3" class="setting-value">Loading...</span></button>
-            <button onclick="setting:circuit:4"><span class="setting-label">Circuit 4 (Pro)</span><span id="enhancement-circuit-4" class="setting-value">Loading...</span></button>
-            <button onclick="setting:circuit:5"><span class="setting-label">Circuit 5 (Pro)</span><span id="enhancement-circuit-5" class="setting-value">Loading...</span></button>
-            <button onclick="setting:circuit:6"><span class="setting-label">Circuit 6 (Pro)</span><span id="enhancement-circuit-6" class="setting-value">Loading...</span></button>
-          </div>
-          <div class="column">
-            <h2>Chase camera (sense of speed)</h2>
-            <button onclick="setting:camdist:next"><span class="setting-label">Camera distance</span><span id="enhancement-camdist" class="setting-value">Loading...</span></button>
-            <button onclick="setting:camheight:next"><span class="setting-label">Camera height</span><span id="enhancement-camheight" class="setting-value">Loading...</span></button>
-            <button onclick="setting:fov:next"><span class="setting-label">Field-of-view boost</span><span id="enhancement-fov" class="setting-value">Loading...</span></button>
-          </div>
-        </div>
+            <p class="help">Full-track visibility reduces distant pop-in per circuit when LOD limits are removed. Pro circuits may reveal unfinished scenery.</p>
 
-        <button class="secondary exit-btn" onclick="back">Back to Settings</button>
+            <div class="setting-group">
+              <div class="setting-group-title">ATMOSPHERE</div>
+              <div class="setting-list">
+                <div id="toggle-fog" class="setting-row" tab-index="auto" onclick="setting:fog:toggle">
+                  <div class="setting-info">
+                    <span class="setting-name">Match 3P/4P fog</span>
+                    <span class="setting-desc">Uses player-car fog treatment when only one car is drawn.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span id="enhancement-fog" class="setting-value">Loading...</span>
+                      <span id="switch-fog" class="switch"><span class="knob"></span></span>
+                    </div>
+                  </div>
+                </div>
+                <div id="toggle-sky" class="setting-row" tab-index="auto" onclick="setting:sky:toggle">
+                  <div class="setting-info">
+                    <span class="setting-name">Match 3P/4P sky</span>
+                    <span class="setting-desc">Uses the wide-screen sky treatment from multi-car races.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span id="enhancement-sky" class="setting-value">Loading...</span>
+                      <span id="switch-sky" class="switch"><span class="knob"></span></span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
 
-        <div class="footer-bar">
-          <div class="controller-guide">
-            <span class="guide-item"><span class="guide-key">A / Enter</span> Toggle / Cycle</span>
-            <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
-            <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
+            <div class="setting-group">
+              <div class="setting-group-title">WORLD DETAIL</div>
+              <div class="setting-list">
+                <div id="toggle-lod" class="setting-row" tab-index="auto" onclick="setting:lod:toggle">
+                  <div class="setting-info">
+                    <span class="setting-name">Remove original LOD limits</span>
+                    <span class="setting-desc">Keeps full-detail models visible at any distance.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span id="enhancement-lod" class="setting-value">Loading...</span>
+                      <span id="switch-lod" class="switch"><span class="knob"></span></span>
+                    </div>
+                  </div>
+                </div>
+                <div id="setting-distance" class="setting-row" tab-index="auto">
+                  <div class="setting-info">
+                    <span class="setting-name">Draw distance</span>
+                    <span class="setting-desc">Multiplier applied to scenery and opponent draw range.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span class="step-btn" onclick="setting:distance:prev">&lt;</span>
+                      <span id="enhancement-distance" class="setting-value">Loading...</span>
+                      <span class="step-btn" onclick="setting:distance:next">&gt;</span>
+                    </div>
+                    <div id="enhancement-distance-track" class="track"></div>
+                  </div>
+                </div>
+                <div id="setting-fogdensity" class="setting-row" tab-index="auto">
+                  <div class="setting-info">
+                    <span class="setting-name">Fog density</span>
+                    <span class="setting-desc">Scales the authored distance fog. Off reveals the full track.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span class="step-btn" onclick="setting:fogdensity:prev">&lt;</span>
+                      <span id="enhancement-fog-density" class="setting-value">Loading...</span>
+                      <span class="step-btn" onclick="setting:fogdensity:next">&gt;</span>
+                    </div>
+                    <div id="enhancement-fog-density-track" class="track"></div>
+                  </div>
+                </div>
+                <div id="toggle-circuit-1" class="setting-row" tab-index="auto" onclick="setting:circuit:1">
+                  <div class="setting-info">
+                    <span class="setting-name">Circuit 1 (Basic)</span>
+                    <span class="setting-desc">Full-track visibility for this circuit.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span id="enhancement-circuit-1" class="setting-value">Loading...</span>
+                      <span id="switch-circuit-1" class="switch"><span class="knob"></span></span>
+                    </div>
+                  </div>
+                </div>
+                <div id="toggle-circuit-2" class="setting-row" tab-index="auto" onclick="setting:circuit:2">
+                  <div class="setting-info">
+                    <span class="setting-name">Circuit 2 (Basic)</span>
+                    <span class="setting-desc">Full-track visibility for this circuit.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span id="enhancement-circuit-2" class="setting-value">Loading...</span>
+                      <span id="switch-circuit-2" class="switch"><span class="knob"></span></span>
+                    </div>
+                  </div>
+                </div>
+                <div id="toggle-circuit-3" class="setting-row" tab-index="auto" onclick="setting:circuit:3">
+                  <div class="setting-info">
+                    <span class="setting-name">Circuit 3 (Basic)</span>
+                    <span class="setting-desc">Full-track visibility for this circuit.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span id="enhancement-circuit-3" class="setting-value">Loading...</span>
+                      <span id="switch-circuit-3" class="switch"><span class="knob"></span></span>
+                    </div>
+                  </div>
+                </div>
+                <div id="toggle-circuit-4" class="setting-row" tab-index="auto" onclick="setting:circuit:4">
+                  <div class="setting-info">
+                    <span class="setting-name">Circuit 4 (Pro)</span>
+                    <span class="setting-desc">Full-track visibility for this circuit.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span id="enhancement-circuit-4" class="setting-value">Loading...</span>
+                      <span id="switch-circuit-4" class="switch"><span class="knob"></span></span>
+                    </div>
+                  </div>
+                </div>
+                <div id="toggle-circuit-5" class="setting-row" tab-index="auto" onclick="setting:circuit:5">
+                  <div class="setting-info">
+                    <span class="setting-name">Circuit 5 (Pro)</span>
+                    <span class="setting-desc">Full-track visibility for this circuit.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span id="enhancement-circuit-5" class="setting-value">Loading...</span>
+                      <span id="switch-circuit-5" class="switch"><span class="knob"></span></span>
+                    </div>
+                  </div>
+                </div>
+                <div id="toggle-circuit-6" class="setting-row" tab-index="auto" onclick="setting:circuit:6">
+                  <div class="setting-info">
+                    <span class="setting-name">Circuit 6 (Pro)</span>
+                    <span class="setting-desc">Full-track visibility for this circuit.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span id="enhancement-circuit-6" class="setting-value">Loading...</span>
+                      <span id="switch-circuit-6" class="switch"><span class="knob"></span></span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="setting-group">
+              <div class="setting-group-title">CHASE CAMERA (SENSE OF SPEED)</div>
+              <div class="setting-list">
+                <div id="setting-camdist" class="setting-row" tab-index="auto">
+                  <div class="setting-info">
+                    <span class="setting-name">Camera distance</span>
+                    <span class="setting-desc">Pulls the chase camera closer for a faster feel.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span class="step-btn" onclick="setting:camdist:prev">&lt;</span>
+                      <span id="enhancement-camdist" class="setting-value">Loading...</span>
+                      <span class="step-btn" onclick="setting:camdist:next">&gt;</span>
+                    </div>
+                    <div id="enhancement-camdist-track" class="track"></div>
+                  </div>
+                </div>
+                <div id="setting-camheight" class="setting-row" tab-index="auto">
+                  <div class="setting-info">
+                    <span class="setting-name">Camera height</span>
+                    <span class="setting-desc">Lowers the chase camera for a more grounded angle.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span class="step-btn" onclick="setting:camheight:prev">&lt;</span>
+                      <span id="enhancement-camheight" class="setting-value">Loading...</span>
+                      <span class="step-btn" onclick="setting:camheight:next">&gt;</span>
+                    </div>
+                    <div id="enhancement-camheight-track" class="track"></div>
+                  </div>
+                </div>
+                <div id="setting-fov" class="setting-row" tab-index="auto">
+                  <div class="setting-info">
+                    <span class="setting-name">Field-of-view boost</span>
+                    <span class="setting-desc">Widens the lens. The view cone adapts automatically.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span class="step-btn" onclick="setting:fov:prev">&lt;</span>
+                      <span id="enhancement-fov" class="setting-value">Loading...</span>
+                      <span class="step-btn" onclick="setting:fov:next">&gt;</span>
+                    </div>
+                    <div id="enhancement-fov-track" class="track"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/assets/ui/pages/enhancements.rml
+++ b/assets/ui/pages/enhancements.rml
@@ -1,38 +1,10 @@
 <rml>
   <head>
     <title>Enhancements</title>
-    <link type="text/rcss" href="../lambo.rcss"/>
+    <link type="text/template" href="../settings_shell.rml"/>
   </head>
-  <body>
-    <div id="window">
-      <div class="panel settings-panel">
-        <div class="settings-shell">
-          <div class="settings-nav">
-            <div class="nav-brand">
-              <span class="nav-kicker">AUTOMOBILI</span>
-              <h1>LAMBORGHINI</h1>
-            </div>
-            <div class="nav-list">
-              <button id="nav-settings" class="nav-item" onclick="page:settings"><span class="nav-marker"></span><span class="nav-label">Overview</span></button>
-              <button id="nav-graphics" class="nav-item" onclick="page:graphics"><span class="nav-marker"></span><span class="nav-label">Graphics &amp; Display</span></button>
-              <button id="nav-enhancements" class="nav-item active" onclick="page:enhancements"><span class="nav-marker"></span><span class="nav-label">Visual Enhancements</span></button>
-              <button id="nav-controls" class="nav-item" onclick="page:controls"><span class="nav-marker"></span><span class="nav-label">Controls Mapper</span></button>
-              <button id="nav-player" class="nav-item" onclick="page:player"><span class="nav-marker"></span><span class="nav-label">Driver Name</span></button>
-              <button id="nav-haptics" class="nav-item" disabled="disabled" onclick="page:haptics"><span class="nav-marker"></span><span class="nav-label">Haptics<span class="nav-note">COMING SOON</span></span></button>
-            </div>
-            <div class="nav-spacer"></div>
-            <div class="nav-footer">
-              <button class="nav-back" onclick="back">Back</button>
-              <div class="nav-hints">
-                <span class="guide-item"><span class="guide-key">A / Enter</span> Toggle / Change</span>
-                <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
-                <span class="guide-item"><span class="guide-key">Left / Right</span> Change value</span>
-              </div>
-              <div id="version" class="nav-version">Loading version...</div>
-            </div>
-          </div>
-
-          <div class="settings-content">
+  <body template="settings-shell">
+    <div class="settings-content">
             <div class="content-header">
               <h1>VISUAL ENHANCEMENTS</h1>
               <p class="brand-subtitle">Optional visual polish and draw distance extensions. Settings save automatically.</p>
@@ -236,8 +208,5 @@
               </div>
             </div>
           </div>
-        </div>
-      </div>
-    </div>
   </body>
 </rml>

--- a/assets/ui/pages/graphics.rml
+++ b/assets/ui/pages/graphics.rml
@@ -5,39 +5,164 @@
   </head>
   <body>
     <div id="window">
-      <div class="panel">
-        <div class="header-brand">
-          <div class="brand-title-row">
-            <h1>GRAPHICS AND DISPLAY</h1>
+      <div class="panel settings-panel">
+        <div class="settings-shell">
+          <div class="settings-nav">
+            <div class="nav-brand">
+              <span class="nav-kicker">AUTOMOBILI</span>
+              <h1>LAMBORGHINI</h1>
+            </div>
+            <div class="nav-list">
+              <button id="nav-settings" class="nav-item" onclick="page:settings"><span class="nav-marker"></span><span class="nav-label">Overview</span></button>
+              <button id="nav-graphics" class="nav-item active" onclick="page:graphics"><span class="nav-marker"></span><span class="nav-label">Graphics &amp; Display</span></button>
+              <button id="nav-enhancements" class="nav-item" onclick="page:enhancements"><span class="nav-marker"></span><span class="nav-label">Visual Enhancements</span></button>
+              <button id="nav-controls" class="nav-item" onclick="page:controls"><span class="nav-marker"></span><span class="nav-label">Controls Mapper</span></button>
+              <button id="nav-player" class="nav-item" onclick="page:player"><span class="nav-marker"></span><span class="nav-label">Driver Name</span></button>
+              <button id="nav-haptics" class="nav-item" disabled="disabled" onclick="page:haptics"><span class="nav-marker"></span><span class="nav-label">Haptics<span class="nav-note">COMING SOON</span></span></button>
+            </div>
+            <div class="nav-spacer"></div>
+            <div class="nav-footer">
+              <button class="nav-back" onclick="back">Back</button>
+              <div class="nav-hints">
+                <span class="guide-item"><span class="guide-key">A / Enter</span> Change value</span>
+                <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
+                <span class="guide-item"><span class="guide-key">Left / Right</span> Change value</span>
+              </div>
+              <div id="version" class="nav-version">Loading version...</div>
+            </div>
           </div>
-          <p class="brand-subtitle">Activate a row to cycle its value. Live-safe changes apply and save immediately.</p>
-        </div>
 
-        <div class="columns">
-          <div class="column">
-            <h2>Display Settings</h2>
-            <button id="autofocus" onclick="setting:res:next"><span class="setting-label">Internal resolution</span><span id="graphics-resolution" class="setting-value">Loading...</span></button>
-            <button onclick="setting:ss:next"><span class="setting-label">Supersampling</span><span id="graphics-supersampling" class="setting-value">Loading...</span></button>
-            <button onclick="setting:aspect:next"><span class="setting-label">Aspect ratio</span><span id="graphics-aspect" class="setting-value">Loading...</span></button>
-            <button onclick="setting:hud:next"><span class="setting-label">HUD layout</span><span id="graphics-hud" class="setting-value">Loading...</span></button>
-          </div>
-          <div class="column">
-            <h2>Rendering Options</h2>
-            <button onclick="setting:rate:next"><span class="setting-label">Refresh rate</span><span id="graphics-refresh" class="setting-value">Loading...</span></button>
-            <button onclick="setting:msaa:next"><span class="setting-label">Anti-aliasing</span><span id="graphics-msaa" class="setting-value">Loading...</span></button>
-            <button onclick="setting:hpfb:next"><span class="setting-label">Framebuffer precision</span><span id="graphics-hpfb" class="setting-value">Loading...</span></button>
-            <button onclick="setting:api:next"><span class="setting-label">Graphics API *</span><span id="graphics-api" class="setting-value">Loading...</span></button>
-          </div>
-        </div>
+          <div class="settings-content">
+            <div class="content-header">
+              <h1>GRAPHICS AND DISPLAY</h1>
+              <p class="brand-subtitle">Presentation and rendering. Live-safe changes apply and save immediately.</p>
+            </div>
 
-        <p class="note">* Graphics API changes are saved for the next launch and do not apply immediately.</p>
-        <button class="secondary exit-btn" onclick="back">Back to Settings</button>
+            <div class="setting-group">
+              <div class="setting-group-title">DISPLAY</div>
+              <div class="setting-list">
+                <div id="setting-res" class="setting-row" tab-index="auto">
+                  <div class="setting-info">
+                    <span class="setting-name">Internal resolution</span>
+                    <span class="setting-desc">Scale of the render target before it is presented.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span class="step-btn" onclick="setting:res:prev">&lt;</span>
+                      <span id="graphics-resolution" class="setting-value">Loading...</span>
+                      <span class="step-btn" onclick="setting:res:next">&gt;</span>
+                    </div>
+                    <div id="graphics-resolution-track" class="track"></div>
+                  </div>
+                </div>
+                <div id="setting-ss" class="setting-row" tab-index="auto">
+                  <div class="setting-info">
+                    <span class="setting-name">Supersampling</span>
+                    <span class="setting-desc">Renders above native size and downsamples for sharper edges.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span class="step-btn" onclick="setting:ss:prev">&lt;</span>
+                      <span id="graphics-supersampling" class="setting-value">Loading...</span>
+                      <span class="step-btn" onclick="setting:ss:next">&gt;</span>
+                    </div>
+                    <div id="graphics-supersampling-track" class="track"></div>
+                  </div>
+                </div>
+                <div id="setting-aspect" class="setting-row" tab-index="auto">
+                  <div class="setting-info">
+                    <span class="setting-name">Aspect ratio</span>
+                    <span class="setting-desc">Expand widens the view on widescreen displays.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span class="step-btn" onclick="setting:aspect:prev">&lt;</span>
+                      <span id="graphics-aspect" class="setting-value">Loading...</span>
+                      <span class="step-btn" onclick="setting:aspect:next">&gt;</span>
+                    </div>
+                    <div id="graphics-aspect-track" class="track"></div>
+                  </div>
+                </div>
+                <div id="setting-hud" class="setting-row" tab-index="auto">
+                  <div class="setting-info">
+                    <span class="setting-name">HUD layout</span>
+                    <span class="setting-desc">How the on-screen display is placed on wide screens.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span class="step-btn" onclick="setting:hud:prev">&lt;</span>
+                      <span id="graphics-hud" class="setting-value">Loading...</span>
+                      <span class="step-btn" onclick="setting:hud:next">&gt;</span>
+                    </div>
+                    <div id="graphics-hud-track" class="track"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
 
-        <div class="footer-bar">
-          <div class="controller-guide">
-            <span class="guide-item"><span class="guide-key">A / Enter</span> Change Value</span>
-            <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
-            <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
+            <div class="setting-group">
+              <div class="setting-group-title">RENDERING</div>
+              <div class="setting-list">
+                <div id="setting-rate" class="setting-row" tab-index="auto">
+                  <div class="setting-info">
+                    <span class="setting-name">Refresh rate</span>
+                    <span class="setting-desc">Original follows the N64 timing. Manual locks a fixed rate.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span class="step-btn" onclick="setting:rate:prev">&lt;</span>
+                      <span id="graphics-refresh" class="setting-value">Loading...</span>
+                      <span class="step-btn" onclick="setting:rate:next">&gt;</span>
+                    </div>
+                    <div id="graphics-refresh-track" class="track"></div>
+                  </div>
+                </div>
+                <div id="setting-msaa" class="setting-row" tab-index="auto">
+                  <div class="setting-info">
+                    <span class="setting-name">Anti-aliasing</span>
+                    <span class="setting-desc">Multisample anti-aliasing smooths jagged polygon edges.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span class="step-btn" onclick="setting:msaa:prev">&lt;</span>
+                      <span id="graphics-msaa" class="setting-value">Loading...</span>
+                      <span class="step-btn" onclick="setting:msaa:next">&gt;</span>
+                    </div>
+                    <div id="graphics-msaa-track" class="track"></div>
+                  </div>
+                </div>
+                <div id="setting-hpfb" class="setting-row" tab-index="auto">
+                  <div class="setting-info">
+                    <span class="setting-name">Framebuffer precision</span>
+                    <span class="setting-desc">Higher precision reduces banding in gradients and fog.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span class="step-btn" onclick="setting:hpfb:prev">&lt;</span>
+                      <span id="graphics-hpfb" class="setting-value">Loading...</span>
+                      <span class="step-btn" onclick="setting:hpfb:next">&gt;</span>
+                    </div>
+                    <div id="graphics-hpfb-track" class="track"></div>
+                  </div>
+                </div>
+                <div id="setting-api" class="setting-row" tab-index="auto">
+                  <div class="setting-info">
+                    <span class="setting-name">Graphics API</span>
+                    <span class="setting-desc">Backend used to present the game. Restart required.</span>
+                  </div>
+                  <div class="setting-control">
+                    <div class="setting-stepper">
+                      <span class="step-btn" onclick="setting:api:prev">&lt;</span>
+                      <span id="graphics-api" class="setting-value">Loading...</span>
+                      <span class="step-btn" onclick="setting:api:next">&gt;</span>
+                    </div>
+                    <div id="graphics-api-track" class="track"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <p class="note">* Graphics API changes are saved for the next launch and do not apply immediately.</p>
           </div>
         </div>
       </div>

--- a/assets/ui/pages/graphics.rml
+++ b/assets/ui/pages/graphics.rml
@@ -1,38 +1,10 @@
 <rml>
   <head>
     <title>Graphics</title>
-    <link type="text/rcss" href="../lambo.rcss"/>
+    <link type="text/template" href="../settings_shell.rml"/>
   </head>
-  <body>
-    <div id="window">
-      <div class="panel settings-panel">
-        <div class="settings-shell">
-          <div class="settings-nav">
-            <div class="nav-brand">
-              <span class="nav-kicker">AUTOMOBILI</span>
-              <h1>LAMBORGHINI</h1>
-            </div>
-            <div class="nav-list">
-              <button id="nav-settings" class="nav-item" onclick="page:settings"><span class="nav-marker"></span><span class="nav-label">Overview</span></button>
-              <button id="nav-graphics" class="nav-item active" onclick="page:graphics"><span class="nav-marker"></span><span class="nav-label">Graphics &amp; Display</span></button>
-              <button id="nav-enhancements" class="nav-item" onclick="page:enhancements"><span class="nav-marker"></span><span class="nav-label">Visual Enhancements</span></button>
-              <button id="nav-controls" class="nav-item" onclick="page:controls"><span class="nav-marker"></span><span class="nav-label">Controls Mapper</span></button>
-              <button id="nav-player" class="nav-item" onclick="page:player"><span class="nav-marker"></span><span class="nav-label">Driver Name</span></button>
-              <button id="nav-haptics" class="nav-item" disabled="disabled" onclick="page:haptics"><span class="nav-marker"></span><span class="nav-label">Haptics<span class="nav-note">COMING SOON</span></span></button>
-            </div>
-            <div class="nav-spacer"></div>
-            <div class="nav-footer">
-              <button class="nav-back" onclick="back">Back</button>
-              <div class="nav-hints">
-                <span class="guide-item"><span class="guide-key">A / Enter</span> Change value</span>
-                <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
-                <span class="guide-item"><span class="guide-key">Left / Right</span> Change value</span>
-              </div>
-              <div id="version" class="nav-version">Loading version...</div>
-            </div>
-          </div>
-
-          <div class="settings-content">
+  <body template="settings-shell">
+    <div class="settings-content">
             <div class="content-header">
               <h1>GRAPHICS AND DISPLAY</h1>
               <p class="brand-subtitle">Presentation and rendering. Live-safe changes apply and save immediately.</p>
@@ -163,9 +135,6 @@
             </div>
 
             <p class="note">* Graphics API changes are saved for the next launch and do not apply immediately.</p>
-          </div>
-        </div>
-      </div>
     </div>
   </body>
 </rml>

--- a/assets/ui/pages/haptics.rml
+++ b/assets/ui/pages/haptics.rml
@@ -5,23 +5,40 @@
   </head>
   <body>
     <div id="window">
-      <div class="panel">
-        <div class="header-brand">
-          <div class="brand-title-row">
-            <h1>HAPTICS AND RUMBLE</h1>
-            <span class="badge-pill">COMING SOON</span>
+      <div class="panel settings-panel">
+        <div class="settings-shell">
+          <div class="settings-nav">
+            <div class="nav-brand">
+              <span class="nav-kicker">AUTOMOBILI</span>
+              <h1>LAMBORGHINI</h1>
+            </div>
+            <div class="nav-list">
+              <button id="nav-settings" class="nav-item" onclick="page:settings"><span class="nav-marker"></span><span class="nav-label">Overview</span></button>
+              <button id="nav-graphics" class="nav-item" onclick="page:graphics"><span class="nav-marker"></span><span class="nav-label">Graphics &amp; Display</span></button>
+              <button id="nav-enhancements" class="nav-item" onclick="page:enhancements"><span class="nav-marker"></span><span class="nav-label">Visual Enhancements</span></button>
+              <button id="nav-controls" class="nav-item" onclick="page:controls"><span class="nav-marker"></span><span class="nav-label">Controls Mapper</span></button>
+              <button id="nav-player" class="nav-item" onclick="page:player"><span class="nav-marker"></span><span class="nav-label">Driver Name</span></button>
+              <button id="nav-haptics" class="nav-item active" disabled="disabled" onclick="page:haptics"><span class="nav-marker"></span><span class="nav-label">Haptics<span class="nav-note">COMING SOON</span></span></button>
+            </div>
+            <div class="nav-spacer"></div>
+            <div class="nav-footer">
+              <button class="nav-back" onclick="back">Back</button>
+              <div class="nav-hints">
+                <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
+              </div>
+              <div id="version" class="nav-version">Loading version...</div>
+            </div>
           </div>
-          <p class="brand-subtitle">Controller rumble vibration motors and trigger feedback.</p>
-        </div>
 
-        <p class="help">Rumble strength calibration and trigger vibration controls will be available here in an upcoming release.</p>
-        <button id="autofocus" class="secondary exit-btn" onclick="back">Back to Settings</button>
+          <div class="settings-content">
+            <div class="content-header">
+              <h1>HAPTICS AND RUMBLE</h1>
+              <p class="brand-subtitle">Controller rumble vibration motors and trigger feedback.</p>
+            </div>
 
-        <div class="footer-bar">
-          <div class="controller-guide">
-            <span class="guide-item"><span class="guide-key">A / Enter</span> Select</span>
-            <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
-            <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
+            <div class="placeholder-card">
+              <p>Rumble strength calibration and trigger vibration controls will be available here in an upcoming release.</p>
+            </div>
           </div>
         </div>
       </div>

--- a/assets/ui/pages/haptics.rml
+++ b/assets/ui/pages/haptics.rml
@@ -1,36 +1,10 @@
 <rml>
   <head>
     <title>Haptics</title>
-    <link type="text/rcss" href="../lambo.rcss"/>
+    <link type="text/template" href="../settings_shell.rml"/>
   </head>
-  <body>
-    <div id="window">
-      <div class="panel settings-panel">
-        <div class="settings-shell">
-          <div class="settings-nav">
-            <div class="nav-brand">
-              <span class="nav-kicker">AUTOMOBILI</span>
-              <h1>LAMBORGHINI</h1>
-            </div>
-            <div class="nav-list">
-              <button id="nav-settings" class="nav-item" onclick="page:settings"><span class="nav-marker"></span><span class="nav-label">Overview</span></button>
-              <button id="nav-graphics" class="nav-item" onclick="page:graphics"><span class="nav-marker"></span><span class="nav-label">Graphics &amp; Display</span></button>
-              <button id="nav-enhancements" class="nav-item" onclick="page:enhancements"><span class="nav-marker"></span><span class="nav-label">Visual Enhancements</span></button>
-              <button id="nav-controls" class="nav-item" onclick="page:controls"><span class="nav-marker"></span><span class="nav-label">Controls Mapper</span></button>
-              <button id="nav-player" class="nav-item" onclick="page:player"><span class="nav-marker"></span><span class="nav-label">Driver Name</span></button>
-              <button id="nav-haptics" class="nav-item active" disabled="disabled" onclick="page:haptics"><span class="nav-marker"></span><span class="nav-label">Haptics<span class="nav-note">COMING SOON</span></span></button>
-            </div>
-            <div class="nav-spacer"></div>
-            <div class="nav-footer">
-              <button class="nav-back" onclick="back">Back</button>
-              <div class="nav-hints">
-                <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
-              </div>
-              <div id="version" class="nav-version">Loading version...</div>
-            </div>
-          </div>
-
-          <div class="settings-content">
+  <body template="settings-shell">
+    <div class="settings-content">
             <div class="content-header">
               <h1>HAPTICS AND RUMBLE</h1>
               <p class="brand-subtitle">Controller rumble vibration motors and trigger feedback.</p>
@@ -39,9 +13,6 @@
             <div class="placeholder-card">
               <p>Rumble strength calibration and trigger vibration controls will be available here in an upcoming release.</p>
             </div>
-          </div>
-        </div>
-      </div>
     </div>
   </body>
 </rml>

--- a/assets/ui/pages/player.rml
+++ b/assets/ui/pages/player.rml
@@ -5,35 +5,52 @@
   </head>
   <body>
     <div id="window">
-      <div class="panel">
-        <div class="header-brand">
-          <div class="brand-title-row">
-            <h1>DRIVER NAME</h1>
+      <div class="panel settings-panel">
+        <div class="settings-shell">
+          <div class="settings-nav">
+            <div class="nav-brand">
+              <span class="nav-kicker">AUTOMOBILI</span>
+              <h1>LAMBORGHINI</h1>
+            </div>
+            <div class="nav-list">
+              <button id="nav-settings" class="nav-item" onclick="page:settings"><span class="nav-marker"></span><span class="nav-label">Overview</span></button>
+              <button id="nav-graphics" class="nav-item" onclick="page:graphics"><span class="nav-marker"></span><span class="nav-label">Graphics &amp; Display</span></button>
+              <button id="nav-enhancements" class="nav-item" onclick="page:enhancements"><span class="nav-marker"></span><span class="nav-label">Visual Enhancements</span></button>
+              <button id="nav-controls" class="nav-item" onclick="page:controls"><span class="nav-marker"></span><span class="nav-label">Controls Mapper</span></button>
+              <button id="nav-player" class="nav-item active" onclick="page:player"><span class="nav-marker"></span><span class="nav-label">Driver Name</span></button>
+              <button id="nav-haptics" class="nav-item" disabled="disabled" onclick="page:haptics"><span class="nav-marker"></span><span class="nav-label">Haptics<span class="nav-note">COMING SOON</span></span></button>
+            </div>
+            <div class="nav-spacer"></div>
+            <div class="nav-footer">
+              <button class="nav-back" onclick="back">Back</button>
+              <div class="nav-hints">
+                <span class="guide-item"><span class="guide-key">A / Enter</span> Save / Clear</span>
+                <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
+              </div>
+              <div id="version" class="nav-version">Loading version...</div>
+            </div>
           </div>
-          <p class="brand-subtitle">Player one's saved identity, used for Championship records. Saved to player.json when you activate Save below.</p>
-        </div>
 
-        <p class="help">1-12 letters A-Z and spaces. Lowercase is uppercased automatically. The in-game Championship name editor saves here too, so both stay in sync.</p>
+          <div class="settings-content">
+            <div class="content-header">
+              <h1>DRIVER NAME</h1>
+              <p class="brand-subtitle">Player one's saved identity, used for Championship records.</p>
+            </div>
 
-        <div class="columns">
-          <div class="column">
-            <h2>Saved driver</h2>
-            <p>Current driver: <span id="player-name-current" class="highlight-val">Loading...</span></p>
-            <p>Edit the name below, then activate Save. Keyboard: click the field and type, then Tab to Save.</p>
-            <input type="text" id="player-name-input" maxlength="12" size="14" value=""/>
-            <button id="autofocus" onclick="player:save">Save driver name</button>
-            <button onclick="player:clear">Clear saved name (use ROM default)</button>
-            <p id="player-name-status" class="summary"></p>
-          </div>
-        </div>
-
-        <button class="secondary exit-btn" onclick="back">Back to Settings</button>
-
-        <div class="footer-bar">
-          <div class="controller-guide">
-            <span class="guide-item"><span class="guide-key">A / Enter</span> Save / Clear</span>
-            <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
-            <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
+            <div class="setting-group">
+              <div class="setting-group-title">SAVED DRIVER</div>
+              <div class="overview-item">
+                <span class="overview-kicker">CURRENT</span>
+                <span id="player-name-current" class="overview-value">Loading...</span>
+              </div>
+              <p class="help">1-12 letters A-Z and spaces. Lowercase is uppercased automatically. The in-game Championship editor saves here too, so both stay in sync.</p>
+              <input type="text" id="player-name-input" class="driver-field" maxlength="12" size="14" value=""/>
+              <div class="driver-actions">
+                <button class="primary" onclick="player:save">Save driver name</button>
+                <button class="secondary" onclick="player:clear">Clear saved name</button>
+              </div>
+              <p id="player-name-status" class="summary"></p>
+            </div>
           </div>
         </div>
       </div>

--- a/assets/ui/pages/player.rml
+++ b/assets/ui/pages/player.rml
@@ -1,37 +1,10 @@
 <rml>
   <head>
     <title>Driver name</title>
-    <link type="text/rcss" href="../lambo.rcss"/>
+    <link type="text/template" href="../settings_shell.rml"/>
   </head>
-  <body>
-    <div id="window">
-      <div class="panel settings-panel">
-        <div class="settings-shell">
-          <div class="settings-nav">
-            <div class="nav-brand">
-              <span class="nav-kicker">AUTOMOBILI</span>
-              <h1>LAMBORGHINI</h1>
-            </div>
-            <div class="nav-list">
-              <button id="nav-settings" class="nav-item" onclick="page:settings"><span class="nav-marker"></span><span class="nav-label">Overview</span></button>
-              <button id="nav-graphics" class="nav-item" onclick="page:graphics"><span class="nav-marker"></span><span class="nav-label">Graphics &amp; Display</span></button>
-              <button id="nav-enhancements" class="nav-item" onclick="page:enhancements"><span class="nav-marker"></span><span class="nav-label">Visual Enhancements</span></button>
-              <button id="nav-controls" class="nav-item" onclick="page:controls"><span class="nav-marker"></span><span class="nav-label">Controls Mapper</span></button>
-              <button id="nav-player" class="nav-item active" onclick="page:player"><span class="nav-marker"></span><span class="nav-label">Driver Name</span></button>
-              <button id="nav-haptics" class="nav-item" disabled="disabled" onclick="page:haptics"><span class="nav-marker"></span><span class="nav-label">Haptics<span class="nav-note">COMING SOON</span></span></button>
-            </div>
-            <div class="nav-spacer"></div>
-            <div class="nav-footer">
-              <button class="nav-back" onclick="back">Back</button>
-              <div class="nav-hints">
-                <span class="guide-item"><span class="guide-key">A / Enter</span> Save / Clear</span>
-                <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
-              </div>
-              <div id="version" class="nav-version">Loading version...</div>
-            </div>
-          </div>
-
-          <div class="settings-content">
+  <body template="settings-shell">
+    <div class="settings-content">
             <div class="content-header">
               <h1>DRIVER NAME</h1>
               <p class="brand-subtitle">Player one's saved identity, used for Championship records.</p>
@@ -51,9 +24,6 @@
               </div>
               <p id="player-name-status" class="summary"></p>
             </div>
-          </div>
-        </div>
-      </div>
     </div>
   </body>
 </rml>

--- a/assets/ui/settings.rml
+++ b/assets/ui/settings.rml
@@ -5,55 +5,54 @@
   </head>
   <body>
     <div id="window">
-      <div class="panel">
-        <div class="header-brand">
-          <div class="brand-title-row">
-            <h1>CONFIGURATION</h1>
-            <span class="badge-pill">PAUSED</span>
-          </div>
-        </div>
-
-        <div class="grid-2x2">
-          <div class="grid-row">
-            <button id="autofocus" class="menu-card" onclick="page:graphics">
-              <span class="btn-main-label">Graphics and Display</span>
-              <span class="btn-sub-label">Resolution, aspect ratio, refresh rate, MSAA anti-aliasing, and API</span>
-            </button>
-            <button class="menu-card" onclick="page:enhancements">
-              <span class="btn-main-label">Visual Enhancements</span>
-              <span class="btn-sub-label">Widescreen fog and sky matching, draw distance, per-circuit LOD, and chase camera</span>
-            </button>
-          </div>
-
-          <div class="grid-row">
-            <button class="menu-card" onclick="page:controls">
-              <span class="btn-main-label">Controls Mapper</span>
-              <span class="btn-sub-label">N64 controller remapping, analog stick calibration, and profiles</span>
-            </button>
-            <button class="menu-card" disabled="disabled" onclick="page:haptics">
-              <span class="btn-main-label">Haptics and Rumble (Coming Soon)</span>
-              <span class="btn-sub-label">Controller rumble vibration motors and trigger feedback</span>
-            </button>
+      <div class="panel settings-panel">
+        <div class="settings-shell">
+          <div class="settings-nav">
+            <div class="nav-brand">
+              <span class="nav-kicker">AUTOMOBILI</span>
+              <h1>LAMBORGHINI</h1>
+            </div>
+            <div class="nav-list">
+              <button id="nav-settings" class="nav-item active" onclick="page:settings"><span class="nav-marker"></span><span class="nav-label">Overview</span></button>
+              <button id="nav-graphics" class="nav-item" onclick="page:graphics"><span class="nav-marker"></span><span class="nav-label">Graphics &amp; Display</span></button>
+              <button id="nav-enhancements" class="nav-item" onclick="page:enhancements"><span class="nav-marker"></span><span class="nav-label">Visual Enhancements</span></button>
+              <button id="nav-controls" class="nav-item" onclick="page:controls"><span class="nav-marker"></span><span class="nav-label">Controls Mapper</span></button>
+              <button id="nav-player" class="nav-item" onclick="page:player"><span class="nav-marker"></span><span class="nav-label">Driver Name</span></button>
+              <button id="nav-haptics" class="nav-item" disabled="disabled" onclick="page:haptics"><span class="nav-marker"></span><span class="nav-label">Haptics<span class="nav-note">COMING SOON</span></span></button>
+            </div>
+            <div class="nav-spacer"></div>
+            <div class="nav-footer">
+              <button class="nav-back" onclick="back">Back</button>
+              <div class="nav-hints">
+                <span class="guide-item"><span class="guide-key">A / Enter</span> Select</span>
+                <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
+                <span class="guide-item"><span class="guide-key">Left / Right</span> Change value</span>
+              </div>
+              <div id="version" class="nav-version">Loading version...</div>
+            </div>
           </div>
 
-          <div class="grid-row">
-            <button class="menu-card slim" onclick="page:player">
-              <span class="btn-main-label">Driver Name</span>
-              <span class="btn-sub-label">Player one's saved identity for Championship records</span>
-            </button>
-          </div>
-        </div>
+          <div class="settings-content">
+            <div class="content-header">
+              <h1>OVERVIEW</h1>
+              <p class="brand-subtitle">Choose a section on the left. Changes apply and save automatically.</p>
+            </div>
 
-        <div class="overlay-actions">
-          <button class="primary overlay-action-btn" onclick="back">Resume Game</button>
-          <button class="secondary overlay-action-btn" onclick="quit">Exit to Desktop</button>
-        </div>
+            <div class="overview-list">
+              <div class="overview-item">
+                <span class="overview-kicker">GRAPHICS &amp; DISPLAY</span>
+                <span id="overview-graphics" class="overview-value">Loading...</span>
+              </div>
+              <div class="overview-item">
+                <span class="overview-kicker">VISUAL ENHANCEMENTS</span>
+                <span id="overview-enhancements" class="overview-value">Loading...</span>
+              </div>
+              <div class="overview-item">
+                <span class="overview-kicker">DRIVER</span>
+                <span id="overview-driver" class="overview-value">Loading...</span>
+              </div>
+            </div>
 
-        <div class="footer-bar">
-          <div class="controller-guide">
-            <span class="guide-item"><span class="guide-key">A / Enter</span> Select</span>
-            <span class="guide-item"><span class="guide-key">B / Esc / Menu</span> Resume</span>
-            <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
           </div>
         </div>
       </div>

--- a/assets/ui/settings.rml
+++ b/assets/ui/settings.rml
@@ -1,41 +1,15 @@
 <rml>
   <head>
     <title>Settings</title>
-    <link type="text/rcss" href="lambo.rcss"/>
+    <link type="text/template" href="settings_shell.rml"/>
   </head>
-  <body>
-    <div id="window">
-      <div class="panel settings-panel">
-        <div class="settings-shell">
-          <div class="settings-nav">
-            <div class="nav-brand">
-              <span class="nav-kicker">AUTOMOBILI</span>
-              <h1>LAMBORGHINI</h1>
-            </div>
-            <div class="nav-list">
-              <button id="nav-settings" class="nav-item active" onclick="page:settings"><span class="nav-marker"></span><span class="nav-label">Overview</span></button>
-              <button id="nav-graphics" class="nav-item" onclick="page:graphics"><span class="nav-marker"></span><span class="nav-label">Graphics &amp; Display</span></button>
-              <button id="nav-enhancements" class="nav-item" onclick="page:enhancements"><span class="nav-marker"></span><span class="nav-label">Visual Enhancements</span></button>
-              <button id="nav-controls" class="nav-item" onclick="page:controls"><span class="nav-marker"></span><span class="nav-label">Controls Mapper</span></button>
-              <button id="nav-player" class="nav-item" onclick="page:player"><span class="nav-marker"></span><span class="nav-label">Driver Name</span></button>
-              <button id="nav-haptics" class="nav-item" disabled="disabled" onclick="page:haptics"><span class="nav-marker"></span><span class="nav-label">Haptics<span class="nav-note">COMING SOON</span></span></button>
-            </div>
-            <div class="nav-spacer"></div>
-            <div class="nav-footer">
-              <button class="nav-back" onclick="back">Back</button>
-              <div class="nav-hints">
-                <span class="guide-item"><span class="guide-key">A / Enter</span> Select</span>
-                <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
-                <span class="guide-item"><span class="guide-key">Left / Right</span> Change value</span>
-              </div>
-              <div id="version" class="nav-version">Loading version...</div>
-            </div>
-          </div>
-
-          <div class="settings-content">
+  <body template="settings-shell">
+    <div class="settings-content">
             <div class="content-header">
-              <h1>OVERVIEW</h1>
-              <p class="brand-subtitle">Choose a section on the left. Changes apply and save automatically.</p>
+              <div class="brand-title-row">
+                <h1>OVERVIEW</h1>
+                <span class="badge-pill">PAUSED</span>
+              </div>
             </div>
 
             <div class="overview-list">
@@ -53,9 +27,10 @@
               </div>
             </div>
 
-          </div>
-        </div>
-      </div>
+            <div class="overlay-actions">
+              <button class="primary overlay-action-btn" onclick="back">Resume Game</button>
+              <button class="secondary overlay-action-btn" onclick="quit">Exit to Desktop</button>
+            </div>
     </div>
   </body>
 </rml>

--- a/assets/ui/settings_shell.rml
+++ b/assets/ui/settings_shell.rml
@@ -1,0 +1,38 @@
+<template name="settings-shell" content="content">
+  <head>
+    <link type="text/rcss" href="lambo.rcss"/>
+  </head>
+  <body>
+    <div id="window">
+      <div class="panel settings-panel">
+        <div class="settings-shell">
+          <div class="settings-nav">
+            <div class="nav-brand">
+              <span class="nav-kicker">AUTOMOBILI</span>
+              <h1>LAMBORGHINI</h1>
+            </div>
+            <div class="nav-list">
+              <button id="nav-settings" class="nav-item" onclick="page:settings"><span class="nav-marker"></span><span class="nav-label">Overview</span></button>
+              <button id="nav-graphics" class="nav-item" onclick="page:graphics"><span class="nav-marker"></span><span class="nav-label">Graphics &amp; Display</span></button>
+              <button id="nav-enhancements" class="nav-item" onclick="page:enhancements"><span class="nav-marker"></span><span class="nav-label">Visual Enhancements</span></button>
+              <button id="nav-controls" class="nav-item" onclick="page:controls"><span class="nav-marker"></span><span class="nav-label">Controls Mapper</span></button>
+              <button id="nav-player" class="nav-item" onclick="page:player"><span class="nav-marker"></span><span class="nav-label">Driver Name</span></button>
+              <button id="nav-haptics" class="nav-item" disabled="disabled" onclick="page:haptics"><span class="nav-marker"></span><span class="nav-label">Haptics<span class="nav-note">COMING SOON</span></span></button>
+            </div>
+            <div class="nav-spacer"></div>
+            <div class="nav-footer">
+              <button class="nav-back" onclick="back">Back</button>
+              <div class="nav-hints">
+                <span class="guide-item"><span class="guide-key">A / Enter</span> Select</span>
+                <span class="guide-item"><span class="guide-key">B / Esc</span> Back</span>
+                <span class="guide-item"><span class="guide-key">D-Pad / Stick</span> Navigate</span>
+              </div>
+              <div id="version" class="nav-version">Loading version...</div>
+            </div>
+          </div>
+          <div id="content"></div>
+        </div>
+      </div>
+    </div>
+  </body>
+</template>

--- a/src/ui/lambo_ui.cpp
+++ b/src/ui/lambo_ui.cpp
@@ -144,6 +144,7 @@ struct UiState {
     void restore_focus(lambo::ui::Page page);
     void set_input_mode(InputMode mode);
     void set_text(const char* id, const std::string& value);
+    void set_toggle(const char* id, bool on);
     void set_input_value(const char* id, const std::string& value);
     std::string input_value(const char* id);
     void refresh_player_values();
@@ -152,8 +153,12 @@ struct UiState {
     void refresh_controls_values();
     void load_page(lambo::ui::Page page, bool push_history);
     void show_page(lambo::ui::Page page);
+    void navigate_settings(lambo::ui::Page page);
     void hide_pages();
     void back();
+    void focus_settings_content();
+    bool adjust_focused_setting(bool forward);
+    bool activate_focused_setting();
     void process_key_down(int key, bool repeat);
     void process_navigation_events(const std::vector<lambo::ui::NavigationEvent>& events);
     void process_queued_events();
@@ -216,6 +221,41 @@ void UiState::restore_focus(lambo::ui::Page page) {
         focus = document->GetElementById(saved->second);
     }
     if (focus == nullptr) focus = document->GetElementById("autofocus");
+    if (focus == nullptr) {
+        const char* nav_id = nullptr;
+        switch (page) {
+            case lambo::ui::Page::Settings: nav_id = "nav-settings"; break;
+            case lambo::ui::Page::Graphics: nav_id = "nav-graphics"; break;
+            case lambo::ui::Page::Enhancements: nav_id = "nav-enhancements"; break;
+            case lambo::ui::Page::Controls: nav_id = "nav-controls"; break;
+            case lambo::ui::Page::Player: nav_id = "nav-player"; break;
+            default: break;
+        }
+        if (nav_id != nullptr) focus = document->GetElementById(nav_id);
+    }
+    if (focus != nullptr) focus->Focus();
+}
+
+void UiState::focus_settings_content() {
+    if (document == nullptr || !current_page.has_value()) return;
+
+    Rml::Element* focus = nullptr;
+    switch (*current_page) {
+        case lambo::ui::Page::Graphics:
+            focus = document->GetElementById("setting-res");
+            break;
+        case lambo::ui::Page::Enhancements:
+            focus = document->GetElementById("toggle-fog");
+            break;
+        case lambo::ui::Page::Controls:
+            focus = document->QuerySelector(".mapper-slot-btn");
+            break;
+        case lambo::ui::Page::Player:
+            focus = document->GetElementById("player-name-input");
+            break;
+        default:
+            break;
+    }
     if (focus != nullptr) focus->Focus();
 }
 
@@ -234,6 +274,13 @@ void UiState::set_text(const char* id, const std::string& value) {
     if (document == nullptr) return;
     if (Rml::Element* element = document->GetElementById(id)) {
         element->SetInnerRML(value);
+    }
+}
+
+void UiState::set_toggle(const char* id, bool on) {
+    if (document == nullptr) return;
+    if (Rml::Element* element = document->GetElementById(id)) {
+        element->SetClass("on", on);
     }
 }
 
@@ -261,6 +308,7 @@ void UiState::refresh_player_values() {
     set_input_value("player-name-input", saved);
     set_text("player-name-status", player_status);
     set_text("launcher-driver-name", saved.empty() ? "(ROM default)" : saved);
+    set_text("overview-driver", saved.empty() ? "(ROM default)" : saved);
 }
 
 // Status-only update: unlike refresh_player_values it leaves the typed input
@@ -281,6 +329,14 @@ void UiState::refresh_document_values() {
     set_text("graphics-msaa", values.msaa);
     set_text("graphics-hpfb", values.framebuffer_precision);
     set_text("graphics-api", values.graphics_api);
+    set_text("graphics-resolution-track", values.resolution_track);
+    set_text("graphics-supersampling-track", values.supersampling_track);
+    set_text("graphics-aspect-track", values.aspect_track);
+    set_text("graphics-hud-track", values.hud_track);
+    set_text("graphics-refresh-track", values.refresh_track);
+    set_text("graphics-msaa-track", values.msaa_track);
+    set_text("graphics-hpfb-track", values.framebuffer_precision_track);
+    set_text("graphics-api-track", values.graphics_api_track);
     set_text("enhancement-fog", values.widescreen_fog);
     set_text("enhancement-sky", values.widescreen_sky);
     set_text("enhancement-lod", values.lod_removal);
@@ -289,10 +345,26 @@ void UiState::refresh_document_values() {
     set_text("enhancement-camdist", values.camera_distance);
     set_text("enhancement-camheight", values.camera_height);
     set_text("enhancement-fov", values.camera_fov);
+    set_text("enhancement-distance-track", values.draw_distance_track);
+    set_text("enhancement-fog-density-track", values.fog_density_track);
+    set_text("enhancement-camdist-track", values.camera_distance_track);
+    set_text("enhancement-camheight-track", values.camera_height_track);
+    set_text("enhancement-fov-track", values.camera_fov_track);
     for (size_t circuit = 0; circuit < values.circuit_visibility.size(); ++circuit) {
         const std::string id = "enhancement-circuit-" + std::to_string(circuit + 1);
         set_text(id.c_str(), values.circuit_visibility[circuit]);
     }
+    set_toggle("switch-fog", values.widescreen_fog == "Enabled");
+    set_toggle("switch-sky", values.widescreen_sky == "Enabled");
+    set_toggle("switch-lod", values.lod_removal == "Enabled");
+    for (size_t circuit = 0; circuit < values.circuit_visibility.size(); ++circuit) {
+        const std::string id = "switch-circuit-" + std::to_string(circuit + 1);
+        set_toggle(id.c_str(), values.circuit_visibility[circuit] == "Enabled");
+    }
+    set_text("overview-graphics",
+             values.resolution + " | " + values.aspect_ratio + " | " + values.msaa + " AA");
+    set_text("overview-enhancements",
+             values.draw_distance + " draw | " + values.fog_density + " fog");
     refresh_player_values();
     refresh_controls_values();
 }
@@ -364,6 +436,7 @@ void UiState::load_page(lambo::ui::Page page, bool push_history) {
     if (push_history) pages.push_back(page);
     refresh_document_values();
     restore_focus(page);
+    focus_settings_content();
     set_input_mode(input_mode);
     g_visible.store(true, std::memory_order_release);
     g_capture.store(true, std::memory_order_release);
@@ -372,6 +445,25 @@ void UiState::load_page(lambo::ui::Page page, bool push_history) {
 
 void UiState::show_page(lambo::ui::Page page) {
     load_page(page, true);
+}
+
+// The sidebar replaces content in place: Back always returns to the Settings
+// hub rather than replaying every category the user visited. Launcher shortcuts
+// (reached from Home) keep Home as their single parent instead.
+void UiState::navigate_settings(lambo::ui::Page page) {
+    const bool from_home = current_page == lambo::ui::Page::Home;
+    std::vector<lambo::ui::Page> stack;
+    if (!pages.empty() && pages.front() == lambo::ui::Page::Home) {
+        stack.push_back(lambo::ui::Page::Home);
+    }
+    if (from_home) {
+        stack.push_back(page);
+    } else {
+        stack.push_back(lambo::ui::Page::Settings);
+        if (page != lambo::ui::Page::Settings) stack.push_back(page);
+    }
+    pages = std::move(stack);
+    load_page(page, false);
 }
 
 void UiState::hide_pages() {
@@ -424,17 +516,17 @@ void process_action(const std::string& action, const std::string& parameter) {
         if (g_state != nullptr) g_state->show_page(lambo::ui::Page::Settings);
     } else if (action == "page") {
         if (g_state == nullptr) return;
-        if (parameter == "settings") g_state->show_page(lambo::ui::Page::Settings);
-        else if (parameter == "graphics") g_state->show_page(lambo::ui::Page::Graphics);
-        else if (parameter == "enhancements") g_state->show_page(lambo::ui::Page::Enhancements);
-        else if (parameter == "controls") g_state->show_page(lambo::ui::Page::Controls);
-        else if (parameter == "haptics") g_state->show_page(lambo::ui::Page::Haptics);
-        else if (parameter == "player") g_state->show_page(lambo::ui::Page::Player);
+        if (parameter == "settings") g_state->navigate_settings(lambo::ui::Page::Settings);
+        else if (parameter == "graphics") g_state->navigate_settings(lambo::ui::Page::Graphics);
+        else if (parameter == "enhancements") g_state->navigate_settings(lambo::ui::Page::Enhancements);
+        else if (parameter == "controls") g_state->navigate_settings(lambo::ui::Page::Controls);
+        else if (parameter == "haptics") g_state->navigate_settings(lambo::ui::Page::Haptics);
+        else if (parameter == "player") g_state->navigate_settings(lambo::ui::Page::Player);
     } else if (action == "back") {
         if (g_state != nullptr) g_state->back();
     } else if (action == "setting") {
-        const auto setting = lambo::ui::setting_action_from_name(parameter);
-        if (setting.has_value() && lambo::ui::apply_setting_action(*setting) && g_state != nullptr) {
+        const auto request = lambo::ui::setting_request_from_name(parameter);
+        if (request.has_value() && lambo::ui::apply_setting_request(*request) && g_state != nullptr) {
             g_state->refresh_document_values();
         }
     } else if (action == "control") {
@@ -460,6 +552,41 @@ void process_action(const std::string& action, const std::string& parameter) {
             g_state->refresh_document_values();
         }
     }
+}
+
+// Settings rows carry their binding in their element id so a focused row can be
+// adjusted with the D-Pad/stick without a second focus stop per value. Naming:
+// "setting-res" -> res:next/:prev (stepper), "toggle-fog" -> fog:toggle (switch).
+bool UiState::adjust_focused_setting(bool forward) {
+    if (context == nullptr) return false;
+    Rml::Element* focused = context->GetFocusElement();
+    if (focused == nullptr) return false;
+    const std::string id = std::string(focused->GetId().c_str());
+    if (id.rfind("setting-", 0) != 0) return false;
+    std::string name = id.substr(8);
+    if (name.rfind("circuit-", 0) == 0) name.replace(7, 1, ":");
+    process_action("setting", name + (forward ? ":next" : ":prev"));
+    return true;
+}
+
+bool UiState::activate_focused_setting() {
+    if (context == nullptr) return false;
+    Rml::Element* focused = context->GetFocusElement();
+    if (focused == nullptr) return false;
+    const std::string id = std::string(focused->GetId().c_str());
+    if (id.rfind("setting-", 0) == 0) {
+        std::string name = id.substr(8);
+        if (name.rfind("circuit-", 0) == 0) name.replace(7, 1, ":");
+        process_action("setting", name + ":next");
+        return true;
+    }
+    if (id.rfind("toggle-", 0) == 0) {
+        std::string name = id.substr(7);
+        if (name.rfind("circuit-", 0) == 0) name.replace(7, 1, ":");
+        process_action("setting", name + ":toggle");
+        return true;
+    }
+    return false;
 }
 
 void install_event_handlers(UiState& state) {
@@ -567,6 +694,11 @@ void UiState::process_key_down(int key, bool repeat) {
         if (!repeat) back();
         return;
     }
+    if ((key == SDLK_RETURN || key == SDLK_KP_ENTER) && !repeat && activate_focused_setting()) {
+        return;
+    }
+    if (key == SDLK_LEFT && adjust_focused_setting(false)) return;
+    if (key == SDLK_RIGHT && adjust_focused_setting(true)) return;
     context->ProcessKeyDown(RmlSDL::ConvertKey(key), RmlSDL::GetKeyModifierState());
 }
 
@@ -584,6 +716,11 @@ void UiState::process_navigation_events(
         if (event.key == NavigationKey::Back) {
             if (event.type == NavigationEventType::Press) back();
             continue;
+        }
+        if (event.type == NavigationEventType::Press) {
+            if (event.key == NavigationKey::Activate && activate_focused_setting()) continue;
+            if (event.key == NavigationKey::Left && adjust_focused_setting(false)) continue;
+            if (event.key == NavigationKey::Right && adjust_focused_setting(true)) continue;
         }
         const int key = sdl_key_from_navigation(event.key);
         if (key == SDLK_UNKNOWN) continue;
@@ -674,6 +811,16 @@ void draw_hook(RT64::RenderCommandList* command_list,
         }
         if (requested == static_cast<int>(lambo::ui::Page::Player) &&
             g_requested_player_route.exchange(false, std::memory_order_acq_rel)) {
+            if (g_state->entry_point == lambo::ui::EntryPoint::Startup)
+                g_state->pages = {lambo::ui::Page::Home, lambo::ui::Page::Settings};
+            else
+                g_state->pages = {lambo::ui::Page::Settings};
+        }
+        // Native-menu shortcuts into a settings category should still let the
+        // sidebar's Back button return to the hub (or the launcher).
+        if (requested == static_cast<int>(lambo::ui::Page::Graphics) ||
+            requested == static_cast<int>(lambo::ui::Page::Enhancements) ||
+            requested == static_cast<int>(lambo::ui::Page::Haptics)) {
             if (g_state->entry_point == lambo::ui::EntryPoint::Startup)
                 g_state->pages = {lambo::ui::Page::Home, lambo::ui::Page::Settings};
             else

--- a/src/ui/lambo_ui.cpp
+++ b/src/ui/lambo_ui.cpp
@@ -56,6 +56,22 @@ struct PageDescriptor {
     const char* title;
 };
 
+std::optional<std::string> setting_action_from_element_id(std::string_view id) {
+    constexpr std::string_view setting_prefix = "setting-";
+    constexpr std::string_view toggle_prefix = "toggle-";
+    constexpr std::string_view circuit_prefix = "circuit-";
+
+    const bool is_toggle = id.starts_with(toggle_prefix);
+    const auto prefix = is_toggle ? toggle_prefix : setting_prefix;
+    if (!id.starts_with(prefix)) return std::nullopt;
+
+    std::string name{id.substr(prefix.size())};
+    if (name.starts_with(circuit_prefix))
+        name.replace(circuit_prefix.size() - 1, 1, ":");
+    if (is_toggle && !name.starts_with("circuit:")) name += ":toggle";
+    return name;
+}
+
 constexpr std::array page_descriptors{
     PageDescriptor{"launcher.rml", "Home"},
     PageDescriptor{"settings.rml", "Settings"},
@@ -151,7 +167,8 @@ struct UiState {
     void show_player_status();
     void refresh_document_values();
     void refresh_controls_values();
-    void load_page(lambo::ui::Page page, bool push_history);
+    void refresh_settings_navigation();
+    void load_page(lambo::ui::Page page, bool push_history, bool focus_content);
     void show_page(lambo::ui::Page page);
     void navigate_settings(lambo::ui::Page page);
     void hide_pages();
@@ -337,9 +354,9 @@ void UiState::refresh_document_values() {
     set_text("graphics-msaa-track", values.msaa_track);
     set_text("graphics-hpfb-track", values.framebuffer_precision_track);
     set_text("graphics-api-track", values.graphics_api_track);
-    set_text("enhancement-fog", values.widescreen_fog);
-    set_text("enhancement-sky", values.widescreen_sky);
-    set_text("enhancement-lod", values.lod_removal);
+    set_text("enhancement-fog", values.widescreen_fog_enabled ? "Enabled" : "Disabled");
+    set_text("enhancement-sky", values.widescreen_sky_enabled ? "Enabled" : "Disabled");
+    set_text("enhancement-lod", values.lod_removal_enabled ? "Enabled" : "Disabled");
     set_text("enhancement-distance", values.draw_distance);
     set_text("enhancement-fog-density", values.fog_density);
     set_text("enhancement-camdist", values.camera_distance);
@@ -352,14 +369,14 @@ void UiState::refresh_document_values() {
     set_text("enhancement-fov-track", values.camera_fov_track);
     for (size_t circuit = 0; circuit < values.circuit_visibility.size(); ++circuit) {
         const std::string id = "enhancement-circuit-" + std::to_string(circuit + 1);
-        set_text(id.c_str(), values.circuit_visibility[circuit]);
+        set_text(id.c_str(), values.circuit_visibility[circuit] ? "Enabled" : "Disabled");
     }
-    set_toggle("switch-fog", values.widescreen_fog == "Enabled");
-    set_toggle("switch-sky", values.widescreen_sky == "Enabled");
-    set_toggle("switch-lod", values.lod_removal == "Enabled");
+    set_toggle("switch-fog", values.widescreen_fog_enabled);
+    set_toggle("switch-sky", values.widescreen_sky_enabled);
+    set_toggle("switch-lod", values.lod_removal_enabled);
     for (size_t circuit = 0; circuit < values.circuit_visibility.size(); ++circuit) {
         const std::string id = "switch-circuit-" + std::to_string(circuit + 1);
-        set_toggle(id.c_str(), values.circuit_visibility[circuit] == "Enabled");
+        set_toggle(id.c_str(), values.circuit_visibility[circuit]);
     }
     set_text("overview-graphics",
              values.resolution + " | " + values.aspect_ratio + " | " + values.msaa + " AA");
@@ -406,7 +423,7 @@ void UiState::refresh_controls_values() {
     }
 }
 
-void UiState::load_page(lambo::ui::Page page, bool push_history) {
+void UiState::load_page(lambo::ui::Page page, bool push_history, bool focus_content) {
     if (context == nullptr) return;
     remember_focus();
     if (current_page == lambo::ui::Page::Controls)
@@ -434,17 +451,38 @@ void UiState::load_page(lambo::ui::Page page, bool push_history) {
         controls_sample_revision = ~std::uint64_t{};
     }
     if (push_history) pages.push_back(page);
+    refresh_settings_navigation();
     refresh_document_values();
     restore_focus(page);
-    focus_settings_content();
+    if (focus_content) focus_settings_content();
     set_input_mode(input_mode);
     g_visible.store(true, std::memory_order_release);
     g_capture.store(true, std::memory_order_release);
     LAMBO_LOG_INFO("ui", "opened %s page\n", descriptor.title);
 }
 
+void UiState::refresh_settings_navigation() {
+    if (document == nullptr || !current_page.has_value()) return;
+    struct SidebarEntry {
+        const char* id;
+        lambo::ui::Page page;
+    };
+    constexpr std::array entries{
+        SidebarEntry{"nav-settings", lambo::ui::Page::Settings},
+        SidebarEntry{"nav-graphics", lambo::ui::Page::Graphics},
+        SidebarEntry{"nav-enhancements", lambo::ui::Page::Enhancements},
+        SidebarEntry{"nav-controls", lambo::ui::Page::Controls},
+        SidebarEntry{"nav-player", lambo::ui::Page::Player},
+        SidebarEntry{"nav-haptics", lambo::ui::Page::Haptics},
+    };
+    for (const auto& entry : entries) {
+        if (Rml::Element* element = document->GetElementById(entry.id))
+            element->SetClass("active", entry.page == *current_page);
+    }
+}
+
 void UiState::show_page(lambo::ui::Page page) {
-    load_page(page, true);
+    load_page(page, true, page != lambo::ui::Page::Settings);
 }
 
 // The sidebar replaces content in place: Back always returns to the Settings
@@ -463,7 +501,7 @@ void UiState::navigate_settings(lambo::ui::Page page) {
         if (page != lambo::ui::Page::Settings) stack.push_back(page);
     }
     pages = std::move(stack);
-    load_page(page, false);
+    load_page(page, false, page != lambo::ui::Page::Settings);
 }
 
 void UiState::hide_pages() {
@@ -492,7 +530,7 @@ void UiState::back() {
     if (pages.empty()) return;
     if (pages.size() > 1) {
         pages.pop_back();
-        load_page(pages.back(), false);
+        load_page(pages.back(), false, false);
         return;
     }
     if (entry_point == lambo::ui::EntryPoint::InGameOverlay) hide_pages();
@@ -562,10 +600,10 @@ bool UiState::adjust_focused_setting(bool forward) {
     Rml::Element* focused = context->GetFocusElement();
     if (focused == nullptr) return false;
     const std::string id = std::string(focused->GetId().c_str());
-    if (id.rfind("setting-", 0) != 0) return false;
-    std::string name = id.substr(8);
-    if (name.rfind("circuit-", 0) == 0) name.replace(7, 1, ":");
-    process_action("setting", name + (forward ? ":next" : ":prev"));
+    if (!id.starts_with("setting-")) return false;
+    const auto name = setting_action_from_element_id(id);
+    if (!name.has_value()) return false;
+    process_action("setting", *name + (forward ? ":next" : ":prev"));
     return true;
 }
 
@@ -574,16 +612,8 @@ bool UiState::activate_focused_setting() {
     Rml::Element* focused = context->GetFocusElement();
     if (focused == nullptr) return false;
     const std::string id = std::string(focused->GetId().c_str());
-    if (id.rfind("setting-", 0) == 0) {
-        std::string name = id.substr(8);
-        if (name.rfind("circuit-", 0) == 0) name.replace(7, 1, ":");
-        process_action("setting", name + ":next");
-        return true;
-    }
-    if (id.rfind("toggle-", 0) == 0) {
-        std::string name = id.substr(7);
-        if (name.rfind("circuit-", 0) == 0) name.replace(7, 1, ":");
-        process_action("setting", name + ":toggle");
+    if (const auto name = setting_action_from_element_id(id); name.has_value()) {
+        process_action("setting", *name);
         return true;
     }
     return false;

--- a/src/ui/lambo_ui.cpp
+++ b/src/ui/lambo_ui.cpp
@@ -56,7 +56,26 @@ struct PageDescriptor {
     const char* title;
 };
 
-std::optional<std::string> setting_action_from_element_id(std::string_view id) {
+struct SettingsSidebarEntry {
+    const char* id;
+    lambo::ui::Page page;
+};
+
+constexpr std::array settings_sidebar_entries{
+    SettingsSidebarEntry{"nav-settings", lambo::ui::Page::Settings},
+    SettingsSidebarEntry{"nav-graphics", lambo::ui::Page::Graphics},
+    SettingsSidebarEntry{"nav-enhancements", lambo::ui::Page::Enhancements},
+    SettingsSidebarEntry{"nav-controls", lambo::ui::Page::Controls},
+    SettingsSidebarEntry{"nav-player", lambo::ui::Page::Player},
+    SettingsSidebarEntry{"nav-haptics", lambo::ui::Page::Haptics},
+};
+
+struct FocusedSetting {
+    std::string name;
+    bool toggle;
+};
+
+std::optional<FocusedSetting> focused_setting_from_element_id(std::string_view id) {
     constexpr std::string_view setting_prefix = "setting-";
     constexpr std::string_view toggle_prefix = "toggle-";
     constexpr std::string_view circuit_prefix = "circuit-";
@@ -67,9 +86,8 @@ std::optional<std::string> setting_action_from_element_id(std::string_view id) {
 
     std::string name{id.substr(prefix.size())};
     if (name.starts_with(circuit_prefix))
-        name.replace(circuit_prefix.size() - 1, 1, ":");
-    if (is_toggle && !name.starts_with("circuit:")) name += ":toggle";
-    return name;
+        name = "circuit:" + std::string{name.substr(circuit_prefix.size())};
+    return FocusedSetting{std::move(name), is_toggle};
 }
 
 constexpr std::array page_descriptors{
@@ -168,6 +186,7 @@ struct UiState {
     void refresh_document_values();
     void refresh_controls_values();
     void refresh_settings_navigation();
+    std::optional<std::string> focused_element_id();
     void load_page(lambo::ui::Page page, bool push_history, bool focus_content);
     void show_page(lambo::ui::Page page);
     void navigate_settings(lambo::ui::Page page);
@@ -201,8 +220,6 @@ std::atomic<bool> g_capture{false};
 std::atomic<int> g_requested_page{-1};
 std::atomic<int> g_requested_entry_point{static_cast<int>(lambo::ui::EntryPoint::Startup)};
 std::atomic<bool> g_requested_back{false};
-std::atomic<bool> g_requested_controls_route{false};
-std::atomic<bool> g_requested_player_route{false};
 std::atomic<lambo::StartupController*> g_startup_controller{nullptr};
 moodycamel::ConcurrentQueue<QueuedEvent> g_event_queue;
 
@@ -239,18 +256,21 @@ void UiState::restore_focus(lambo::ui::Page page) {
     }
     if (focus == nullptr) focus = document->GetElementById("autofocus");
     if (focus == nullptr) {
-        const char* nav_id = nullptr;
-        switch (page) {
-            case lambo::ui::Page::Settings: nav_id = "nav-settings"; break;
-            case lambo::ui::Page::Graphics: nav_id = "nav-graphics"; break;
-            case lambo::ui::Page::Enhancements: nav_id = "nav-enhancements"; break;
-            case lambo::ui::Page::Controls: nav_id = "nav-controls"; break;
-            case lambo::ui::Page::Player: nav_id = "nav-player"; break;
-            default: break;
+        for (const auto& entry : settings_sidebar_entries) {
+            if (entry.page == page) {
+                focus = document->GetElementById(entry.id);
+                break;
+            }
         }
-        if (nav_id != nullptr) focus = document->GetElementById(nav_id);
     }
     if (focus != nullptr) focus->Focus();
+}
+
+std::optional<std::string> UiState::focused_element_id() {
+    if (context == nullptr) return std::nullopt;
+    Rml::Element* focused = context->GetFocusElement();
+    if (focused == nullptr || focused->GetId().empty()) return std::nullopt;
+    return std::string(focused->GetId().c_str());
 }
 
 void UiState::focus_settings_content() {
@@ -453,8 +473,11 @@ void UiState::load_page(lambo::ui::Page page, bool push_history, bool focus_cont
     if (push_history) pages.push_back(page);
     refresh_settings_navigation();
     refresh_document_values();
+    const bool has_saved_focus = current_page.has_value() &&
+        focused_element_by_page.contains(page) &&
+        document->GetElementById(focused_element_by_page.at(page)) != nullptr;
     restore_focus(page);
-    if (focus_content) focus_settings_content();
+    if (focus_content && !has_saved_focus) focus_settings_content();
     set_input_mode(input_mode);
     g_visible.store(true, std::memory_order_release);
     g_capture.store(true, std::memory_order_release);
@@ -463,19 +486,7 @@ void UiState::load_page(lambo::ui::Page page, bool push_history, bool focus_cont
 
 void UiState::refresh_settings_navigation() {
     if (document == nullptr || !current_page.has_value()) return;
-    struct SidebarEntry {
-        const char* id;
-        lambo::ui::Page page;
-    };
-    constexpr std::array entries{
-        SidebarEntry{"nav-settings", lambo::ui::Page::Settings},
-        SidebarEntry{"nav-graphics", lambo::ui::Page::Graphics},
-        SidebarEntry{"nav-enhancements", lambo::ui::Page::Enhancements},
-        SidebarEntry{"nav-controls", lambo::ui::Page::Controls},
-        SidebarEntry{"nav-player", lambo::ui::Page::Player},
-        SidebarEntry{"nav-haptics", lambo::ui::Page::Haptics},
-    };
-    for (const auto& entry : entries) {
+    for (const auto& entry : settings_sidebar_entries) {
         if (Rml::Element* element = document->GetElementById(entry.id))
             element->SetClass("active", entry.page == *current_page);
     }
@@ -596,24 +607,29 @@ void process_action(const std::string& action, const std::string& parameter) {
 // adjusted with the D-Pad/stick without a second focus stop per value. Naming:
 // "setting-res" -> res:next/:prev (stepper), "toggle-fog" -> fog:toggle (switch).
 bool UiState::adjust_focused_setting(bool forward) {
-    if (context == nullptr) return false;
-    Rml::Element* focused = context->GetFocusElement();
-    if (focused == nullptr) return false;
-    const std::string id = std::string(focused->GetId().c_str());
-    if (!id.starts_with("setting-")) return false;
-    const auto name = setting_action_from_element_id(id);
-    if (!name.has_value()) return false;
-    process_action("setting", *name + (forward ? ":next" : ":prev"));
+    const auto id = focused_element_id();
+    if (!id.has_value() || !id->starts_with("setting-")) return false;
+    const auto setting = focused_setting_from_element_id(*id);
+    if (!setting.has_value() || setting->toggle) return false;
+    const std::string request_name = setting->name + (forward ? ":next" : ":prev");
+    if (!lambo::ui::setting_request_from_name(request_name).has_value()) return false;
+    process_action("setting", request_name);
     return true;
 }
 
 bool UiState::activate_focused_setting() {
-    if (context == nullptr) return false;
-    Rml::Element* focused = context->GetFocusElement();
-    if (focused == nullptr) return false;
-    const std::string id = std::string(focused->GetId().c_str());
-    if (const auto name = setting_action_from_element_id(id); name.has_value()) {
-        process_action("setting", *name);
+    const auto id = focused_element_id();
+    if (!id.has_value()) return false;
+    const auto setting = focused_setting_from_element_id(*id);
+    if (setting.has_value()) {
+        std::string request_name = setting->name;
+        if (setting->toggle) {
+            if (!request_name.starts_with("circuit:")) request_name += ":toggle";
+        } else {
+            request_name += ":next";
+        }
+        if (!lambo::ui::setting_request_from_name(request_name).has_value()) return false;
+        process_action("setting", request_name);
         return true;
     }
     return false;
@@ -832,25 +848,10 @@ void draw_hook(RT64::RenderCommandList* command_list,
         g_state->entry_point = static_cast<lambo::ui::EntryPoint>(
             g_requested_entry_point.load(std::memory_order_acquire));
         g_state->pages.clear();
-        if (requested == static_cast<int>(lambo::ui::Page::Controls) &&
-            g_requested_controls_route.exchange(false, std::memory_order_acq_rel)) {
-            if (g_state->entry_point == lambo::ui::EntryPoint::Startup)
-                g_state->pages = {lambo::ui::Page::Home, lambo::ui::Page::Settings};
-            else
-                g_state->pages = {lambo::ui::Page::Settings};
-        }
-        if (requested == static_cast<int>(lambo::ui::Page::Player) &&
-            g_requested_player_route.exchange(false, std::memory_order_acq_rel)) {
-            if (g_state->entry_point == lambo::ui::EntryPoint::Startup)
-                g_state->pages = {lambo::ui::Page::Home, lambo::ui::Page::Settings};
-            else
-                g_state->pages = {lambo::ui::Page::Settings};
-        }
-        // Native-menu shortcuts into a settings category should still let the
-        // sidebar's Back button return to the hub (or the launcher).
-        if (requested == static_cast<int>(lambo::ui::Page::Graphics) ||
-            requested == static_cast<int>(lambo::ui::Page::Enhancements) ||
-            requested == static_cast<int>(lambo::ui::Page::Haptics)) {
+        const bool is_settings_page =
+            requested >= static_cast<int>(lambo::ui::Page::Graphics) &&
+            requested <= static_cast<int>(lambo::ui::Page::Player);
+        if (is_settings_page) {
             if (g_state->entry_point == lambo::ui::EntryPoint::Startup)
                 g_state->pages = {lambo::ui::Page::Home, lambo::ui::Page::Settings};
             else
@@ -938,8 +939,6 @@ void open_launcher() {
     g_requested_entry_point.store(static_cast<int>(EntryPoint::Startup), std::memory_order_release);
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
-    g_requested_controls_route.store(false, std::memory_order_release);
-    g_requested_player_route.store(false, std::memory_order_release);
     g_requested_page.store(static_cast<int>(Page::Home), std::memory_order_release);
 }
 
@@ -947,8 +946,6 @@ void open_settings() {
     g_requested_entry_point.store(static_cast<int>(EntryPoint::InGameOverlay), std::memory_order_release);
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
-    g_requested_controls_route.store(false, std::memory_order_release);
-    g_requested_player_route.store(false, std::memory_order_release);
     g_requested_page.store(static_cast<int>(Page::Settings), std::memory_order_release);
 }
 
@@ -959,7 +956,6 @@ void open_controls() {
     g_requested_entry_point.store(static_cast<int>(entry), std::memory_order_release);
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
-    g_requested_controls_route.store(true, std::memory_order_release);
     g_requested_page.store(static_cast<int>(Page::Controls), std::memory_order_release);
 }
 
@@ -967,8 +963,6 @@ void open_graphics() {
     g_requested_entry_point.store(static_cast<int>(EntryPoint::Startup), std::memory_order_release);
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
-    g_requested_controls_route.store(false, std::memory_order_release);
-    g_requested_player_route.store(false, std::memory_order_release);
     g_requested_page.store(static_cast<int>(Page::Graphics), std::memory_order_release);
 }
 
@@ -976,8 +970,6 @@ void open_enhancements() {
     g_requested_entry_point.store(static_cast<int>(EntryPoint::Startup), std::memory_order_release);
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
-    g_requested_controls_route.store(false, std::memory_order_release);
-    g_requested_player_route.store(false, std::memory_order_release);
     g_requested_page.store(static_cast<int>(Page::Enhancements), std::memory_order_release);
 }
 
@@ -985,8 +977,6 @@ void open_haptics() {
     g_requested_entry_point.store(static_cast<int>(EntryPoint::Startup), std::memory_order_release);
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
-    g_requested_controls_route.store(false, std::memory_order_release);
-    g_requested_player_route.store(false, std::memory_order_release);
     g_requested_page.store(static_cast<int>(Page::Haptics), std::memory_order_release);
 }
 
@@ -1000,8 +990,6 @@ void open_player() {
     g_requested_entry_point.store(static_cast<int>(entry), std::memory_order_release);
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
-    g_requested_controls_route.store(false, std::memory_order_release);
-    g_requested_player_route.store(true, std::memory_order_release);
     g_requested_page.store(static_cast<int>(Page::Player), std::memory_order_release);
 }
 

--- a/src/ui/lambo_ui_settings.cpp
+++ b/src/ui/lambo_ui_settings.cpp
@@ -109,14 +109,18 @@ constexpr auto camera_height_options = std::array{1.0, 0.66, 0.4};
 constexpr auto fov_options = std::array{0.0, 5.0, 10.0, 15.0, 20.0};
 
 template <typename T, size_t Size>
+T step_from_index(const std::array<T, Size>& values, size_t index, bool forward) {
+    if (forward) {
+        return index + 1 == values.size() ? values.front() : values[index + 1];
+    }
+    return index == 0 ? values.back() : values[index - 1];
+}
+
+template <typename T, size_t Size>
 T step_value(T current, const std::array<T, Size>& values, bool forward) {
     const auto position = std::find(values.begin(), values.end(), current);
     if (position == values.end()) return forward ? values.front() : values.back();
-    if (forward) {
-        const auto next = std::next(position);
-        return next == values.end() ? values.front() : *next;
-    }
-    return position == values.begin() ? values.back() : *std::prev(position);
+    return step_from_index(values, static_cast<size_t>(position - values.begin()), forward);
 }
 
 template <size_t Size>
@@ -125,17 +129,11 @@ double step_number(double current, const std::array<double, Size>& values, bool 
         return std::abs(value - current) < 0.001;
     });
     if (position == values.end()) return forward ? values.front() : values.back();
-    if (forward) {
-        const auto next = std::next(position);
-        return next == values.end() ? values.front() : *next;
-    }
-    return position == values.begin() ? values.back() : *std::prev(position);
+    return step_from_index(values, static_cast<size_t>(position - values.begin()), forward);
 }
 
-// Index of the value within an authored option list, used only for the visual
-// position track. Exact matches are the normal case; interpolate otherwise.
 template <size_t Size>
-int index_of(double current, const std::array<double, Size>& values) {
+int option_index(double current, const std::array<double, Size>& values) {
     for (size_t i = 0; i < values.size(); ++i) {
         if (std::abs(values[i] - current) < 0.001) return static_cast<int>(i);
     }
@@ -421,15 +419,15 @@ SettingsSnapshot settings_snapshot() {
     result.msaa_track = track(option_index(cfg.msaa_option, msaa_options), msaa_options.size());
     result.framebuffer_precision_track = track(option_index(cfg.hpfb_option, hpfb_options), hpfb_options.size());
     result.graphics_api_track = track(option_index(cfg.api_option, api_options), api_options.size());
-    result.draw_distance_track = track(index_of(
+    result.draw_distance_track = track(option_index(
         lambo::config::global_draw_distance(), draw_distance_options), draw_distance_options.size());
-    result.fog_density_track = track(index_of(
+    result.fog_density_track = track(option_index(
         lambo::config::global_fog_scale(), fog_density_options), fog_density_options.size());
-    result.camera_distance_track = track(index_of(
+    result.camera_distance_track = track(option_index(
         lambo::config::camera_distance_scale(), camera_distance_options), camera_distance_options.size());
-    result.camera_height_track = track(index_of(
+    result.camera_height_track = track(option_index(
         lambo::config::camera_height_scale(), camera_height_options), camera_height_options.size());
-    result.camera_fov_track = track(index_of(
+    result.camera_fov_track = track(option_index(
         lambo::config::camera_fov_add(), fov_options), fov_options.size());
     return result;
 }

--- a/src/ui/lambo_ui_settings.cpp
+++ b/src/ui/lambo_ui_settings.cpp
@@ -58,6 +58,56 @@ constexpr auto setting_bindings = std::to_array<SettingBinding>({
     {"fov:prev", SettingAction::FovNext, SettingDirection::Previous},
 });
 
+constexpr auto resolution_options = std::array{
+    ultramodern::renderer::Resolution::Auto,
+    ultramodern::renderer::Resolution::Original,
+    ultramodern::renderer::Resolution::Original2x,
+};
+constexpr auto supersampling_options = std::array{1, 2, 3, 4};
+constexpr auto aspect_options = std::array{
+    ultramodern::renderer::AspectRatio::Expand,
+    ultramodern::renderer::AspectRatio::Original,
+};
+constexpr auto hud_options = std::array{
+    ultramodern::renderer::HUDRatioMode::Clamp16x9,
+    ultramodern::renderer::HUDRatioMode::Full,
+    ultramodern::renderer::HUDRatioMode::Original,
+};
+constexpr auto refresh_rates = std::array{30, 60, 90, 120, 144, 165, 240};
+constexpr auto msaa_options = std::array{
+    ultramodern::renderer::Antialiasing::None,
+    ultramodern::renderer::Antialiasing::MSAA2X,
+    ultramodern::renderer::Antialiasing::MSAA4X,
+    ultramodern::renderer::Antialiasing::MSAA8X,
+};
+constexpr auto hpfb_options = std::array{
+    ultramodern::renderer::HighPrecisionFramebuffer::Auto,
+    ultramodern::renderer::HighPrecisionFramebuffer::On,
+    ultramodern::renderer::HighPrecisionFramebuffer::Off,
+};
+#if defined(_WIN32)
+constexpr auto api_options = std::array{
+    ultramodern::renderer::GraphicsApi::Auto,
+    ultramodern::renderer::GraphicsApi::D3D12,
+    ultramodern::renderer::GraphicsApi::Vulkan,
+};
+#elif defined(__APPLE__)
+constexpr auto api_options = std::array{
+    ultramodern::renderer::GraphicsApi::Auto,
+    ultramodern::renderer::GraphicsApi::Metal,
+};
+#else
+constexpr auto api_options = std::array{
+    ultramodern::renderer::GraphicsApi::Auto,
+    ultramodern::renderer::GraphicsApi::Vulkan,
+};
+#endif
+constexpr auto draw_distance_options = std::array{1.0, 1.5, 2.0, 3.0, 0.0};
+constexpr auto fog_density_options = std::array{0.0, 0.5, 0.75, 1.0, 1.5, 2.0};
+constexpr auto camera_distance_options = std::array{1.0, 0.8, 0.65, 0.5};
+constexpr auto camera_height_options = std::array{1.0, 0.66, 0.4};
+constexpr auto fov_options = std::array{0.0, 5.0, 10.0, 15.0, 20.0};
+
 template <typename T, size_t Size>
 T step_value(T current, const std::array<T, Size>& values, bool forward) {
     const auto position = std::find(values.begin(), values.end(), current);
@@ -92,6 +142,12 @@ int index_of(double current, const std::array<double, Size>& values) {
     size_t i = 0;
     while (i < values.size() && values[i] < current) ++i;
     return static_cast<int>(i > 0 ? i - 1 : 0);
+}
+
+template <typename T, size_t Size>
+int option_index(T current, const std::array<T, Size>& values) {
+    const auto position = std::find(values.begin(), values.end(), current);
+    return position == values.end() ? 0 : static_cast<int>(position - values.begin());
 }
 
 std::string track(int index, int count) {
@@ -201,89 +257,17 @@ std::string fov_add_name(double value) {
     return "+" + std::to_string(degrees) + " deg";
 }
 
-int resolution_index(ultramodern::renderer::Resolution value) {
-    using ultramodern::renderer::Resolution;
-    switch (value) {
-        case Resolution::Auto: return 0;
-        case Resolution::Original: return 1;
-        case Resolution::Original2x: return 2;
-        default: return 0;
-    }
-}
-
-int aspect_index(ultramodern::renderer::AspectRatio value) {
-    using ultramodern::renderer::AspectRatio;
-    switch (value) {
-        case AspectRatio::Expand: return 0;
-        case AspectRatio::Original: return 1;
-        default: return 0;
-    }
-}
-
-int hud_index(ultramodern::renderer::HUDRatioMode value) {
-    using ultramodern::renderer::HUDRatioMode;
-    switch (value) {
-        case HUDRatioMode::Clamp16x9: return 0;
-        case HUDRatioMode::Full: return 1;
-        case HUDRatioMode::Original: return 2;
-        default: return 0;
-    }
-}
-
-int msaa_index(ultramodern::renderer::Antialiasing value) {
-    using ultramodern::renderer::Antialiasing;
-    switch (value) {
-        case Antialiasing::None: return 0;
-        case Antialiasing::MSAA2X: return 1;
-        case Antialiasing::MSAA4X: return 2;
-        case Antialiasing::MSAA8X: return 3;
-        default: return 0;
-    }
-}
-
-int hpfb_index(ultramodern::renderer::HighPrecisionFramebuffer value) {
-    using ultramodern::renderer::HighPrecisionFramebuffer;
-    switch (value) {
-        case HighPrecisionFramebuffer::Auto: return 0;
-        case HighPrecisionFramebuffer::On: return 1;
-        case HighPrecisionFramebuffer::Off: return 2;
-        default: return 0;
-    }
-}
-
-int api_index(ultramodern::renderer::GraphicsApi value) {
-    using ultramodern::renderer::GraphicsApi;
-    if (value == GraphicsApi::Auto) return 0;
-#if defined(_WIN32)
-    if (value == GraphicsApi::D3D12) return 1;
-    if (value == GraphicsApi::Vulkan) return 2;
-#elif defined(__APPLE__)
-    if (value == GraphicsApi::Metal) return 1;
-#else
-    if (value == GraphicsApi::Vulkan) return 1;
-#endif
-    return 0;
-}
-
-int api_count() {
-#if defined(_WIN32)
-    return 3;
-#else
-    return 2;
-#endif
-}
-
 int refresh_index(const ultramodern::renderer::GraphicsConfig& cfg) {
     using ultramodern::renderer::RefreshRate;
     if (cfg.rr_option == RefreshRate::Original) return 0;
     if (cfg.rr_option == RefreshRate::Display) return 1;
     if (cfg.rr_option == RefreshRate::Manual) {
-        constexpr std::array rates{30, 60, 90, 120, 144, 165, 240};
         int position = 0;
-        while (position < static_cast<int>(rates.size()) && rates[position] < cfg.rr_manual_value) {
+        while (position < static_cast<int>(refresh_rates.size()) &&
+               refresh_rates[position] < cfg.rr_manual_value) {
             ++position;
         }
-        position = std::clamp(position - 1, 0, static_cast<int>(rates.size()) - 1);
+        position = std::clamp(position - 1, 0, static_cast<int>(refresh_rates.size()) - 1);
         return 2 + position;
     }
     return 0;
@@ -293,16 +277,17 @@ int refresh_index(const ultramodern::renderer::GraphicsConfig& cfg) {
 
 namespace lambo::ui {
 
-std::optional<SettingAction> setting_action_from_name(std::string_view name) {
-    for (const auto& binding : setting_bindings) {
-        if (binding.name == name) return binding.action;
-    }
-    return std::nullopt;
-}
-
 std::optional<SettingRequest> setting_request_from_name(std::string_view name) {
     for (const auto& binding : setting_bindings) {
         if (binding.name == name) return SettingRequest{binding.action, binding.direction};
+    }
+    constexpr std::string_view toggle_suffix = ":toggle";
+    if (name.size() > toggle_suffix.size() &&
+        name.substr(name.size() - toggle_suffix.size()) == toggle_suffix) {
+        const auto base_name = name.substr(0, name.size() - toggle_suffix.size());
+        for (const auto& binding : setting_bindings) {
+            if (binding.name == base_name) return SettingRequest{binding.action, binding.direction};
+        }
     }
     return std::nullopt;
 }
@@ -315,26 +300,20 @@ bool apply_setting_request(const SettingRequest& request) {
 
     switch (request.action) {
         case SettingAction::ResolutionNext:
-            cfg.res_option = step_value(cfg.res_option,
-                std::array{Resolution::Auto, Resolution::Original, Resolution::Original2x}, forward); break;
+            cfg.res_option = step_value(cfg.res_option, resolution_options, forward); break;
         case SettingAction::SupersamplingNext:
-            if (forward) cfg.ds_option = cfg.ds_option < 1 || cfg.ds_option >= 4 ? 1 : cfg.ds_option + 1;
-            else cfg.ds_option = cfg.ds_option <= 1 || cfg.ds_option > 4 ? 4 : cfg.ds_option - 1;
-            break;
+            cfg.ds_option = step_value(cfg.ds_option, supersampling_options, forward); break;
         case SettingAction::AspectNext:
-            cfg.ar_option = step_value(cfg.ar_option,
-                std::array{AspectRatio::Expand, AspectRatio::Original}, forward); break;
+            cfg.ar_option = step_value(cfg.ar_option, aspect_options, forward); break;
         case SettingAction::HudNext:
-            cfg.hr_option = step_value(cfg.hr_option,
-                std::array{HUDRatioMode::Clamp16x9, HUDRatioMode::Full, HUDRatioMode::Original}, forward); break;
+            cfg.hr_option = step_value(cfg.hr_option, hud_options, forward); break;
         case SettingAction::RefreshNext: {
-            constexpr std::array rates{30, 60, 90, 120, 144, 165, 240};
             if (cfg.rr_option == RefreshRate::Original) {
                 if (forward) {
                     cfg.rr_option = RefreshRate::Display;
                 } else {
                     cfg.rr_option = RefreshRate::Manual;
-                    cfg.rr_manual_value = rates.back();
+                    cfg.rr_manual_value = refresh_rates.back();
                 }
             } else if (cfg.rr_option == RefreshRate::Display) {
                 if (forward) {
@@ -344,44 +323,35 @@ bool apply_setting_request(const SettingRequest& request) {
                     cfg.rr_option = RefreshRate::Original;
                 }
             } else {
-                const auto position = std::find(rates.begin(), rates.end(), cfg.rr_manual_value);
-                if (position == rates.end()) {
+                const auto position = std::find(refresh_rates.begin(), refresh_rates.end(), cfg.rr_manual_value);
+                if (position == refresh_rates.end()) {
                     if (forward) {
-                        const auto next_rate = std::upper_bound(rates.begin(), rates.end(), cfg.rr_manual_value);
-                        if (next_rate == rates.end()) cfg.rr_option = RefreshRate::Original;
+                        const auto next_rate = std::upper_bound(
+                            refresh_rates.begin(), refresh_rates.end(), cfg.rr_manual_value);
+                        if (next_rate == refresh_rates.end()) cfg.rr_option = RefreshRate::Original;
                         else cfg.rr_manual_value = *next_rate;
                     } else {
-                        const auto lower = std::lower_bound(rates.begin(), rates.end(), cfg.rr_manual_value);
-                        if (lower == rates.begin()) cfg.rr_option = RefreshRate::Display;
+                        const auto lower = std::lower_bound(
+                            refresh_rates.begin(), refresh_rates.end(), cfg.rr_manual_value);
+                        if (lower == refresh_rates.begin()) cfg.rr_option = RefreshRate::Display;
                         else cfg.rr_manual_value = *std::prev(lower);
                     }
                 } else if (forward) {
-                    if (std::next(position) == rates.end()) cfg.rr_option = RefreshRate::Original;
+                    if (std::next(position) == refresh_rates.end()) cfg.rr_option = RefreshRate::Original;
                     else cfg.rr_manual_value = *std::next(position);
                 } else {
-                    if (position == rates.begin()) cfg.rr_option = RefreshRate::Display;
+                    if (position == refresh_rates.begin()) cfg.rr_option = RefreshRate::Display;
                     else cfg.rr_manual_value = *std::prev(position);
                 }
             }
             break;
         }
         case SettingAction::MsaaNext:
-            cfg.msaa_option = step_value(cfg.msaa_option, std::array{
-                Antialiasing::None, Antialiasing::MSAA2X, Antialiasing::MSAA4X, Antialiasing::MSAA8X}, forward); break;
+            cfg.msaa_option = step_value(cfg.msaa_option, msaa_options, forward); break;
         case SettingAction::HpfbNext:
-            cfg.hpfb_option = step_value(cfg.hpfb_option, std::array{
-                HighPrecisionFramebuffer::Auto, HighPrecisionFramebuffer::On, HighPrecisionFramebuffer::Off}, forward); break;
+            cfg.hpfb_option = step_value(cfg.hpfb_option, hpfb_options, forward); break;
         case SettingAction::ApiNext:
-#if defined(_WIN32)
-            cfg.api_option = step_value(cfg.api_option,
-                std::array{GraphicsApi::Auto, GraphicsApi::D3D12, GraphicsApi::Vulkan}, forward);
-#elif defined(__APPLE__)
-            cfg.api_option = step_value(cfg.api_option,
-                std::array{GraphicsApi::Auto, GraphicsApi::Metal}, forward);
-#else
-            cfg.api_option = step_value(cfg.api_option,
-                std::array{GraphicsApi::Auto, GraphicsApi::Vulkan}, forward);
-#endif
+            cfg.api_option = step_value(cfg.api_option, api_options, forward);
             apply_live = false;
             break;
         case SettingAction::FogMatchToggle:
@@ -399,27 +369,23 @@ bool apply_setting_request(const SettingRequest& request) {
         }
         case SettingAction::DrawDistanceNext:
             lambo::config::set_global_draw_distance(step_number(
-                lambo::config::global_draw_distance(), std::array{1.0, 1.5, 2.0, 3.0, 0.0}, forward)); return true;
+                lambo::config::global_draw_distance(), draw_distance_options, forward)); return true;
         case SettingAction::FogDensityNext:
             lambo::config::set_global_fog_scale(step_number(
-                lambo::config::global_fog_scale(), std::array{0.0, 0.5, 0.75, 1.0, 1.5, 2.0}, forward)); return true;
+                lambo::config::global_fog_scale(), fog_density_options, forward)); return true;
         case SettingAction::CameraDistanceNext:
             lambo::config::set_camera_distance_scale(step_number(
-                lambo::config::camera_distance_scale(), std::array{1.0, 0.8, 0.65, 0.5}, forward)); return true;
+                lambo::config::camera_distance_scale(), camera_distance_options, forward)); return true;
         case SettingAction::CameraHeightNext:
             lambo::config::set_camera_height_scale(step_number(
-                lambo::config::camera_height_scale(), std::array{1.0, 0.66, 0.4}, forward)); return true;
+                lambo::config::camera_height_scale(), camera_height_options, forward)); return true;
         case SettingAction::FovNext:
             lambo::config::set_camera_fov_add(step_number(
-                lambo::config::camera_fov_add(), std::array{0.0, 5.0, 10.0, 15.0, 20.0}, forward)); return true;
+                lambo::config::camera_fov_add(), fov_options, forward)); return true;
     }
 
     lambo::config::apply_graphics(cfg, apply_live);
     return true;
-}
-
-bool apply_setting_action(SettingAction action) {
-    return apply_setting_request(SettingRequest{action, SettingDirection::Next});
 }
 
 SettingsSnapshot settings_snapshot() {
@@ -433,9 +399,9 @@ SettingsSnapshot settings_snapshot() {
         msaa_name(cfg.msaa_option),
         hpfb_name(cfg.hpfb_option),
         api_name(cfg.api_option),
-        lambo::config::widescreen_fog_match() ? "Enabled" : "Disabled",
-        lambo::config::widescreen_sky_match() ? "Enabled" : "Disabled",
-        lambo::config::no_lod() ? "Enabled" : "Disabled",
+        lambo::config::widescreen_fog_match(),
+        lambo::config::widescreen_sky_match(),
+        lambo::config::no_lod(),
         multiplier_name(lambo::config::global_draw_distance()),
         {},
         camera_scale_name(lambo::config::camera_distance_scale()),
@@ -445,26 +411,26 @@ SettingsSnapshot settings_snapshot() {
     const int fog_percent = static_cast<int>(std::lround(lambo::config::global_fog_scale() * 100.0));
     result.fog_density = fog_percent == 0 ? "Off" : std::to_string(fog_percent) + "%";
     for (int circuit = 0; circuit < 6; ++circuit) {
-        result.circuit_visibility[circuit] = lambo::config::no_lod_circuit(circuit) ? "Enabled" : "Disabled";
+        result.circuit_visibility[circuit] = lambo::config::no_lod_circuit(circuit);
     }
-    result.resolution_track = track(resolution_index(cfg.res_option), 3);
-    result.supersampling_track = track(std::clamp(static_cast<int>(cfg.ds_option) - 1, 0, 3), 4);
-    result.aspect_track = track(aspect_index(cfg.ar_option), 2);
-    result.hud_track = track(hud_index(cfg.hr_option), 3);
-    result.refresh_track = track(refresh_index(cfg), 9);
-    result.msaa_track = track(msaa_index(cfg.msaa_option), 4);
-    result.framebuffer_precision_track = track(hpfb_index(cfg.hpfb_option), 3);
-    result.graphics_api_track = track(api_index(cfg.api_option), api_count());
+    result.resolution_track = track(option_index(cfg.res_option, resolution_options), resolution_options.size());
+    result.supersampling_track = track(option_index(cfg.ds_option, supersampling_options), supersampling_options.size());
+    result.aspect_track = track(option_index(cfg.ar_option, aspect_options), aspect_options.size());
+    result.hud_track = track(option_index(cfg.hr_option, hud_options), hud_options.size());
+    result.refresh_track = track(refresh_index(cfg), 2 + refresh_rates.size());
+    result.msaa_track = track(option_index(cfg.msaa_option, msaa_options), msaa_options.size());
+    result.framebuffer_precision_track = track(option_index(cfg.hpfb_option, hpfb_options), hpfb_options.size());
+    result.graphics_api_track = track(option_index(cfg.api_option, api_options), api_options.size());
     result.draw_distance_track = track(index_of(
-        lambo::config::global_draw_distance(), std::array{1.0, 1.5, 2.0, 3.0, 0.0}), 5);
+        lambo::config::global_draw_distance(), draw_distance_options), draw_distance_options.size());
     result.fog_density_track = track(index_of(
-        lambo::config::global_fog_scale(), std::array{0.0, 0.5, 0.75, 1.0, 1.5, 2.0}), 6);
+        lambo::config::global_fog_scale(), fog_density_options), fog_density_options.size());
     result.camera_distance_track = track(index_of(
-        lambo::config::camera_distance_scale(), std::array{1.0, 0.8, 0.65, 0.5}), 4);
+        lambo::config::camera_distance_scale(), camera_distance_options), camera_distance_options.size());
     result.camera_height_track = track(index_of(
-        lambo::config::camera_height_scale(), std::array{1.0, 0.66, 0.4}), 3);
+        lambo::config::camera_height_scale(), camera_height_options), camera_height_options.size());
     result.camera_fov_track = track(index_of(
-        lambo::config::camera_fov_add(), std::array{0.0, 5.0, 10.0, 15.0, 20.0}), 5);
+        lambo::config::camera_fov_add(), fov_options), fov_options.size());
     return result;
 }
 

--- a/src/ui/lambo_ui_settings.cpp
+++ b/src/ui/lambo_ui_settings.cpp
@@ -12,46 +12,95 @@
 namespace {
 
 using lambo::ui::SettingAction;
+using lambo::ui::SettingDirection;
 
-constexpr auto setting_bindings = std::to_array<std::pair<std::string_view, SettingAction>>({
-    {"res:next", SettingAction::ResolutionNext},
-    {"ss:next", SettingAction::SupersamplingNext},
-    {"aspect:next", SettingAction::AspectNext},
-    {"hud:next", SettingAction::HudNext},
-    {"rate:next", SettingAction::RefreshNext},
-    {"msaa:next", SettingAction::MsaaNext},
-    {"hpfb:next", SettingAction::HpfbNext},
-    {"api:next", SettingAction::ApiNext},
-    {"fog:toggle", SettingAction::FogMatchToggle},
-    {"sky:toggle", SettingAction::SkyMatchToggle},
-    {"lod:toggle", SettingAction::NoLodToggle},
-    {"circuit:1", SettingAction::Circuit1Toggle},
-    {"circuit:2", SettingAction::Circuit2Toggle},
-    {"circuit:3", SettingAction::Circuit3Toggle},
-    {"circuit:4", SettingAction::Circuit4Toggle},
-    {"circuit:5", SettingAction::Circuit5Toggle},
-    {"circuit:6", SettingAction::Circuit6Toggle},
-    {"distance:next", SettingAction::DrawDistanceNext},
-    {"fogdensity:next", SettingAction::FogDensityNext},
-    {"camdist:next", SettingAction::CameraDistanceNext},
-    {"camheight:next", SettingAction::CameraHeightNext},
-    {"fov:next", SettingAction::FovNext},
+struct SettingBinding {
+    std::string_view name;
+    SettingAction action;
+    SettingDirection direction;
+};
+
+constexpr auto setting_bindings = std::to_array<SettingBinding>({
+    {"res:next", SettingAction::ResolutionNext, SettingDirection::Next},
+    {"res:prev", SettingAction::ResolutionNext, SettingDirection::Previous},
+    {"ss:next", SettingAction::SupersamplingNext, SettingDirection::Next},
+    {"ss:prev", SettingAction::SupersamplingNext, SettingDirection::Previous},
+    {"aspect:next", SettingAction::AspectNext, SettingDirection::Next},
+    {"aspect:prev", SettingAction::AspectNext, SettingDirection::Previous},
+    {"hud:next", SettingAction::HudNext, SettingDirection::Next},
+    {"hud:prev", SettingAction::HudNext, SettingDirection::Previous},
+    {"rate:next", SettingAction::RefreshNext, SettingDirection::Next},
+    {"rate:prev", SettingAction::RefreshNext, SettingDirection::Previous},
+    {"msaa:next", SettingAction::MsaaNext, SettingDirection::Next},
+    {"msaa:prev", SettingAction::MsaaNext, SettingDirection::Previous},
+    {"hpfb:next", SettingAction::HpfbNext, SettingDirection::Next},
+    {"hpfb:prev", SettingAction::HpfbNext, SettingDirection::Previous},
+    {"api:next", SettingAction::ApiNext, SettingDirection::Next},
+    {"api:prev", SettingAction::ApiNext, SettingDirection::Previous},
+    {"fog:toggle", SettingAction::FogMatchToggle, SettingDirection::Next},
+    {"sky:toggle", SettingAction::SkyMatchToggle, SettingDirection::Next},
+    {"lod:toggle", SettingAction::NoLodToggle, SettingDirection::Next},
+    {"circuit:1", SettingAction::Circuit1Toggle, SettingDirection::Next},
+    {"circuit:2", SettingAction::Circuit2Toggle, SettingDirection::Next},
+    {"circuit:3", SettingAction::Circuit3Toggle, SettingDirection::Next},
+    {"circuit:4", SettingAction::Circuit4Toggle, SettingDirection::Next},
+    {"circuit:5", SettingAction::Circuit5Toggle, SettingDirection::Next},
+    {"circuit:6", SettingAction::Circuit6Toggle, SettingDirection::Next},
+    {"distance:next", SettingAction::DrawDistanceNext, SettingDirection::Next},
+    {"distance:prev", SettingAction::DrawDistanceNext, SettingDirection::Previous},
+    {"fogdensity:next", SettingAction::FogDensityNext, SettingDirection::Next},
+    {"fogdensity:prev", SettingAction::FogDensityNext, SettingDirection::Previous},
+    {"camdist:next", SettingAction::CameraDistanceNext, SettingDirection::Next},
+    {"camdist:prev", SettingAction::CameraDistanceNext, SettingDirection::Previous},
+    {"camheight:next", SettingAction::CameraHeightNext, SettingDirection::Next},
+    {"camheight:prev", SettingAction::CameraHeightNext, SettingDirection::Previous},
+    {"fov:next", SettingAction::FovNext, SettingDirection::Next},
+    {"fov:prev", SettingAction::FovNext, SettingDirection::Previous},
 });
 
 template <typename T, size_t Size>
-T next_value(T current, const std::array<T, Size>& values) {
+T step_value(T current, const std::array<T, Size>& values, bool forward) {
     const auto position = std::find(values.begin(), values.end(), current);
-    if (position == values.end() || std::next(position) == values.end()) return values.front();
-    return *std::next(position);
+    if (position == values.end()) return forward ? values.front() : values.back();
+    if (forward) {
+        const auto next = std::next(position);
+        return next == values.end() ? values.front() : *next;
+    }
+    return position == values.begin() ? values.back() : *std::prev(position);
 }
 
 template <size_t Size>
-double next_number(double current, const std::array<double, Size>& values) {
+double step_number(double current, const std::array<double, Size>& values, bool forward) {
     const auto position = std::find_if(values.begin(), values.end(), [current](double value) {
         return std::abs(value - current) < 0.001;
     });
-    if (position == values.end() || std::next(position) == values.end()) return values.front();
-    return *std::next(position);
+    if (position == values.end()) return forward ? values.front() : values.back();
+    if (forward) {
+        const auto next = std::next(position);
+        return next == values.end() ? values.front() : *next;
+    }
+    return position == values.begin() ? values.back() : *std::prev(position);
+}
+
+// Index of the value within an authored option list, used only for the visual
+// position track. Exact matches are the normal case; interpolate otherwise.
+template <size_t Size>
+int index_of(double current, const std::array<double, Size>& values) {
+    for (size_t i = 0; i < values.size(); ++i) {
+        if (std::abs(values[i] - current) < 0.001) return static_cast<int>(i);
+    }
+    size_t i = 0;
+    while (i < values.size() && values[i] < current) ++i;
+    return static_cast<int>(i > 0 ? i - 1 : 0);
+}
+
+std::string track(int index, int count) {
+    std::string html;
+    for (int step = 0; step < count; ++step) {
+        html += step == index ? "<span class=\"track-step on\"></span>"
+                              : "<span class=\"track-step\"></span>";
+    }
+    return html;
 }
 
 const char* resolution_name(ultramodern::renderer::Resolution value) {
@@ -152,64 +201,186 @@ std::string fov_add_name(double value) {
     return "+" + std::to_string(degrees) + " deg";
 }
 
+int resolution_index(ultramodern::renderer::Resolution value) {
+    using ultramodern::renderer::Resolution;
+    switch (value) {
+        case Resolution::Auto: return 0;
+        case Resolution::Original: return 1;
+        case Resolution::Original2x: return 2;
+        default: return 0;
+    }
+}
+
+int aspect_index(ultramodern::renderer::AspectRatio value) {
+    using ultramodern::renderer::AspectRatio;
+    switch (value) {
+        case AspectRatio::Expand: return 0;
+        case AspectRatio::Original: return 1;
+        default: return 0;
+    }
+}
+
+int hud_index(ultramodern::renderer::HUDRatioMode value) {
+    using ultramodern::renderer::HUDRatioMode;
+    switch (value) {
+        case HUDRatioMode::Clamp16x9: return 0;
+        case HUDRatioMode::Full: return 1;
+        case HUDRatioMode::Original: return 2;
+        default: return 0;
+    }
+}
+
+int msaa_index(ultramodern::renderer::Antialiasing value) {
+    using ultramodern::renderer::Antialiasing;
+    switch (value) {
+        case Antialiasing::None: return 0;
+        case Antialiasing::MSAA2X: return 1;
+        case Antialiasing::MSAA4X: return 2;
+        case Antialiasing::MSAA8X: return 3;
+        default: return 0;
+    }
+}
+
+int hpfb_index(ultramodern::renderer::HighPrecisionFramebuffer value) {
+    using ultramodern::renderer::HighPrecisionFramebuffer;
+    switch (value) {
+        case HighPrecisionFramebuffer::Auto: return 0;
+        case HighPrecisionFramebuffer::On: return 1;
+        case HighPrecisionFramebuffer::Off: return 2;
+        default: return 0;
+    }
+}
+
+int api_index(ultramodern::renderer::GraphicsApi value) {
+    using ultramodern::renderer::GraphicsApi;
+    if (value == GraphicsApi::Auto) return 0;
+#if defined(_WIN32)
+    if (value == GraphicsApi::D3D12) return 1;
+    if (value == GraphicsApi::Vulkan) return 2;
+#elif defined(__APPLE__)
+    if (value == GraphicsApi::Metal) return 1;
+#else
+    if (value == GraphicsApi::Vulkan) return 1;
+#endif
+    return 0;
+}
+
+int api_count() {
+#if defined(_WIN32)
+    return 3;
+#else
+    return 2;
+#endif
+}
+
+int refresh_index(const ultramodern::renderer::GraphicsConfig& cfg) {
+    using ultramodern::renderer::RefreshRate;
+    if (cfg.rr_option == RefreshRate::Original) return 0;
+    if (cfg.rr_option == RefreshRate::Display) return 1;
+    if (cfg.rr_option == RefreshRate::Manual) {
+        constexpr std::array rates{30, 60, 90, 120, 144, 165, 240};
+        int position = 0;
+        while (position < static_cast<int>(rates.size()) && rates[position] < cfg.rr_manual_value) {
+            ++position;
+        }
+        position = std::clamp(position - 1, 0, static_cast<int>(rates.size()) - 1);
+        return 2 + position;
+    }
+    return 0;
+}
+
 } // namespace
 
 namespace lambo::ui {
 
 std::optional<SettingAction> setting_action_from_name(std::string_view name) {
-    for (const auto& [binding, action] : setting_bindings) {
-        if (binding == name) return action;
+    for (const auto& binding : setting_bindings) {
+        if (binding.name == name) return binding.action;
     }
     return std::nullopt;
 }
 
-bool apply_setting_action(SettingAction action) {
+std::optional<SettingRequest> setting_request_from_name(std::string_view name) {
+    for (const auto& binding : setting_bindings) {
+        if (binding.name == name) return SettingRequest{binding.action, binding.direction};
+    }
+    return std::nullopt;
+}
+
+bool apply_setting_request(const SettingRequest& request) {
     using namespace ultramodern::renderer;
     auto cfg = lambo::config::current_graphics();
+    const bool forward = request.direction == SettingDirection::Next;
     bool apply_live = true;
 
-    switch (action) {
+    switch (request.action) {
         case SettingAction::ResolutionNext:
-            cfg.res_option = next_value(cfg.res_option,
-                std::array{Resolution::Auto, Resolution::Original, Resolution::Original2x}); break;
+            cfg.res_option = step_value(cfg.res_option,
+                std::array{Resolution::Auto, Resolution::Original, Resolution::Original2x}, forward); break;
         case SettingAction::SupersamplingNext:
-            cfg.ds_option = cfg.ds_option < 1 || cfg.ds_option >= 4 ? 1 : cfg.ds_option + 1; break;
+            if (forward) cfg.ds_option = cfg.ds_option < 1 || cfg.ds_option >= 4 ? 1 : cfg.ds_option + 1;
+            else cfg.ds_option = cfg.ds_option <= 1 || cfg.ds_option > 4 ? 4 : cfg.ds_option - 1;
+            break;
         case SettingAction::AspectNext:
-            cfg.ar_option = next_value(cfg.ar_option, std::array{AspectRatio::Expand, AspectRatio::Original}); break;
+            cfg.ar_option = step_value(cfg.ar_option,
+                std::array{AspectRatio::Expand, AspectRatio::Original}, forward); break;
         case SettingAction::HudNext:
-            cfg.hr_option = next_value(cfg.hr_option,
-                std::array{HUDRatioMode::Clamp16x9, HUDRatioMode::Full, HUDRatioMode::Original}); break;
-        case SettingAction::RefreshNext:
-            if (cfg.rr_option == RefreshRate::Original) cfg.rr_option = RefreshRate::Display;
-            else if (cfg.rr_option == RefreshRate::Display) { cfg.rr_option = RefreshRate::Manual; cfg.rr_manual_value = 30; }
-            else {
-                constexpr std::array rates{30, 60, 90, 120, 144, 165, 240};
+            cfg.hr_option = step_value(cfg.hr_option,
+                std::array{HUDRatioMode::Clamp16x9, HUDRatioMode::Full, HUDRatioMode::Original}, forward); break;
+        case SettingAction::RefreshNext: {
+            constexpr std::array rates{30, 60, 90, 120, 144, 165, 240};
+            if (cfg.rr_option == RefreshRate::Original) {
+                if (forward) {
+                    cfg.rr_option = RefreshRate::Display;
+                } else {
+                    cfg.rr_option = RefreshRate::Manual;
+                    cfg.rr_manual_value = rates.back();
+                }
+            } else if (cfg.rr_option == RefreshRate::Display) {
+                if (forward) {
+                    cfg.rr_option = RefreshRate::Manual;
+                    cfg.rr_manual_value = 30;
+                } else {
+                    cfg.rr_option = RefreshRate::Original;
+                }
+            } else {
                 const auto position = std::find(rates.begin(), rates.end(), cfg.rr_manual_value);
                 if (position == rates.end()) {
-                    const auto next_rate = std::upper_bound(rates.begin(), rates.end(), cfg.rr_manual_value);
-                    if (next_rate == rates.end()) cfg.rr_option = RefreshRate::Original;
-                    else cfg.rr_manual_value = *next_rate;
+                    if (forward) {
+                        const auto next_rate = std::upper_bound(rates.begin(), rates.end(), cfg.rr_manual_value);
+                        if (next_rate == rates.end()) cfg.rr_option = RefreshRate::Original;
+                        else cfg.rr_manual_value = *next_rate;
+                    } else {
+                        const auto lower = std::lower_bound(rates.begin(), rates.end(), cfg.rr_manual_value);
+                        if (lower == rates.begin()) cfg.rr_option = RefreshRate::Display;
+                        else cfg.rr_manual_value = *std::prev(lower);
+                    }
+                } else if (forward) {
+                    if (std::next(position) == rates.end()) cfg.rr_option = RefreshRate::Original;
+                    else cfg.rr_manual_value = *std::next(position);
+                } else {
+                    if (position == rates.begin()) cfg.rr_option = RefreshRate::Display;
+                    else cfg.rr_manual_value = *std::prev(position);
                 }
-                else if (std::next(position) == rates.end()) cfg.rr_option = RefreshRate::Original;
-                else cfg.rr_manual_value = *std::next(position);
             }
             break;
+        }
         case SettingAction::MsaaNext:
-            cfg.msaa_option = next_value(cfg.msaa_option, std::array{
-                Antialiasing::None, Antialiasing::MSAA2X, Antialiasing::MSAA4X, Antialiasing::MSAA8X}); break;
+            cfg.msaa_option = step_value(cfg.msaa_option, std::array{
+                Antialiasing::None, Antialiasing::MSAA2X, Antialiasing::MSAA4X, Antialiasing::MSAA8X}, forward); break;
         case SettingAction::HpfbNext:
-            cfg.hpfb_option = next_value(cfg.hpfb_option, std::array{
-                HighPrecisionFramebuffer::Auto, HighPrecisionFramebuffer::On, HighPrecisionFramebuffer::Off}); break;
+            cfg.hpfb_option = step_value(cfg.hpfb_option, std::array{
+                HighPrecisionFramebuffer::Auto, HighPrecisionFramebuffer::On, HighPrecisionFramebuffer::Off}, forward); break;
         case SettingAction::ApiNext:
 #if defined(_WIN32)
-            cfg.api_option = next_value(cfg.api_option,
-                std::array{GraphicsApi::Auto, GraphicsApi::D3D12, GraphicsApi::Vulkan});
+            cfg.api_option = step_value(cfg.api_option,
+                std::array{GraphicsApi::Auto, GraphicsApi::D3D12, GraphicsApi::Vulkan}, forward);
 #elif defined(__APPLE__)
-            cfg.api_option = next_value(cfg.api_option,
-                std::array{GraphicsApi::Auto, GraphicsApi::Metal});
+            cfg.api_option = step_value(cfg.api_option,
+                std::array{GraphicsApi::Auto, GraphicsApi::Metal}, forward);
 #else
-            cfg.api_option = next_value(cfg.api_option,
-                std::array{GraphicsApi::Auto, GraphicsApi::Vulkan});
+            cfg.api_option = step_value(cfg.api_option,
+                std::array{GraphicsApi::Auto, GraphicsApi::Vulkan}, forward);
 #endif
             apply_live = false;
             break;
@@ -222,29 +393,33 @@ bool apply_setting_action(SettingAction action) {
         case SettingAction::Circuit1Toggle: case SettingAction::Circuit2Toggle:
         case SettingAction::Circuit3Toggle: case SettingAction::Circuit4Toggle:
         case SettingAction::Circuit5Toggle: case SettingAction::Circuit6Toggle: {
-            const int circuit = static_cast<int>(action) - static_cast<int>(SettingAction::Circuit1Toggle);
+            const int circuit = static_cast<int>(request.action) - static_cast<int>(SettingAction::Circuit1Toggle);
             lambo::config::set_no_lod_circuit(circuit, !lambo::config::no_lod_circuit(circuit));
             return true;
         }
         case SettingAction::DrawDistanceNext:
-            lambo::config::set_global_draw_distance(next_number(
-                lambo::config::global_draw_distance(), std::array{1.0, 1.5, 2.0, 3.0, 0.0})); return true;
+            lambo::config::set_global_draw_distance(step_number(
+                lambo::config::global_draw_distance(), std::array{1.0, 1.5, 2.0, 3.0, 0.0}, forward)); return true;
         case SettingAction::FogDensityNext:
-            lambo::config::set_global_fog_scale(next_number(
-                lambo::config::global_fog_scale(), std::array{0.0, 0.5, 0.75, 1.0, 1.5, 2.0})); return true;
+            lambo::config::set_global_fog_scale(step_number(
+                lambo::config::global_fog_scale(), std::array{0.0, 0.5, 0.75, 1.0, 1.5, 2.0}, forward)); return true;
         case SettingAction::CameraDistanceNext:
-            lambo::config::set_camera_distance_scale(next_number(
-                lambo::config::camera_distance_scale(), std::array{1.0, 0.8, 0.65, 0.5})); return true;
+            lambo::config::set_camera_distance_scale(step_number(
+                lambo::config::camera_distance_scale(), std::array{1.0, 0.8, 0.65, 0.5}, forward)); return true;
         case SettingAction::CameraHeightNext:
-            lambo::config::set_camera_height_scale(next_number(
-                lambo::config::camera_height_scale(), std::array{1.0, 0.66, 0.4})); return true;
+            lambo::config::set_camera_height_scale(step_number(
+                lambo::config::camera_height_scale(), std::array{1.0, 0.66, 0.4}, forward)); return true;
         case SettingAction::FovNext:
-            lambo::config::set_camera_fov_add(next_number(
-                lambo::config::camera_fov_add(), std::array{0.0, 5.0, 10.0, 15.0, 20.0})); return true;
+            lambo::config::set_camera_fov_add(step_number(
+                lambo::config::camera_fov_add(), std::array{0.0, 5.0, 10.0, 15.0, 20.0}, forward)); return true;
     }
 
     lambo::config::apply_graphics(cfg, apply_live);
     return true;
+}
+
+bool apply_setting_action(SettingAction action) {
+    return apply_setting_request(SettingRequest{action, SettingDirection::Next});
 }
 
 SettingsSnapshot settings_snapshot() {
@@ -272,6 +447,24 @@ SettingsSnapshot settings_snapshot() {
     for (int circuit = 0; circuit < 6; ++circuit) {
         result.circuit_visibility[circuit] = lambo::config::no_lod_circuit(circuit) ? "Enabled" : "Disabled";
     }
+    result.resolution_track = track(resolution_index(cfg.res_option), 3);
+    result.supersampling_track = track(std::clamp(static_cast<int>(cfg.ds_option) - 1, 0, 3), 4);
+    result.aspect_track = track(aspect_index(cfg.ar_option), 2);
+    result.hud_track = track(hud_index(cfg.hr_option), 3);
+    result.refresh_track = track(refresh_index(cfg), 9);
+    result.msaa_track = track(msaa_index(cfg.msaa_option), 4);
+    result.framebuffer_precision_track = track(hpfb_index(cfg.hpfb_option), 3);
+    result.graphics_api_track = track(api_index(cfg.api_option), api_count());
+    result.draw_distance_track = track(index_of(
+        lambo::config::global_draw_distance(), std::array{1.0, 1.5, 2.0, 3.0, 0.0}), 5);
+    result.fog_density_track = track(index_of(
+        lambo::config::global_fog_scale(), std::array{0.0, 0.5, 0.75, 1.0, 1.5, 2.0}), 6);
+    result.camera_distance_track = track(index_of(
+        lambo::config::camera_distance_scale(), std::array{1.0, 0.8, 0.65, 0.5}), 4);
+    result.camera_height_track = track(index_of(
+        lambo::config::camera_height_scale(), std::array{1.0, 0.66, 0.4}), 3);
+    result.camera_fov_track = track(index_of(
+        lambo::config::camera_fov_add(), std::array{0.0, 5.0, 10.0, 15.0, 20.0}), 5);
     return result;
 }
 

--- a/src/ui/lambo_ui_settings.h
+++ b/src/ui/lambo_ui_settings.h
@@ -33,7 +33,6 @@ enum class SettingAction {
     FovNext,
 };
 
-// Cycle settings can step forwards or backwards; toggles ignore the direction.
 enum class SettingDirection {
     Next,
     Previous,
@@ -53,17 +52,16 @@ struct SettingsSnapshot {
     std::string msaa;
     std::string framebuffer_precision;
     std::string graphics_api;
-    std::string widescreen_fog;
-    std::string widescreen_sky;
-    std::string lod_removal;
+    bool widescreen_fog_enabled;
+    bool widescreen_sky_enabled;
+    bool lod_removal_enabled;
     std::string draw_distance;
     std::string fog_density;
     std::string camera_distance;
     std::string camera_height;
     std::string camera_fov;
-    std::array<std::string, 6> circuit_visibility;
-    // Position indicators ("<span class=\"track-step on\"></span>"...) so the
-    // focused row can show where the current value sits in its option cycle.
+    std::array<bool, 6> circuit_visibility;
+    // Position indicators let the focused row show where its value sits in its cycle.
     std::string resolution_track;
     std::string supersampling_track;
     std::string aspect_track;
@@ -79,15 +77,8 @@ struct SettingsSnapshot {
     std::string camera_fov_track;
 };
 
-// Full parse of a `<key>:<verb>` binding, including direction. Prefer this over
-// setting_action_from_name for new call sites.
 std::optional<SettingRequest> setting_request_from_name(std::string_view name);
 bool apply_setting_request(const SettingRequest& request);
-
-// Back-compatibility wrappers used by the existing tests and any caller that
-// only needs the action identity.
-std::optional<SettingAction> setting_action_from_name(std::string_view name);
-bool apply_setting_action(SettingAction action);
 
 SettingsSnapshot settings_snapshot();
 

--- a/src/ui/lambo_ui_settings.h
+++ b/src/ui/lambo_ui_settings.h
@@ -33,6 +33,17 @@ enum class SettingAction {
     FovNext,
 };
 
+// Cycle settings can step forwards or backwards; toggles ignore the direction.
+enum class SettingDirection {
+    Next,
+    Previous,
+};
+
+struct SettingRequest {
+    SettingAction action;
+    SettingDirection direction;
+};
+
 struct SettingsSnapshot {
     std::string resolution;
     std::string supersampling;
@@ -51,10 +62,33 @@ struct SettingsSnapshot {
     std::string camera_height;
     std::string camera_fov;
     std::array<std::string, 6> circuit_visibility;
+    // Position indicators ("<span class=\"track-step on\"></span>"...) so the
+    // focused row can show where the current value sits in its option cycle.
+    std::string resolution_track;
+    std::string supersampling_track;
+    std::string aspect_track;
+    std::string hud_track;
+    std::string refresh_track;
+    std::string msaa_track;
+    std::string framebuffer_precision_track;
+    std::string graphics_api_track;
+    std::string draw_distance_track;
+    std::string fog_density_track;
+    std::string camera_distance_track;
+    std::string camera_height_track;
+    std::string camera_fov_track;
 };
 
+// Full parse of a `<key>:<verb>` binding, including direction. Prefer this over
+// setting_action_from_name for new call sites.
+std::optional<SettingRequest> setting_request_from_name(std::string_view name);
+bool apply_setting_request(const SettingRequest& request);
+
+// Back-compatibility wrappers used by the existing tests and any caller that
+// only needs the action identity.
 std::optional<SettingAction> setting_action_from_name(std::string_view name);
 bool apply_setting_action(SettingAction action);
+
 SettingsSnapshot settings_snapshot();
 
 } // namespace lambo::ui

--- a/tests/test_ui_assets.py
+++ b/tests/test_ui_assets.py
@@ -44,12 +44,14 @@ def main() -> None:
                 page_actions.add(onclick.removeprefix("page:"))
 
     expected_settings = {
-        "res:next", "ss:next", "aspect:next", "hud:next", "rate:next",
-        "msaa:next", "hpfb:next", "api:next",
+        "res:next", "res:prev", "ss:next", "ss:prev", "aspect:next", "aspect:prev",
+        "hud:next", "hud:prev", "rate:next", "rate:prev", "msaa:next", "msaa:prev",
+        "hpfb:next", "hpfb:prev", "api:next", "api:prev",
         "fog:toggle", "sky:toggle", "lod:toggle",
         "circuit:1", "circuit:2", "circuit:3", "circuit:4", "circuit:5", "circuit:6",
-        "distance:next", "fogdensity:next",
-        "camdist:next", "camheight:next", "fov:next",
+        "distance:next", "distance:prev", "fogdensity:next", "fogdensity:prev",
+        "camdist:next", "camdist:prev", "camheight:next", "camheight:prev",
+        "fov:next", "fov:prev",
     }
     require(setting_actions == expected_settings,
             f"setting actions differ: missing={expected_settings - setting_actions}, "
@@ -57,11 +59,31 @@ def main() -> None:
     require({"graphics", "enhancements", "controls", "haptics", "player"} <= page_actions,
             "settings hub is missing a stable route identifier")
 
+    sidebar_pages = {
+        "settings.rml", "pages/graphics.rml", "pages/enhancements.rml",
+        "pages/controls.rml", "pages/haptics.rml", "pages/player.rml",
+    }
+    expected_sidebar_ids = {
+        "nav-settings", "nav-graphics", "nav-enhancements", "nav-controls",
+        "nav-player", "nav-haptics",
+    }
+    for relative in sidebar_pages:
+        sidebar_document = ET.parse(ui_root / relative)
+        sidebar_ids = {element.attrib.get("id") for element in sidebar_document.iter()
+                       if element.attrib.get("id", "").startswith("nav-")}
+        require(sidebar_ids == expected_sidebar_ids,
+                f"{relative} must expose the complete focusable settings sidebar")
+
     graphics = ET.parse(ui_root / "pages" / "graphics.rml")
-    graphics_controls = [element for element in graphics.iter("button")
-                         if element.attrib.get("onclick", "").startswith("setting:")]
-    require(len(graphics_controls) == 8,
-            "graphics must expose one control per setting, not one button per value")
+    graphics_rows = [element for element in graphics.iter()
+                     if element.attrib.get("id", "").startswith("setting-")]
+    require(len(graphics_rows) == 8,
+            "graphics must expose one focusable row per setting, not one button per value")
+    graphics_actions = {element.attrib.get("onclick", "") for element in graphics.iter()
+                        if element.attrib.get("onclick", "").startswith("setting:")}
+    for key in ("res", "ss", "aspect", "hud", "rate", "msaa", "hpfb", "api"):
+        require(f"setting:{key}:prev" in graphics_actions and f"setting:{key}:next" in graphics_actions,
+                f"graphics row {key} must offer both directions")
     for value_id in ("graphics-resolution", "graphics-supersampling", "graphics-aspect",
                      "graphics-hud", "graphics-refresh", "graphics-msaa", "graphics-hpfb",
                      "graphics-api"):
@@ -106,8 +128,8 @@ def main() -> None:
             "graphics API must not pretend to apply live")
 
     enhancements_text = (ui_root / "pages" / "enhancements.rml").read_text(encoding="utf-8")
-    require(enhancements_text.index('class="help"') < enhancements_text.index('class="columns"'),
-            "enhancement guidance must sit above both columns to keep their controls aligned")
+    require(enhancements_text.index('class="help"') < enhancements_text.index('class="setting-group"'),
+            "enhancement guidance must sit above the setting groups to keep their rows aligned")
     enhancements = ET.parse(ui_root / "pages" / "enhancements.rml")
     for value_id in ("enhancement-camdist", "enhancement-camheight", "enhancement-fov"):
         require(any(element.attrib.get("id") == value_id for element in enhancements.iter()),
@@ -164,7 +186,20 @@ def main() -> None:
     scrollbar_rule = re.search(r"scrollbarvertical\s*\{([^}]*)\}", rcss, re.DOTALL)
     require(scrollbar_rule is not None and "width:" in scrollbar_rule.group(1),
             "RmlUi scrollbars need an explicit width or they consume the content area")
+    settings_content_rule = re.search(r"\.settings-content\s*\{([^}]*)\}", rcss, re.DOTALL)
+    require(settings_content_rule is not None and "overflow-y: auto" in settings_content_rule.group(1),
+            "the settings content pane must own the vertical scrollbar")
+    setting_row_rule = re.search(r"\.setting-row\s*\{([^}]*)\}", rcss, re.DOTALL)
+    require(setting_row_rule is not None and "tab-index: auto" in setting_row_rule.group(1),
+            "setting rows must be focusable so left/right can adjust their value")
+    require(setting_row_rule is not None and "nav: auto" in setting_row_rule.group(1),
+            "setting rows must participate in RmlUi directional navigation")
+    nav_rule = re.search(r"\.settings-nav\s*\{([^}]*)\}", rcss, re.DOTALL)
+    require(nav_rule is not None and "width:" in nav_rule.group(1),
+            "the settings sidebar needs an explicit width so content can flex beside it")
     ui_source = (repo / "src" / "ui" / "lambo_ui.cpp").read_text(encoding="utf-8")
+    require("focus_settings_content" in ui_source,
+            "entering a settings section must transfer focus into its content")
     require('data, "Lato"' in ui_source,
             "fonts must be registered explicitly under the stylesheet family name")
     require("font_data" in ui_source and "font_data.reserve(2)" in ui_source,

--- a/tests/test_ui_assets.py
+++ b/tests/test_ui_assets.py
@@ -16,6 +16,7 @@ def main() -> None:
     ui_root = repo / "assets" / "ui"
     required_documents = {
         "launcher.rml",
+        "settings_shell.rml",
         "settings.rml",
         "pages/graphics.rml",
         "pages/enhancements.rml",
@@ -67,12 +68,16 @@ def main() -> None:
         "nav-settings", "nav-graphics", "nav-enhancements", "nav-controls",
         "nav-player", "nav-haptics",
     }
+    sidebar_template = ET.parse(ui_root / "settings_shell.rml")
+    sidebar_ids = {element.attrib.get("id") for element in sidebar_template.iter()
+                   if element.attrib.get("id", "").startswith("nav-")}
+    require(sidebar_ids == expected_sidebar_ids,
+            "settings shell must expose the complete focusable settings sidebar")
     for relative in sidebar_pages:
         sidebar_document = ET.parse(ui_root / relative)
-        sidebar_ids = {element.attrib.get("id") for element in sidebar_document.iter()
-                       if element.attrib.get("id", "").startswith("nav-")}
-        require(sidebar_ids == expected_sidebar_ids,
-                f"{relative} must expose the complete focusable settings sidebar")
+        body = sidebar_document.find("body")
+        require(body is not None and body.attrib.get("template") == "settings-shell",
+                f"{relative} must use the shared settings shell template")
 
     graphics = ET.parse(ui_root / "pages" / "graphics.rml")
     graphics_rows = [element for element in graphics.iter()
@@ -90,8 +95,8 @@ def main() -> None:
         require(any(element.attrib.get("id") == value_id for element in graphics.iter()),
                 f"graphics control is missing current-value target: {value_id}")
 
-    settings = ET.parse(ui_root / "settings.rml")
-    unavailable = [element for element in settings.iter("button")
+    settings_shell = ET.parse(ui_root / "settings_shell.rml")
+    unavailable = [element for element in settings_shell.iter("button")
                    if element.attrib.get("disabled") == "disabled"]
     require(len(unavailable) == 1 and
             {element.attrib.get("onclick") for element in unavailable} ==
@@ -109,6 +114,9 @@ def main() -> None:
     }
     require(required_control_ids <= controls_ids,
             f"Controls page is missing state targets: {required_control_ids - controls_ids}")
+    controls_text = (ui_root / "pages" / "controls.rml").read_text(encoding="utf-8")
+    require("id=\"autofocus\"" not in controls_text and "class=\"footer-bar\"" not in controls_text,
+            "Controls page must not add a second back button or navigation footer")
     control_actions = {element.attrib.get("onclick") for element in controls.iter()
                        if element.attrib.get("onclick", "").startswith("control:")}
     require({"control:reset-profile", "control:capture-cancel", "control:conflict-accept"}

--- a/tests/test_ui_settings.cpp
+++ b/tests/test_ui_settings.cpp
@@ -65,10 +65,10 @@ int main() {
         "camdist:next", "camheight:next", "fov:next",
     };
     for (const char* name : binding_names) {
-        expect(lambo::ui::setting_action_from_name(name).has_value(),
+        expect(lambo::ui::setting_request_from_name(name).has_value(),
                "every documented setting binding parses");
     }
-    expect(!lambo::ui::setting_action_from_name("unknown:setting").has_value(),
+    expect(!lambo::ui::setting_request_from_name("unknown:setting").has_value(),
            "unknown setting bindings are rejected");
 
     const auto previous = lambo::ui::setting_request_from_name("res:prev");
@@ -78,6 +78,10 @@ int main() {
     const auto toggle = lambo::ui::setting_request_from_name("fog:toggle");
     expect(toggle.has_value() && toggle->direction == lambo::ui::SettingDirection::Next,
            "toggle bindings parse as forward requests");
+    const auto circuit_toggle = lambo::ui::setting_request_from_name("circuit:1:toggle");
+    expect(circuit_toggle.has_value() &&
+           circuit_toggle->action == lambo::ui::SettingAction::Circuit1Toggle,
+           "focused circuit rows accept their toggle request");
 
     const auto apply_request = [](const char* name) {
         const auto request = lambo::ui::setting_request_from_name(name);
@@ -95,8 +99,8 @@ int main() {
            "previous request wraps to the last option at the head of the cycle");
     lambo::config::apply_graphics(lambo::config::default_graphics_config());
     const auto apply = [](const char* name) {
-        const auto action = lambo::ui::setting_action_from_name(name);
-        return action.has_value() && lambo::ui::apply_setting_action(*action);
+        const auto request = lambo::ui::setting_request_from_name(name);
+        return request.has_value() && lambo::ui::apply_setting_request(*request);
     };
 
     auto custom_refresh = lambo::config::current_graphics();
@@ -135,12 +139,14 @@ int main() {
 #endif
 
     expect(apply("fog:toggle") && apply("sky:toggle") && apply("lod:toggle") &&
-           apply("circuit:6") && apply("distance:next") && apply("fogdensity:next") &&
+           apply("circuit:6") && apply("circuit:1:toggle") &&
+           apply("distance:next") && apply("fogdensity:next") &&
            apply("camdist:next") && apply("camheight:next") && apply("fov:next"),
            "enhancement bindings apply through the typed settings seam");
     expect(!lambo::config::widescreen_fog_match(), "fog match toggles live");
     expect(!lambo::config::widescreen_sky_match(), "sky match toggles live");
     expect(!lambo::config::no_lod(), "LOD removal toggles live");
+    expect(!lambo::config::no_lod_circuit(0), "focused circuit toggle applies live");
     expect(lambo::config::no_lod_circuit(5), "per-circuit visibility toggles live");
     expect(lambo::config::global_draw_distance() == 2.0, "draw-distance cycle applies live");
     expect(lambo::config::global_fog_scale() == 1.5, "fog-density cycle applies live");
@@ -152,7 +158,7 @@ int main() {
     expect(snapshot.resolution == "Original", "settings snapshot presents resolution");
     expect(snapshot.refresh_rate == "30 Hz", "settings snapshot presents refresh rate");
     expect(snapshot.msaa == "4x", "settings snapshot presents MSAA");
-    expect(snapshot.circuit_visibility[5] == "Enabled",
+    expect(snapshot.circuit_visibility[5],
            "settings snapshot presents every circuit");
     expect(snapshot.draw_distance == "2x", "settings snapshot presents draw distance");
     expect(snapshot.fog_density == "150%", "settings snapshot presents fog density");

--- a/tests/test_ui_settings.cpp
+++ b/tests/test_ui_settings.cpp
@@ -71,6 +71,29 @@ int main() {
     expect(!lambo::ui::setting_action_from_name("unknown:setting").has_value(),
            "unknown setting bindings are rejected");
 
+    const auto previous = lambo::ui::setting_request_from_name("res:prev");
+    expect(previous.has_value() &&
+           previous->direction == lambo::ui::SettingDirection::Previous,
+           "previous-direction bindings parse with their direction");
+    const auto toggle = lambo::ui::setting_request_from_name("fog:toggle");
+    expect(toggle.has_value() && toggle->direction == lambo::ui::SettingDirection::Next,
+           "toggle bindings parse as forward requests");
+
+    const auto apply_request = [](const char* name) {
+        const auto request = lambo::ui::setting_request_from_name(name);
+        return request.has_value() && lambo::ui::apply_setting_request(*request);
+    };
+    using ResolutionSetting = ultramodern::renderer::Resolution;
+    expect(apply_request("res:next") &&
+           lambo::config::current_graphics().res_option == ResolutionSetting::Original,
+           "forward request steps to the next option");
+    expect(apply_request("res:prev") &&
+           lambo::config::current_graphics().res_option == ResolutionSetting::Auto,
+           "previous request steps back to the original option");
+    expect(apply_request("res:prev") &&
+           lambo::config::current_graphics().res_option == ResolutionSetting::Original2x,
+           "previous request wraps to the last option at the head of the cycle");
+    lambo::config::apply_graphics(lambo::config::default_graphics_config());
     const auto apply = [](const char* name) {
         const auto action = lambo::ui::setting_action_from_name(name);
         return action.has_value() && lambo::ui::apply_setting_action(*action);
@@ -136,6 +159,10 @@ int main() {
     expect(snapshot.camera_distance == "0.8x", "settings snapshot presents camera distance");
     expect(snapshot.camera_height == "0.66x", "settings snapshot presents camera height");
     expect(snapshot.camera_fov == "+5 deg", "settings snapshot presents FOV boost");
+    expect(snapshot.resolution_track.find("track-step on") != std::string::npos,
+           "settings snapshot exposes a position track for stepped values");
+    expect(snapshot.draw_distance_track.find("track-step on") != std::string::npos,
+           "settings snapshot exposes a position track for numeric cycles");
 
     using SnapshotStringMember = std::string lambo::ui::SettingsSnapshot::*;
     const auto expect_cycle_wraps = [&](const char* binding, int steps, const std::string& initial,


### PR DESCRIPTION
## Summary

- Revamp the settings UI with a shared sidebar and content-pane layout.
- Transfer focus into submenu content and support controller directional navigation.
- Keep Controls Mapper inside the shared sidebar layout without competing back controls.
- Fix controller activation of per-circuit visibility toggles.
- Centralize settings option tables and keep snapshot toggle state typed.
- Restore Resume Game and Exit to Desktop actions on the settings overview.
- Remove explanatory copy from the settings overview.

## Verification

- `python tests/test_ui_assets.py .`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure` (36/36 passed)
- `python tools/run_game_scenario.py scenarios/harness-smoke.json`
- Graphics and Controls page-specific smoke launches
- `git diff --check`

No linked issue - settings UI usability and review fixes.
