### PR TITLE
fix(ui): toggle the options overlay and repair the overview page

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -124,7 +124,7 @@ Run from the repository root so the ROM path resolves:
 ./build/lamborghini_modern
 ```
 
-The game auto-boots directly into gameplay. Press the **Menu / Back / Guide** button on your controller, or press <kbd>Esc</kbd> / <kbd>F1</kbd> on your keyboard to open the in-game configuration overlay and controls mapper. To launch into the standalone launcher shell instead, set `LAMBO_LAUNCHER=1` in your environment or set `"show_launcher": true` in `graphics.json`.
+The game auto-boots directly into gameplay. Press the **Menu / Back / Guide** button on your controller, or press <kbd>Esc</kbd> / <kbd>F1</kbd> on your keyboard to open the in-game configuration overlay and controls mapper (press the same button again to close it). To launch into the standalone launcher shell instead, set `LAMBO_LAUNCHER=1` in your environment or set `"show_launcher": true` in `graphics.json`.
 
 ## Notes
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -124,7 +124,7 @@ Run from the repository root so the ROM path resolves:
 ./build/lamborghini_modern
 ```
 
-The game auto-boots directly into gameplay. Press the **Menu / Back / Guide** button on your controller, or press <kbd>Esc</kbd> / <kbd>F1</kbd> on your keyboard to open the in-game configuration overlay and controls mapper (press the same button again to close it). To launch into the standalone launcher shell instead, set `LAMBO_LAUNCHER=1` in your environment or set `"show_launcher": true` in `graphics.json`.
+The game auto-boots directly into gameplay. Press the **Menu / Back / Guide** button on your controller, or <kbd>F1</kbd> on your keyboard, to toggle the in-game configuration overlay and controls mapper: it opens on Settings, and the same button closes it again from anywhere. <kbd>Esc</kbd> is Back instead — it steps up one level at a time and closes the overlay only once you are on the top-level Overview page. To launch into the standalone launcher shell instead, set `LAMBO_LAUNCHER=1` in your environment or set `"show_launcher": true` in `graphics.json`.
 
 ## Notes
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,16 @@ if(BUILD_TESTING)
     )
     add_test(NAME lambo_ui_controller_navigation COMMAND lambo_ui_input_tests)
 
+    add_executable(lambo_ui_requests_tests
+        tests/test_ui_requests.cpp
+        src/ui/lambo_ui_requests.cpp
+    )
+    target_include_directories(lambo_ui_requests_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    target_link_libraries(lambo_ui_requests_tests PRIVATE Threads::Threads)
+    add_test(NAME lambo_ui_overlay_requests COMMAND lambo_ui_requests_tests)
+
     add_executable(lambo_ui_settings_tests
         tests/test_ui_settings.cpp
         src/ui/lambo_ui_settings.cpp
@@ -625,6 +635,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
         src/controls/lambo_controls_sdl.cpp
         src/ui/lambo_ui.cpp
         src/ui/lambo_ui_input.cpp
+        src/ui/lambo_ui_requests.cpp
         src/ui/lambo_ui_controls.cpp
         src/ui/lambo_ui_render_interface.cpp
         src/ui/lambo_ui_settings.cpp

--- a/assets/ui/lambo.rcss
+++ b/assets/ui/lambo.rcss
@@ -211,7 +211,9 @@ input:focus-visible {
   margin-top: 14dp;
 }
 
-.overlay-action-btn {
+/* Scoped so the margin reset beats button.secondary's margin-top; a bare
+   .overlay-action-btn loses the specificity tie-break. */
+.overlay-actions .overlay-action-btn {
   flex: 1;
   padding: 16dp 24dp;
   font-size: 18dp;
@@ -223,7 +225,7 @@ input:focus-visible {
   nav-up: auto;
   nav-right: auto;
   nav-down: auto;
-  nav-left: auto;
+  nav-left: #nav-settings;
 }
 
 /* 2x2 Grid Cards for Launcher and Settings */
@@ -1111,6 +1113,16 @@ scrollbarvertical sliderarrowinc {
   color: #4b586b;
   background-color: transparent;
   border-color: transparent;
+}
+
+/* The content pane scrolls (overflow-y: auto), and RmlUi's directional search
+   refuses to descend into scroll containers, so nav: auto can never carry focus
+   from the sidebar into a page's content. Name the Overview page's only action
+   explicitly to keep that pane reachable; other pages transfer focus on entry
+   via focus_settings_content(). Scoped to .active so the target id only
+   resolves on the page that actually defines it. */
+#nav-settings.active {
+  nav-right: #overview-exit;
 }
 
 .nav-spacer {

--- a/assets/ui/settings.rml
+++ b/assets/ui/settings.rml
@@ -28,8 +28,7 @@
             </div>
 
             <div class="overlay-actions">
-              <button class="primary overlay-action-btn" onclick="back">Resume Game</button>
-              <button class="secondary overlay-action-btn" onclick="quit">Exit to Desktop</button>
+              <button id="overview-exit" class="secondary overlay-action-btn" onclick="quit">Exit Game</button>
             </div>
     </div>
   </body>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -449,14 +449,29 @@ static void update_gfx_stub(void* /*gfx_data*/) {
 
             if (g_controls != nullptr && g_controls->handle_capture_event(event)) continue;
             if (lambo::menu::handle_event(event)) continue;
+
+            // The menu button (F1 or the pad's Back/Guide) toggles the options overlay:
+            // it opens Settings from gameplay and closes it again from anywhere inside.
+            // This runs before lambo::ui::handle_event so the press still toggles once the
+            // overlay owns input; Esc keeps its page-stack "back" meaning below.
+            const bool menu_button =
+                (event.type == SDL_KEYDOWN && !event.key.repeat && event.key.keysym.sym == SDLK_F1) ||
+                (g_controls != nullptr && g_controls->selected_back_pressed(event));
+            if (menu_button &&
+                g_startup_controller != nullptr &&
+                g_startup_controller->state() == lambo::StartupState::Started) {
+                if (lambo::ui::is_visible()) lambo::ui::dismiss();
+                else lambo::ui::open_settings();
+                continue;
+            }
+
             if (lambo::ui::handle_event(event)) continue;
 
             // Once the launcher/overlay captures input, guest and developer shortcuts are
             // suppressed. F11 and Alt+Enter remain application-level shortcuts otherwise.
             const bool settings_shortcut =
-                (event.type == SDL_KEYDOWN && !event.key.repeat &&
-                 (event.key.keysym.sym == SDLK_ESCAPE || event.key.keysym.sym == SDLK_F1)) ||
-                (g_controls != nullptr && g_controls->selected_back_pressed(event));
+                event.type == SDL_KEYDOWN && !event.key.repeat &&
+                event.key.keysym.sym == SDLK_ESCAPE;
             if (settings_shortcut &&
                 g_startup_controller != nullptr &&
                 g_startup_controller->state() == lambo::StartupState::Started &&

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -460,8 +460,7 @@ static void update_gfx_stub(void* /*gfx_data*/) {
             if (menu_button &&
                 g_startup_controller != nullptr &&
                 g_startup_controller->state() == lambo::StartupState::Started) {
-                if (lambo::ui::is_visible()) lambo::ui::dismiss();
-                else lambo::ui::open_settings();
+                lambo::ui::toggle_settings();
                 continue;
             }
 
@@ -475,7 +474,7 @@ static void update_gfx_stub(void* /*gfx_data*/) {
             if (settings_shortcut &&
                 g_startup_controller != nullptr &&
                 g_startup_controller->state() == lambo::StartupState::Started &&
-                !lambo::ui::is_visible()) {
+                !lambo::ui::overlay_visible_intent()) {
                 lambo::ui::open_settings();
                 continue;
             }

--- a/src/ui/lambo_ui.cpp
+++ b/src/ui/lambo_ui.cpp
@@ -220,6 +220,7 @@ std::atomic<bool> g_capture{false};
 std::atomic<int> g_requested_page{-1};
 std::atomic<int> g_requested_entry_point{static_cast<int>(lambo::ui::EntryPoint::Startup)};
 std::atomic<bool> g_requested_back{false};
+std::atomic<bool> g_requested_dismiss{false};
 std::atomic<lambo::StartupController*> g_startup_controller{nullptr};
 moodycamel::ConcurrentQueue<QueuedEvent> g_event_queue;
 
@@ -860,6 +861,7 @@ void draw_hook(RT64::RenderCommandList* command_list,
         g_state->show_page(static_cast<lambo::ui::Page>(requested));
     }
     if (g_requested_back.exchange(false, std::memory_order_acq_rel)) g_state->back();
+    if (g_requested_dismiss.exchange(false, std::memory_order_acq_rel)) g_state->hide_pages();
     g_state->process_queued_events();
     if (!g_visible.load(std::memory_order_acquire)) return;
     g_state->refresh_controls_values();
@@ -995,6 +997,12 @@ void open_player() {
 
 void close_top_page() {
     g_requested_back.store(true, std::memory_order_release);
+}
+
+// Closes the overlay outright instead of popping one page, so the menu button
+// can toggle the whole UI regardless of how deep the user has navigated.
+void dismiss() {
+    g_requested_dismiss.store(true, std::memory_order_release);
 }
 
 bool is_initialized() {

--- a/src/ui/lambo_ui.cpp
+++ b/src/ui/lambo_ui.cpp
@@ -36,6 +36,7 @@
 #include "lambo_ui_input.h"
 #include "lambo_ui_controls.h"
 #include "lambo_ui_render_interface.h"
+#include "lambo_ui_requests.h"
 #include "lambo_ui_settings.h"
 
 #ifndef LAMBO_VERSION
@@ -217,10 +218,11 @@ std::mutex g_state_mutex;
 SDL_Window* g_window = nullptr;
 std::atomic<bool> g_visible{false};
 std::atomic<bool> g_capture{false};
-std::atomic<int> g_requested_page{-1};
-std::atomic<int> g_requested_entry_point{static_cast<int>(lambo::ui::EntryPoint::Startup)};
-std::atomic<bool> g_requested_back{false};
-std::atomic<bool> g_requested_dismiss{false};
+// One coherent intent instead of separate page/back/dismiss atomics: those were
+// applied in a fixed order rather than the order the user pressed them, so a
+// dismiss arriving after an open would load a document and unload it again in
+// the same frame.
+lambo::ui::OverlayRequestQueue g_requests;
 std::atomic<lambo::StartupController*> g_startup_controller{nullptr};
 moodycamel::ConcurrentQueue<QueuedEvent> g_event_queue;
 
@@ -783,7 +785,9 @@ void UiState::process_queued_events() {
     QueuedEvent queued{};
     while (g_event_queue.try_dequeue(queued)) {
         SDL_Event& event = queued.event;
-        if (context == nullptr) continue;
+        // A queued Back can unload the document part-way through this loop; the
+        // remaining events are stale and must not reach a torn-down document.
+        if (context == nullptr || document == nullptr) continue;
         switch (event.type) {
             case SDL_KEYDOWN:
                 process_key_down(event.key.keysym.sym, event.key.repeat != 0);
@@ -839,29 +843,56 @@ void UiState::process_queued_events() {
     process_navigation_events(controller_navigation.update(Clock::now()));
 }
 
+// Input queued while the overlay was visible is meaningless once it is gone, and
+// replaying it would drive RmlUi with no document loaded -- where a stale
+// controller press could still fire a page action, or even quit.
+void discard_queued_events() {
+    QueuedEvent queued{};
+    while (g_event_queue.try_dequeue(queued)) {
+    }
+}
+
 void draw_hook(RT64::RenderCommandList* command_list,
                RT64::RenderFramebuffer* swap_chain_framebuffer) {
     std::lock_guard lock(g_state_mutex);
     if (g_state == nullptr || g_state->context == nullptr || swap_chain_framebuffer == nullptr) return;
 
-    const int requested = g_requested_page.exchange(-1, std::memory_order_acq_rel);
-    if (requested >= 0) {
-        g_state->entry_point = static_cast<lambo::ui::EntryPoint>(
-            g_requested_entry_point.load(std::memory_order_acquire));
-        g_state->pages.clear();
-        const bool is_settings_page =
-            requested >= static_cast<int>(lambo::ui::Page::Graphics) &&
-            requested <= static_cast<int>(lambo::ui::Page::Player);
-        if (is_settings_page) {
-            if (g_state->entry_point == lambo::ui::EntryPoint::Startup)
-                g_state->pages = {lambo::ui::Page::Home, lambo::ui::Page::Settings};
-            else
-                g_state->pages = {lambo::ui::Page::Settings};
+    // At most one intent is outstanding, so an open can never be undone by a
+    // dismiss (or a Back) applied later in the same frame.
+    const lambo::ui::OverlayRequestQueue::Request request = g_requests.take();
+    switch (request.kind) {
+        case lambo::ui::OverlayRequestQueue::Kind::ShowPage: {
+            g_state->entry_point = static_cast<lambo::ui::EntryPoint>(request.entry_point);
+            g_state->pages.clear();
+            const bool is_settings_page =
+                request.page >= static_cast<int>(lambo::ui::Page::Graphics) &&
+                request.page <= static_cast<int>(lambo::ui::Page::Player);
+            if (is_settings_page) {
+                if (g_state->entry_point == lambo::ui::EntryPoint::Startup)
+                    g_state->pages = {lambo::ui::Page::Home, lambo::ui::Page::Settings};
+                else
+                    g_state->pages = {lambo::ui::Page::Settings};
+            }
+            g_state->show_page(static_cast<lambo::ui::Page>(request.page));
+            break;
         }
-        g_state->show_page(static_cast<lambo::ui::Page>(requested));
+        case lambo::ui::OverlayRequestQueue::Kind::Back:
+            g_state->back();
+            break;
+        case lambo::ui::OverlayRequestQueue::Kind::Dismiss:
+            g_state->hide_pages();
+            break;
+        case lambo::ui::OverlayRequestQueue::Kind::None:
+            break;
     }
-    if (g_requested_back.exchange(false, std::memory_order_acq_rel)) g_state->back();
-    if (g_requested_dismiss.exchange(false, std::memory_order_acq_rel)) g_state->hide_pages();
+    // Publish what was actually applied so the next toggle decides from the real
+    // state, unless a newer producer intent has already replaced it.
+    g_requests.note_visibility(g_visible.load(std::memory_order_acquire));
+
+    if (!g_visible.load(std::memory_order_acquire)) {
+        discard_queued_events();
+        return;
+    }
     g_state->process_queued_events();
     if (!g_visible.load(std::memory_order_acquire)) return;
     g_state->refresh_controls_values();
@@ -937,49 +968,46 @@ bool handle_event(const SDL_Event& event) {
     }
 }
 
+// Each of these replaces any outstanding request, so the newest caller wins
+// instead of racing the previous one.
 void open_launcher() {
-    g_requested_entry_point.store(static_cast<int>(EntryPoint::Startup), std::memory_order_release);
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
-    g_requested_page.store(static_cast<int>(Page::Home), std::memory_order_release);
+    g_requests.request_show(static_cast<int>(Page::Home), static_cast<int>(EntryPoint::Startup));
 }
 
 void open_settings() {
-    g_requested_entry_point.store(static_cast<int>(EntryPoint::InGameOverlay), std::memory_order_release);
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
-    g_requested_page.store(static_cast<int>(Page::Settings), std::memory_order_release);
+    g_requests.request_show(static_cast<int>(Page::Settings),
+                            static_cast<int>(EntryPoint::InGameOverlay));
 }
 
 void open_controls() {
     auto* startup = g_startup_controller.load(std::memory_order_acquire);
     const EntryPoint entry = startup != nullptr && startup->state() == lambo::StartupState::Started
         ? EntryPoint::InGameOverlay : EntryPoint::Startup;
-    g_requested_entry_point.store(static_cast<int>(entry), std::memory_order_release);
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
-    g_requested_page.store(static_cast<int>(Page::Controls), std::memory_order_release);
+    g_requests.request_show(static_cast<int>(Page::Controls), static_cast<int>(entry));
 }
 
 void open_graphics() {
-    g_requested_entry_point.store(static_cast<int>(EntryPoint::Startup), std::memory_order_release);
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
-    g_requested_page.store(static_cast<int>(Page::Graphics), std::memory_order_release);
+    g_requests.request_show(static_cast<int>(Page::Graphics), static_cast<int>(EntryPoint::Startup));
 }
 
 void open_enhancements() {
-    g_requested_entry_point.store(static_cast<int>(EntryPoint::Startup), std::memory_order_release);
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
-    g_requested_page.store(static_cast<int>(Page::Enhancements), std::memory_order_release);
+    g_requests.request_show(static_cast<int>(Page::Enhancements), static_cast<int>(EntryPoint::Startup));
 }
 
 void open_haptics() {
-    g_requested_entry_point.store(static_cast<int>(EntryPoint::Startup), std::memory_order_release);
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
-    g_requested_page.store(static_cast<int>(Page::Haptics), std::memory_order_release);
+    g_requests.request_show(static_cast<int>(Page::Haptics), static_cast<int>(EntryPoint::Startup));
 }
 
 void open_player() {
@@ -989,27 +1017,31 @@ void open_player() {
     auto* startup = g_startup_controller.load(std::memory_order_acquire);
     const EntryPoint entry = startup != nullptr && startup->state() == lambo::StartupState::Started
         ? EntryPoint::InGameOverlay : EntryPoint::Startup;
-    g_requested_entry_point.store(static_cast<int>(entry), std::memory_order_release);
     SDL_ShowCursor(SDL_ENABLE);
     g_capture.store(true, std::memory_order_release);
-    g_requested_page.store(static_cast<int>(Page::Player), std::memory_order_release);
+    g_requests.request_show(static_cast<int>(Page::Player), static_cast<int>(entry));
 }
 
-void close_top_page() {
-    g_requested_back.store(true, std::memory_order_release);
-}
+void close_top_page() { g_requests.request_back(); }
 
-// Closes the overlay outright instead of popping one page, so the menu button
-// can toggle the whole UI regardless of how deep the user has navigated.
-void dismiss() {
-    g_requested_dismiss.store(true, std::memory_order_release);
+// The menu button's toggle: opens Settings from gameplay, hides the overlay
+// outright from any depth. Deciding inside lambo::ui keeps callers out of the
+// overlay's state machine and away from the render thread's asynchronously
+// published visibility, which lags by a frame.
+void toggle_settings() {
+    const bool showing = g_requests.toggle(static_cast<int>(Page::Settings),
+                                           static_cast<int>(EntryPoint::InGameOverlay));
+    if (showing) {
+        SDL_ShowCursor(SDL_ENABLE);
+        g_capture.store(true, std::memory_order_release);
+    }
 }
 
 bool is_initialized() {
     std::lock_guard lock(g_state_mutex);
     return g_state != nullptr && g_state->context != nullptr;
 }
-bool is_visible() { return g_visible.load(std::memory_order_acquire); }
+bool overlay_visible_intent() { return g_requests.visible_intent(); }
 bool captures_input() { return g_capture.load(std::memory_order_acquire); }
 
 void shutdown() {

--- a/src/ui/lambo_ui.h
+++ b/src/ui/lambo_ui.h
@@ -39,6 +39,7 @@ void open_enhancements();
 void open_haptics();
 void open_player();
 void close_top_page();
+void dismiss();
 bool is_initialized();
 bool is_visible();
 bool captures_input();

--- a/src/ui/lambo_ui.h
+++ b/src/ui/lambo_ui.h
@@ -39,9 +39,16 @@ void open_enhancements();
 void open_haptics();
 void open_player();
 void close_top_page();
-void dismiss();
+// Toggles the overlay: opens Settings from gameplay, hides it outright from any
+// depth. Owns the decision internally so callers need not read the render
+// thread's visibility, which lags by a frame.
+void toggle_settings();
 bool is_initialized();
-bool is_visible();
+// Whether the overlay is showing or about to be, including a request the render
+// thread has not consumed yet. This is the accessor to branch on from the event
+// pump: visibility is published asynchronously by the render thread, so reading
+// the applied state directly would lag by a frame.
+bool overlay_visible_intent();
 bool captures_input();
 void shutdown();
 

--- a/src/ui/lambo_ui_requests.cpp
+++ b/src/ui/lambo_ui_requests.cpp
@@ -1,0 +1,56 @@
+#include "ui/lambo_ui_requests.h"
+
+namespace lambo::ui {
+
+void OverlayRequestQueue::request_show(int page, int entry_point) {
+    std::lock_guard lock(mutex_);
+    pending_ = Request{Kind::ShowPage, page, entry_point};
+    visible_intent_ = true;
+}
+
+void OverlayRequestQueue::request_back() {
+    std::lock_guard lock(mutex_);
+    pending_ = Request{Kind::Back, 0, 0};
+}
+
+void OverlayRequestQueue::request_dismiss() {
+    std::lock_guard lock(mutex_);
+    pending_ = Request{Kind::Dismiss, 0, 0};
+    visible_intent_ = false;
+}
+
+bool OverlayRequestQueue::toggle(int page, int entry_point) {
+    std::lock_guard lock(mutex_);
+    const bool showing = !visible_intent_;
+    if (showing) {
+        pending_ = Request{Kind::ShowPage, page, entry_point};
+    } else {
+        pending_ = Request{Kind::Dismiss, 0, 0};
+    }
+    visible_intent_ = showing;
+    return showing;
+}
+
+OverlayRequestQueue::Request OverlayRequestQueue::peek() const {
+    std::lock_guard lock(mutex_);
+    return pending_;
+}
+
+OverlayRequestQueue::Request OverlayRequestQueue::take() {
+    std::lock_guard lock(mutex_);
+    const Request request = pending_;
+    pending_ = Request{};
+    return request;
+}
+
+void OverlayRequestQueue::note_visibility(bool visible) {
+    std::lock_guard lock(mutex_);
+    if (pending_.kind == Kind::None) visible_intent_ = visible;
+}
+
+bool OverlayRequestQueue::visible_intent() const {
+    std::lock_guard lock(mutex_);
+    return visible_intent_;
+}
+
+} // namespace lambo::ui

--- a/src/ui/lambo_ui_requests.h
+++ b/src/ui/lambo_ui_requests.h
@@ -1,0 +1,84 @@
+#ifndef LAMBO_UI_REQUESTS_H
+#define LAMBO_UI_REQUESTS_H
+
+#include <cstdint>
+#include <mutex>
+
+namespace lambo::ui {
+
+// Single-slot request queue for the options overlay.
+//
+// Producers (the menu thread and the event pump) and the consumer (the RT64
+// render thread inside draw_hook) never share a document. Exactly one intent is
+// ever outstanding, and that is the point: separate "show page" / "back" /
+// "dismiss" flags are applied in a fixed order regardless of which the user
+// pressed last, so a dismiss followed by an open would load a document and then
+// unload it again on the very same frame.
+//
+// Page and entry-point values are plain ints so this header stays free of RmlUi
+// and of lambo_ui.h's enums. The UI layer casts. That keeps the whole queue
+// unit testable without a window or a renderer.
+class OverlayRequestQueue {
+public:
+    enum class Kind : uint8_t {
+        None,
+        ShowPage,
+        Back,
+        Dismiss,
+    };
+
+    struct Request {
+        Kind kind = Kind::None;
+        int page = 0;
+        int entry_point = 0;
+
+        bool operator==(const Request&) const = default;
+    };
+
+    // --- Producer side ------------------------------------------------------
+
+    // Show a page, replacing any outstanding request.
+    void request_show(int page, int entry_point);
+
+    // Step back one page. Whether that closes the overlay depends on the page
+    // stack, so the resulting visibility is left for note_visibility to settle.
+    void request_back();
+
+    // Hide the overlay outright.
+    void request_dismiss();
+
+    // Flip between showing `page` and hidden. Returns true when the overlay is
+    // now headed for visible.
+    //
+    // The decision reads the accumulated intent rather than the render thread's
+    // reported visibility, which lags by a frame: reading that would let two
+    // presses inside one frame both observe "hidden" and open twice instead of
+    // toggling.
+    bool toggle(int page, int entry_point);
+
+    // --- Consumer side ------------------------------------------------------
+
+    // The outstanding request, leaving it in place.
+    Request peek() const;
+
+    // The outstanding request, clearing it.
+    Request take();
+
+    // Report the visibility the consumer actually applied. Only adopted when
+    // nothing is outstanding, so a newer producer intent can never be
+    // overwritten by an older observation.
+    void note_visibility(bool visible);
+
+    // Producers' view of whether the overlay should be showing, including any
+    // request that has not been consumed yet.
+    bool visible_intent() const;
+
+private:
+    mutable std::mutex mutex_;
+    Request pending_{};
+    bool visible_intent_ = false;
+};
+
+} // namespace lambo::ui
+
+#endif

--- a/tests/test_ui_assets.py
+++ b/tests/test_ui_assets.py
@@ -197,6 +197,24 @@ def main() -> None:
     settings_content_rule = re.search(r"\.settings-content\s*\{([^}]*)\}", rcss, re.DOTALL)
     require(settings_content_rule is not None and "overflow-y: auto" in settings_content_rule.group(1),
             "the settings content pane must own the vertical scrollbar")
+    # RmlUi's directional search skips scroll containers outright, so a sidebar
+    # item using nav: auto can never carry focus into the scrolling content pane.
+    # The overview page has no autofocus anchor, so its sole action must be named
+    # as an explicit navigation target or the pane is unreachable entirely.
+    overview = ET.parse(ui_root / "settings.rml")
+    overview_exit = [element for element in overview.iter("button")
+                     if element.attrib.get("onclick") == "quit"]
+    require(len(overview_exit) == 1 and overview_exit[0].attrib.get("id"),
+            "the overview exit action needs an id to serve as a navigation target")
+    exit_id = overview_exit[0].attrib.get("id")
+    nav_settings_rule = re.search(r"#nav-settings\.active\s*\{([^}]*)\}", rcss, re.DOTALL)
+    require(nav_settings_rule is not None and f"nav-right: #{exit_id}" in nav_settings_rule.group(1),
+            "the active overview sidebar item must name its content target so the pane is enterable")
+    nav_item_rule = re.search(r"\.nav-item\s*\{([^}]*)\}", rcss, re.DOTALL)
+    require(nav_item_rule is not None and "nav: auto" in nav_item_rule.group(1),
+            "sidebar items keep their default directional navigation")
+    require("id=\"autofocus\"" not in (ui_root / "settings.rml").read_text(encoding="utf-8"),
+            "the overview page must not autofocus its quit action")
     setting_row_rule = re.search(r"\.setting-row\s*\{([^}]*)\}", rcss, re.DOTALL)
     require(setting_row_rule is not None and "tab-index: auto" in setting_row_rule.group(1),
             "setting rows must be focusable so left/right can adjust their value")

--- a/tests/test_ui_requests.cpp
+++ b/tests/test_ui_requests.cpp
@@ -1,0 +1,162 @@
+#include <iostream>
+
+#include "ui/lambo_ui_requests.h"
+
+// The overlay request queue is what makes the menu button's toggle safe across
+// the menu thread and the RT64 render thread. These cases pin down the two
+// behaviours that the render thread cannot recover from: more than one intent
+// outstanding at once, and a toggle deciding from stale visibility.
+namespace {
+
+int failures = 0;
+
+void expect(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+using Kind = lambo::ui::OverlayRequestQueue::Kind;
+
+// Plain ints stand in for lambo::ui::Page/EntryPoint so this test needs neither
+// RmlUi nor the UI header.
+constexpr int settings_page = 1;
+constexpr int home_page = 0;
+constexpr int overlay_entry = 1;
+constexpr int startup_entry = 0;
+
+} // namespace
+
+int main() {
+    // A dismiss followed by an open, both before the render thread runs. Three
+    // independent flags would apply the dismiss last regardless of press order
+    // and unload the document the open had just loaded.
+    {
+        lambo::ui::OverlayRequestQueue queue;
+        queue.request_dismiss();
+        queue.request_show(settings_page, overlay_entry);
+        const auto request = queue.take();
+        expect(request.kind == Kind::ShowPage,
+               "the newest intent wins when a dismiss is followed by an open");
+        expect(request.page == settings_page && request.entry_point == overlay_entry,
+               "a show request carries its page and entry point together");
+        expect(queue.take().kind == Kind::None, "taking a request clears it");
+    }
+
+    // The opposite order must apply the dismiss instead.
+    {
+        lambo::ui::OverlayRequestQueue queue;
+        queue.request_show(settings_page, overlay_entry);
+        queue.request_dismiss();
+        expect(queue.take().kind == Kind::Dismiss,
+               "a dismiss queued after an open replaces it");
+    }
+
+    // Back is its own intent and can equally replace, or be replaced by, a
+    // pending show or dismiss.
+    {
+        lambo::ui::OverlayRequestQueue queue;
+        queue.request_show(settings_page, overlay_entry);
+        queue.take();
+        queue.request_back();
+        expect(queue.take().kind == Kind::Back, "back is delivered as its own intent");
+
+        queue.request_dismiss();
+        queue.request_back();
+        expect(queue.take().kind == Kind::Back, "a back queued after a dismiss replaces it");
+
+        queue.request_back();
+        queue.request_show(settings_page, overlay_entry);
+        expect(queue.take().kind == Kind::ShowPage, "a show queued after a back replaces it");
+    }
+
+    // Two presses inside one frame must toggle closed, not open twice. This is
+    // the case the event pump got wrong by reading the render thread's
+    // asynchronously published visibility, which still reported "hidden".
+    {
+        lambo::ui::OverlayRequestQueue queue;
+        expect(queue.toggle(settings_page, overlay_entry),
+               "the first toggle reports the overlay is showing");
+        expect(queue.visible_intent(), "the first toggle records a visible intent");
+        expect(!queue.toggle(settings_page, overlay_entry),
+               "the second toggle in the same frame reports hiding");
+        expect(queue.take().kind == Kind::Dismiss,
+               "two presses in one frame toggle closed instead of opening twice");
+        expect(!queue.visible_intent(), "a toggle to hidden clears the visible intent");
+    }
+
+    // Toggling when hidden opens Settings as an in-game overlay.
+    {
+        lambo::ui::OverlayRequestQueue queue;
+        expect(queue.toggle(settings_page, overlay_entry), "toggling from hidden opens");
+        const auto request = queue.take();
+        expect(request.kind == Kind::ShowPage && request.page == settings_page &&
+                   request.entry_point == overlay_entry,
+               "toggling open requests the Settings page as the in-game overlay");
+    }
+
+    // A dismiss clears the intent, so the next press reopens rather than
+    // trying to dismiss an already-hidden overlay.
+    {
+        lambo::ui::OverlayRequestQueue queue;
+        queue.request_show(settings_page, overlay_entry);
+        queue.take();
+        queue.note_visibility(true);
+        queue.request_dismiss();
+        expect(!queue.visible_intent(), "a dismiss clears the visible intent");
+        expect(queue.toggle(settings_page, overlay_entry), "toggling after a dismiss reopens");
+    }
+
+    // The consumer's observation is adopted only when nothing newer is pending;
+    // otherwise a producer that ran between take() and note_visibility() would
+    // have its intent silently overwritten.
+    {
+        lambo::ui::OverlayRequestQueue queue;
+        queue.request_show(settings_page, overlay_entry);
+        queue.note_visibility(false);
+        expect(queue.visible_intent(),
+               "a pending request is not clobbered by a stale visibility report");
+
+        queue.take();
+        queue.note_visibility(false);
+        expect(!queue.visible_intent(),
+               "an applied visibility is adopted once nothing is pending");
+    }
+
+    // Back does not itself decide visibility -- only the page stack can -- so
+    // the intent must survive until the consumer reports the outcome.
+    {
+        lambo::ui::OverlayRequestQueue queue;
+        queue.request_show(settings_page, overlay_entry);
+        queue.take();
+        queue.note_visibility(true);
+        queue.request_back();
+        expect(queue.visible_intent(),
+               "back leaves the visible intent for the consumer to settle");
+        expect(queue.take().kind == Kind::Back, "the consumer takes the back intent");
+        queue.note_visibility(false);
+        expect(!queue.visible_intent(),
+               "back at the root hides the overlay and clears the intent");
+    }
+
+    // The launcher path uses the same queue with a different page/entry pair.
+    {
+        lambo::ui::OverlayRequestQueue queue;
+        queue.request_show(home_page, startup_entry);
+        const auto request = queue.take();
+        expect(request.page == home_page && request.entry_point == startup_entry,
+               "the launcher's Home page and Startup entry point round-trip");
+    }
+
+    // peek() exposes the request without consuming it.
+    {
+        lambo::ui::OverlayRequestQueue queue;
+        queue.request_dismiss();
+        expect(queue.peek().kind == Kind::Dismiss, "peek exposes the outstanding request");
+        expect(queue.take().kind == Kind::Dismiss, "peek leaves the request in place");
+        expect(queue.peek().kind == Kind::None, "the queue is empty once taken");
+    }
+
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Three problems on the in-game options overlay, all from the same area.

**1. The menu button could not close the overlay.** Pressing F1 / pad Back / Guide opened Settings, but exiting required Esc/Back, which walks the page stack. It now toggles: opens from gameplay, dismisses outright from any depth. Esc keeps its layered Back meaning.

**2. The overview page had a redundant, mis-sized pair of buttons.** "Resume Game" duplicated the sidebar Back button, and "Exit to Desktop" is Windows-specific wording in a port that also targets Android and Linux. Now a single "Exit Game" action.

The two buttons also rendered at different heights: `button.secondary`'s `margin-top: 16dp` (specificity 0,1,1) beat `.overlay-action-btn`'s `margin: 0` (0,1,0), so the reset never applied.

**3. The remaining action was unreachable.** `.settings-content` is styled `overflow-y: auto`, and RmlUi's directional navigation search refuses to descend into scroll containers (`ElementDocument.cpp`). So `nav: auto` on a sidebar item can never carry focus into a page's content pane. Other pages mask this by transferring focus on entry via `focus_settings_content()`, which has no Overview case — and the recent settings revamp (#199) removed this page's `id="autofocus"` anchor, leaving no way in at all.

## Changes

| Area | Change |
| --- | --- |
| `src/main.cpp` | Menu button intercepted before the UI consumes input; opens when hidden, dismisses when visible |
| `src/ui/lambo_ui.{h,cpp}` | New `dismiss()` hiding the overlay via `hide_pages()` instead of popping one page |
| `assets/ui/settings.rml` | Dropped "Resume Game"; "Exit to Desktop" renamed "Exit Game"; gave it an id |
| `assets/ui/lambo.rcss` | Scoped the overlay button margin reset; added scoped `nav-right`/`nav-left` across the scroll container |
| `tests/test_ui_assets.py` | Guards the exit action's id, its navigation target, and that it is not autofocused |
| `BUILDING.md` | Menu button documented as a toggle |

## Verification

Full suite green: **32/32**.

Verified in a locally built and run binary by posting keys to the SDL window:

- Focus ring moves from the sidebar onto **Exit Game** with Right, and returns with Left.
- Pressing Enter on the focused button quits the game (process exits 0).
- F1 and Esc each toggle the overlay open/closed.
- A non-Overview page (Controls) is unaffected by the scoped selector.

## Note

`assets/ui/launcher.rml` still says "Exit to Desktop" / "Quit and return to Windows", which is likewise wrong on Android/Linux. Left out of this PR to keep the diff focused — happy to align it separately.
